### PR TITLE
feat: Support stack unwinding

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,8 @@
 [target.'cfg(all(target_arch = "riscv64", target_os="none"))']
 runner = "cargo run --package bootimg-runner --"
 rustflags = [
-    "-C", "relocation-model=pie",
-    "-C", "link-args=-zseparate-loadable-segments",
-    "-C", "link-args=--image-base=0xffffffff80000000"
+    "-C",
+    "link-args=-zseparate-loadable-segments",
+    "-C",
+    "link-args=--image-base=0xffffffff80000000",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ name = "kstd"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "gimli",
  "lock_api",
  "onlyerror",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
 name = "kstd"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "cfg-if",
  "gimli",
  "ktest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ lock_api = "0.4.12"
 hashbrown = { version = "0.14.5", default-features = false, features = [
     "nightly",
 ] }
+wasmparser = { version = "0.214.0", default-features = false }
+target-lexicon = { version = "0.12.14", default-features = false }
 cranelift-wasm = { git = "https://github.com/JonasKruckenberg/wasmtime", branch = "no_std2", default-features = false, features = [
     "core",
 ] }
@@ -58,7 +60,6 @@ cranelift-frontend = { git = "https://github.com/JonasKruckenberg/wasmtime", bra
     "core",
 ] }
 cranelift-entity = { git = "https://github.com/JonasKruckenberg/wasmtime", branch = "no_std2", default-features = false }
-target-lexicon = { version = "0.12.14", default-features = false }
 
 # build dependencies
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }

--- a/build/bootimg-runner/src/main.rs
+++ b/build/bootimg-runner/src/main.rs
@@ -68,22 +68,43 @@ fn generate_keypair() -> (VerifyingKey, SigningKey) {
 #[derive(Copy, Clone)]
 pub enum Target {
     Riscv64,
-    Riscv32,
 }
 
 impl Target {
     pub fn from_elf(elf_file: &object::File) -> Target {
         match elf_file.architecture() {
-            Architecture::Riscv32 => Self::Riscv64,
             Architecture::Riscv64 => Self::Riscv64,
             arch => panic!("unsupported architecture {arch:?}"),
         }
     }
 
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_payload_target(&self) -> &'static str {
         match self {
-            Target::Riscv64 => "riscv64gc-unknown-none-elf",
-            Target::Riscv32 => "riscv32imac-unknown-none-elf",
+            Target::Riscv64 => "targets/riscv64gc-k23-kernel.json",
+        }
+    }
+
+    pub fn as_loader_target(&self) -> &'static str {
+        match self {
+            Target::Riscv64 => "targets/riscv64imac-k23-loader.json",
+        }
+    }
+
+    pub fn payload_target_dir(&self) -> &'static str {
+        match self {
+            Target::Riscv64 => "riscv64gc-k23-kernel",
+        }
+    }
+
+    pub fn loader_target_dir(&self) -> &'static str {
+        match self {
+            Target::Riscv64 => "riscv64imac-k23-loader",
+        }
+    }
+
+    pub fn qemu_runner(&self) -> &'static str {
+        match self {
+            Target::Riscv64 => "qemu-system-riscv64",
         }
     }
 }
@@ -91,7 +112,8 @@ impl Target {
 pub struct Builder {
     cargo: PathBuf,
     target: Target,
-    out_dir: PathBuf,
+    payload_out_dir: PathBuf,
+    loader_out_dir: PathBuf,
     release: bool,
 }
 
@@ -107,21 +129,30 @@ impl Builder {
                 .to_path_buf()
         };
 
-        let out_dir = workspace_dir
-            .join("target")
-            .join(target.as_str())
-            .join(if release { "release" } else { "debug" });
+        let out_dir = workspace_dir.join("target");
+
+        let payload_out_dir = out_dir.join(target.payload_target_dir()).join(if release {
+            "release"
+        } else {
+            "debug"
+        });
+        let loader_out_dir = out_dir.join(target.loader_target_dir()).join(if release {
+            "release"
+        } else {
+            "debug"
+        });
 
         Self {
             target,
-            out_dir,
+            payload_out_dir,
+            loader_out_dir,
             cargo,
             release,
         }
     }
 
     pub fn build_loader(&self, verifying_key: VerifyingKey, payload_path: &Path) -> PathBuf {
-        let verifying_key_path = self.out_dir.join("verifying_key.bin");
+        let verifying_key_path = self.payload_out_dir.join("verifying_key.bin");
         fs::write(&verifying_key_path, verifying_key.as_bytes()).unwrap();
 
         let mut cmd = Command::new(&self.cargo);
@@ -130,7 +161,7 @@ impl Builder {
             "-p",
             "loader",
             "--target",
-            self.target.as_str(),
+            self.target.as_loader_target(),
             "-Z",
             "build-std=core,alloc",
             "-Z",
@@ -153,7 +184,7 @@ impl Builder {
             core::str::from_utf8(&out.stderr).unwrap()
         );
 
-        self.out_dir.join("loader")
+        self.loader_out_dir.join("loader")
     }
 
     pub fn compress_and_sign(&self, input: &[u8], signing_key: SigningKey) -> PathBuf {
@@ -161,7 +192,7 @@ impl Builder {
 
         let signature = signing_key.sign(&compressed);
 
-        let out_path = self.out_dir.join("payload.bin");
+        let out_path = self.payload_out_dir.join("payload.bin");
         let mut file = File::create(&out_path).unwrap();
 
         file.write_vectored(&[
@@ -175,13 +206,8 @@ impl Builder {
 }
 
 fn run_in_qemu(target: Target, bootimg_path: &Path, wait_for_debugger: bool) -> Option<i32> {
-    let runner = match target {
-        Target::Riscv64 => "qemu-system-riscv64",
-        Target::Riscv32 => "qemu-system-riscv32",
-    };
-
     let mut child = KillOnDrop({
-        let mut cmd = Command::new(runner);
+        let mut cmd = Command::new(target.qemu_runner());
         cmd.args([
             "-kernel",
             bootimg_path.to_str().unwrap(),

--- a/build/bootimg-runner/src/main.rs
+++ b/build/bootimg-runner/src/main.rs
@@ -78,15 +78,15 @@ impl Target {
         }
     }
 
-    pub fn as_payload_target(&self) -> &'static str {
+    pub fn as_payload_target(&self, workspace_dir: &Path) -> PathBuf {
         match self {
-            Target::Riscv64 => "targets/riscv64gc-k23-kernel.json",
+            Target::Riscv64 => workspace_dir.join("targets/riscv64gc-k23-kernel.json"),
         }
     }
 
-    pub fn as_loader_target(&self) -> &'static str {
+    pub fn as_loader_target(&self, workspace_dir: &Path) -> PathBuf {
         match self {
-            Target::Riscv64 => "targets/riscv64imac-k23-loader.json",
+            Target::Riscv64 => workspace_dir.join("targets/riscv64imac-k23-loader.json"),
         }
     }
 
@@ -114,6 +114,7 @@ pub struct Builder {
     target: Target,
     payload_out_dir: PathBuf,
     loader_out_dir: PathBuf,
+    workspace_dir: PathBuf,
     release: bool,
 }
 
@@ -146,6 +147,7 @@ impl Builder {
             target,
             payload_out_dir,
             loader_out_dir,
+            workspace_dir,
             cargo,
             release,
         }
@@ -161,7 +163,10 @@ impl Builder {
             "-p",
             "loader",
             "--target",
-            self.target.as_loader_target(),
+            self.target
+                .as_loader_target(&self.workspace_dir)
+                .to_str()
+                .unwrap(),
             "-Z",
             "build-std=core,alloc",
             "-Z",

--- a/justfile
+++ b/justfile
@@ -19,7 +19,7 @@ _riscv64crates := "-p kernel -p loader -p kstd -p vmm"
 _buildstd := "-Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem"
 
 run-riscv64 *FLAGS:
-    {{ _cargo }} run -p kernel --target riscv64gc-unknown-none-elf {{ _buildstd }} {{ FLAGS }}
+    {{ _cargo }} run -p kernel --target targets/riscv64gc-k23-kernel.json {{ _buildstd }} {{ FLAGS }}
 
 preflight *FLAGS: (lint FLAGS)
 
@@ -27,7 +27,7 @@ lint *FLAGS: (clippy FLAGS) (check-fmt FLAGS)
 
 clippy $RUSTFLAGS='-Dwarnings' *FLAGS='':
     # riscv64 checks
-    {{ _cargo }} clippy --target riscv64gc-unknown-none-elf {{ _riscv64crates }} {{ _buildstd }} {{ FLAGS }} -- -Dclippy::all -Dclippy::pedantic
+    {{ _cargo }} clippy --target targets/riscv64gc-k23-kernel.json {{ _riscv64crates }} {{ _buildstd }} {{ FLAGS }} -- -Dclippy::all -Dclippy::pedantic
 
 # check rustfmt for `crate`
 check-fmt *FLAGS:
@@ -35,7 +35,7 @@ check-fmt *FLAGS:
 
 check *FLAGS:
     # riscv64 checks
-    {{ _cargo }} check --target riscv64gc-unknown-none-elf {{ _riscv64crates }} {{ _buildstd }} {{ FLAGS }}
+    {{ _cargo }} check --target targets/riscv64gc-k23-kernel.json {{ _riscv64crates }} {{ _buildstd }} {{ FLAGS }}
 
 test-riscv64 *FLAGS:
-    {{ _cargo }} test --target riscv64gc-unknown-none-elf -p kernel {{ _buildstd }} {{ FLAGS }}
+    {{ _cargo }} test --target targets/riscv64gc-k23-kernel.json -p kernel {{ _buildstd }} {{ FLAGS }}

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -14,7 +14,7 @@ harness = false
 
 [dependencies]
 vmm.workspace = true
-kstd.workspace = true
+kstd = { workspace = true, features = ["panic-unwind"] }
 loader-api.workspace = true
 
 cfg-if.workspace = true

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -41,7 +41,6 @@ pub mod kconfig {
 }
 
 #[inline(never)]
-#[no_mangle]
 fn main(_hartid: usize) -> ! {
     panic!("test panic");
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -44,7 +44,7 @@ pub mod kconfig {
 fn main(_hartid: usize) -> ! {
     panic!("test panic");
 
-    kstd::arch::abort_internal(1);
+    // kstd::arch::abort_internal(1);
 
     // Eventually this will all be hidden behind other abstractions (the scheduler, etc.) and this
     // function will just jump into the scheduling loop

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -42,38 +42,34 @@ pub mod kconfig {
 
 #[inline(never)]
 fn main(_hartid: usize) -> ! {
-    panic!("test panic");
-
-    // kstd::arch::abort_internal(1);
-
     // Eventually this will all be hidden behind other abstractions (the scheduler, etc.) and this
     // function will just jump into the scheduling loop
 
-    // use crate::runtime::{Engine, Linker, Module, Store};
-    // use cranelift_codegen::settings::Configurable;
+    use crate::runtime::{Engine, Linker, Module, Store};
+    use cranelift_codegen::settings::Configurable;
 
-    // let wasm = include_bytes!("../tests/fib-cpp.wasm");
+    let wasm = include_bytes!("../tests/fib-cpp.wasm");
 
-    // let isa_builder = cranelift_codegen::isa::lookup(target_lexicon::HOST).unwrap();
-    // let mut b = cranelift_codegen::settings::builder();
-    // b.set("opt_level", "speed_and_size").unwrap();
+    let isa_builder = cranelift_codegen::isa::lookup(target_lexicon::HOST).unwrap();
+    let mut b = cranelift_codegen::settings::builder();
+    b.set("opt_level", "speed_and_size").unwrap();
 
-    // let target_isa = isa_builder
-    //     .finish(cranelift_codegen::settings::Flags::new(b))
-    //     .unwrap();
+    let target_isa = isa_builder
+        .finish(cranelift_codegen::settings::Flags::new(b))
+        .unwrap();
 
-    // let engine = Engine::new(target_isa);
+    let engine = Engine::new(target_isa);
 
-    // let mut store = Store::new(0);
+    let mut store = Store::new(0);
 
-    // let module = Module::from_binary(&engine, &store, wasm);
-    // log::debug!("{module:#?}");
+    let module = Module::from_binary(&engine, &store, wasm);
+    log::debug!("{module:#?}");
 
-    // let linker = Linker::new();
-    // let instance = linker.instantiate(&mut store, &module);
-    // instance.debug_print_vmctx(&store);
+    let linker = Linker::new();
+    let instance = linker.instantiate(&mut store, &module);
+    instance.debug_print_vmctx(&store);
 
-    // todo!()
+    todo!()
 }
 
 #[no_mangle]

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -40,35 +40,41 @@ pub mod kconfig {
     pub const TRAP_STACK_SIZE_PAGES: usize = 16; // Size of the per-hart trap stack in pages
 }
 
+#[inline(never)]
+#[no_mangle]
 fn main(_hartid: usize) -> ! {
+    panic!("test panic");
+
+    kstd::arch::abort_internal(1);
+
     // Eventually this will all be hidden behind other abstractions (the scheduler, etc.) and this
     // function will just jump into the scheduling loop
 
-    use crate::runtime::{Engine, Linker, Module, Store};
-    use cranelift_codegen::settings::Configurable;
+    // use crate::runtime::{Engine, Linker, Module, Store};
+    // use cranelift_codegen::settings::Configurable;
 
-    let wasm = include_bytes!("../tests/fib-cpp.wasm");
+    // let wasm = include_bytes!("../tests/fib-cpp.wasm");
 
-    let isa_builder = cranelift_codegen::isa::lookup(target_lexicon::HOST).unwrap();
-    let mut b = cranelift_codegen::settings::builder();
-    b.set("opt_level", "speed_and_size").unwrap();
+    // let isa_builder = cranelift_codegen::isa::lookup(target_lexicon::HOST).unwrap();
+    // let mut b = cranelift_codegen::settings::builder();
+    // b.set("opt_level", "speed_and_size").unwrap();
 
-    let target_isa = isa_builder
-        .finish(cranelift_codegen::settings::Flags::new(b))
-        .unwrap();
+    // let target_isa = isa_builder
+    //     .finish(cranelift_codegen::settings::Flags::new(b))
+    //     .unwrap();
 
-    let engine = Engine::new(target_isa);
+    // let engine = Engine::new(target_isa);
 
-    let mut store = Store::new(0);
+    // let mut store = Store::new(0);
 
-    let module = Module::from_binary(&engine, &store, wasm);
-    log::debug!("{module:#?}");
+    // let module = Module::from_binary(&engine, &store, wasm);
+    // log::debug!("{module:#?}");
 
-    let linker = Linker::new();
-    let instance = linker.instantiate(&mut store, &module);
-    instance.debug_print_vmctx(&store);
+    // let linker = Linker::new();
+    // let instance = linker.instantiate(&mut store, &module);
+    // instance.debug_print_vmctx(&store);
 
-    todo!()
+    // todo!()
 }
 
 #[no_mangle]

--- a/libs/kstd/Cargo.toml
+++ b/libs/kstd/Cargo.toml
@@ -12,3 +12,4 @@ workspace = true
 cfg-if.workspace = true
 onlyerror.workspace = true
 lock_api.workspace = true
+gimli = { workspace = true, features = ["read-core"] }

--- a/libs/kstd/Cargo.toml
+++ b/libs/kstd/Cargo.toml
@@ -15,7 +15,11 @@ harness = false
 cfg-if.workspace = true
 onlyerror.workspace = true
 lock_api.workspace = true
+bitflags.workspace = true
 gimli = { workspace = true, features = ["read-core"] }
 
 [dev-dependencies]
 ktest.workspace = true
+
+[features]
+panic-unwind = []

--- a/libs/kstd/src/arch/mod.rs
+++ b/libs/kstd/src/arch/mod.rs
@@ -2,8 +2,5 @@ cfg_if::cfg_if! {
     if #[cfg(target_arch = "riscv64")] {
         mod riscv64;
         pub use self::riscv64::*;
-    } else {
-        mod unsupported;
-        pub use self::unsupported::*;
     }
 }

--- a/libs/kstd/src/arch/riscv64/mod.rs
+++ b/libs/kstd/src/arch/riscv64/mod.rs
@@ -2,6 +2,7 @@ pub mod hio;
 pub mod register;
 pub mod sbi;
 pub(crate) mod semihosting;
+pub(crate) mod unwinding;
 
 use core::arch::asm;
 pub use register::*;

--- a/libs/kstd/src/arch/riscv64/unwinding.rs
+++ b/libs/kstd/src/arch/riscv64/unwinding.rs
@@ -28,14 +28,17 @@ pub struct Context {
 impl fmt::Debug for Context {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut fmt = fmt.debug_struct("Context");
-        for i in 0..=31 {
-            fmt.field(RiscV::register_name(Register(i as _)).unwrap(), &self.gp[i]);
+        for i in 0..=31u16 {
+            fmt.field(
+                RiscV::register_name(Register(i)).unwrap(),
+                &self.gp[i as usize],
+            );
         }
         #[cfg(target_feature = "d")]
-        for i in 0..=31 {
+        for i in 0..=31u16 {
             fmt.field(
-                RiscV::register_name(Register((i + 32) as _)).unwrap(),
-                &self.fp[i],
+                RiscV::register_name(Register(i + 32)).unwrap(),
+                &self.fp[i as usize],
             );
         }
         fmt.finish()

--- a/libs/kstd/src/arch/riscv64/unwinding.rs
+++ b/libs/kstd/src/arch/riscv64/unwinding.rs
@@ -1,3 +1,5 @@
+//! RISC-V specific unwinding code, mostly saving and restoring registers.
+
 use core::arch::asm;
 use core::fmt;
 use core::ops;
@@ -10,7 +12,7 @@ pub const SP: Register = RiscV::SP;
 pub const RA: Register = RiscV::RA;
 
 pub const UNWIND_DATA_REG: (Register, Register) = (RiscV::A0, RiscV::A1);
-pub const UNWIND_PRIVATE_DATA_SIZE: usize = 2;
+// pub const UNWIND_PRIVATE_DATA_SIZE: usize = 2;
 
 #[cfg(all(target_feature = "f", not(target_feature = "d")))]
 compile_error!("RISC-V with only F extension is not supported");

--- a/libs/kstd/src/arch/unsupported/hio.rs
+++ b/libs/kstd/src/arch/unsupported/hio.rs
@@ -1,5 +1,0 @@
-use core::fmt;
-
-pub fn _print(_args: fmt::Arguments) {}
-
-pub fn _eprint(_args: fmt::Arguments) {}

--- a/libs/kstd/src/arch/unsupported/mod.rs
+++ b/libs/kstd/src/arch/unsupported/mod.rs
@@ -1,5 +1,0 @@
-pub mod hio;
-
-pub fn abort_internal(_code: i32) -> ! {
-    unsafe { core::hint::unreachable_unchecked() }
-}

--- a/libs/kstd/src/lib.rs
+++ b/libs/kstd/src/lib.rs
@@ -24,7 +24,7 @@ mod panicking;
 // Architecture specific code
 pub mod arch;
 
-// Syncronization primitives
+// Synchronization primitives
 pub mod sync;
 
 // DWARF-based stack unwinding

--- a/libs/kstd/src/lib.rs
+++ b/libs/kstd/src/lib.rs
@@ -1,23 +1,37 @@
 #![no_std]
-#![no_main]
-// All of these are used for panicking, unwinding and backtraces
-#![allow(internal_features)]
+// panicking & unwinding
 #![feature(
-    thread_local,
+    naked_functions,
+    lang_items,
     panic_info_message,
     std_internals,
+    used_with_arg,
+    panic_can_unwind,
     fmt_internals,
-    panic_internals,
-    panic_can_unwind
+    core_intrinsics,
+    rustc_attrs
 )]
+#![allow(internal_features)]
+// thread_local
+#![feature(thread_local)]
 
 extern crate alloc;
 
-pub mod arch;
 mod macros;
-pub mod panic;
-pub mod panicking;
-pub mod process;
+mod panicking;
+
+// Architecture specific code
+pub mod arch;
+
+// Syncronization primitives
 pub mod sync;
-pub mod thread_local;
+
+// DWARF-based stack unwinding
+#[cfg(feature = "panic-unwind")]
 pub mod unwinding;
+
+// Public-facing panic API
+pub mod panic;
+
+// Thread-local storage
+pub mod thread_local;

--- a/libs/kstd/src/lib.rs
+++ b/libs/kstd/src/lib.rs
@@ -1,10 +1,23 @@
 #![no_std]
 #![no_main]
-#![feature(thread_local, panic_info_message)]
+// All of these are used for panicking, unwinding and backtraces
+#![allow(internal_features)]
+#![feature(
+    thread_local,
+    panic_info_message,
+    std_internals,
+    fmt_internals,
+    panic_internals,
+    panic_can_unwind
+)]
+
+extern crate alloc;
 
 pub mod arch;
 mod macros;
+pub mod panic;
 pub mod panicking;
 pub mod process;
 pub mod sync;
 pub mod thread_local;
+pub mod unwinding;

--- a/libs/kstd/src/lib.rs
+++ b/libs/kstd/src/lib.rs
@@ -14,6 +14,7 @@
 #![allow(internal_features)]
 // thread_local
 #![feature(thread_local)]
+#![allow(clippy::module_name_repetitions)]
 
 extern crate alloc;
 

--- a/libs/kstd/src/lib.rs
+++ b/libs/kstd/src/lib.rs
@@ -36,3 +36,7 @@ pub mod panic;
 
 // Thread-local storage
 pub mod thread_local;
+
+pub fn abort(code: i32) -> ! {
+    arch::abort_internal(code)
+}

--- a/libs/kstd/src/panic.rs
+++ b/libs/kstd/src/panic.rs
@@ -1,11 +1,9 @@
 use crate::panicking;
 use alloc::{boxed::Box, string::String};
-use core::{
-    any::Any,
-    fmt,
-    panic::{Location, UnwindSafe},
-};
+use core::{any::Any, fmt};
 
+pub use core::panic::Location;
+pub use core::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
 pub use panicking::{set_hook, take_hook, update_hook};
 
 /// # Errors

--- a/libs/kstd/src/panic.rs
+++ b/libs/kstd/src/panic.rs
@@ -1,0 +1,81 @@
+use core::{any::Any, fmt};
+
+pub use crate::panicking::update_hook;
+pub use crate::panicking::{set_hook, take_hook};
+pub use core::panic::Location;
+pub use core::panic::{AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
+
+#[derive(Debug)]
+pub struct PanicHookInfo<'a> {
+    payload: &'a (dyn Any + Send),
+    location: &'a Location<'a>,
+    can_unwind: bool,
+    force_no_backtrace: bool,
+}
+
+impl<'a> PanicHookInfo<'a> {
+    #[inline]
+    pub(crate) fn new(
+        location: &'a Location<'a>,
+        payload: &'a (dyn Any + Send),
+        can_unwind: bool,
+        force_no_backtrace: bool,
+    ) -> Self {
+        PanicHookInfo {
+            payload,
+            location,
+            can_unwind,
+            force_no_backtrace,
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn payload(&self) -> &(dyn Any + Send) {
+        self.payload
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn payload_as_str(&self) -> Option<&str> {
+        if let Some(s) = self.payload.downcast_ref::<&str>() {
+            Some(s)
+        } else if let Some(s) = self.payload.downcast_ref::<String>() {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn location(&self) -> Option<&Location<'_>> {
+        // NOTE: If this is changed to sometimes return None,
+        // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
+        Some(&self.location)
+    }
+
+    #[must_use]
+    #[inline]
+    pub fn can_unwind(&self) -> bool {
+        self.can_unwind
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn force_no_backtrace(&self) -> bool {
+        self.force_no_backtrace
+    }
+}
+
+impl fmt::Display for PanicHookInfo<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("panicked at ")?;
+        self.location.fmt(formatter)?;
+        if let Some(payload) = self.payload_as_str() {
+            formatter.write_str(":\n")?;
+            formatter.write_str(payload)?;
+        }
+        Ok(())
+    }
+}

--- a/libs/kstd/src/panic.rs
+++ b/libs/kstd/src/panic.rs
@@ -8,6 +8,9 @@ use core::{
 
 pub use panicking::{set_hook, take_hook, update_hook};
 
+/// # Errors
+///
+/// If the given closure panics, the panic cause will be returned in the Err variant.
 pub fn catch_unwind<F: FnOnce() -> R + UnwindSafe, R>(
     f: F,
 ) -> Result<R, Box<dyn Any + Send + 'static>> {
@@ -62,7 +65,7 @@ impl<'a> PanicHookInfo<'a> {
     pub fn location(&self) -> Option<&Location<'_>> {
         // NOTE: If this is changed to sometimes return None,
         // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
-        Some(&self.location)
+        Some(self.location)
     }
 
     #[must_use]

--- a/libs/kstd/src/panicking.rs
+++ b/libs/kstd/src/panicking.rs
@@ -1,160 +1,374 @@
-use crate::sync::Mutex;
-use crate::{arch, declare_thread_local, heprintln};
-use core::cell::Cell;
-use core::panic::Location;
-use core::sync::atomic::{AtomicBool, Ordering};
-use core::{fmt, mem};
+use core::{any::Any, fmt, mem, panic::Location};
 
-static GLOBAL_PANICKING: AtomicBool = AtomicBool::new(false);
+use crate::{
+    heprintln,
+    panic::PanicHookInfo,
+    sync::{LocalThreadId, RwLock},
+};
+use alloc::{boxed::Box, string::String};
+use core::panic::PanicPayload;
+use lock_api::GetThreadId;
 
-// Panic count for the current thread and whether a panic hook is currently
-// being executed..
-declare_thread_local! {
-    static LOCAL_PANICKING: Cell<bool> = const { Cell::new(false) }
+#[derive(Default)]
+enum Hook {
+    #[default]
+    Default,
+    Custom(Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>),
 }
 
-/// Determines whether the current hart is panicking.
+impl Hook {
+    #[inline]
+    fn into_box(self) -> Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send> {
+        match self {
+            Hook::Default => Box::new(default_hook),
+            Hook::Custom(hook) => hook,
+        }
+    }
+}
+
+static HOOK: RwLock<Hook> = RwLock::new(Hook::Default);
+
+pub fn set_hook(hook: Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send>) {
+    let new = Hook::Custom(hook);
+    let mut hook = HOOK.write();
+    let old = mem::replace(&mut *hook, new);
+    drop(hook);
+    // Only drop the old hook after releasing the lock to avoid deadlocking
+    // if its destructor panics.
+    drop(old);
+}
+
+pub fn take_hook() -> Box<dyn Fn(&PanicHookInfo<'_>) + 'static + Sync + Send> {
+    let mut hook = HOOK.write();
+    let old_hook = mem::take(&mut *hook);
+    drop(hook);
+
+    old_hook.into_box()
+}
+
+pub fn update_hook<F>(hook_fn: F)
+where
+    F: Fn(&(dyn Fn(&PanicHookInfo<'_>) + Send + Sync + 'static), &PanicHookInfo<'_>)
+        + Sync
+        + Send
+        + 'static,
+{
+    let mut hook = HOOK.write();
+    let prev = mem::take(&mut *hook).into_box();
+    *hook = Hook::Custom(Box::new(move |info| hook_fn(&prev, info)));
+}
+
+/// The default panic handler.
+fn default_hook(info: &PanicHookInfo<'_>) {
+    let thread_id = LocalThreadId::INIT.nonzero_thread_id();
+    let location = info.location().unwrap();
+    let msg = payload_as_str(info.payload());
+
+    let _ = heprintln!("thread '{}' panicked at {}:\n{}", thread_id, location, msg);
+}
+
+/// Determines whether the current thread is unwinding because of panic.
 #[inline]
 pub fn panicking() -> bool {
-    if GLOBAL_PANICKING.load(Ordering::Relaxed) {
-        panicking_slow_path()
-    } else {
-        false
-    }
+    !panic_count::count_is_zero()
 }
 
-// Slow path is in a separate function to reduce the amount of code
-// inlined from `count_is_zero`.
-#[inline(never)]
-#[cold]
-fn panicking_slow_path() -> bool {
-    LOCAL_PANICKING.with(core::cell::Cell::get)
-}
-
-enum AbortReason {
-    AlwaysAbort,
-    PanicInHook,
-}
-
-fn begin_panicking() -> AbortReason {
-    GLOBAL_PANICKING.store(true, Ordering::Relaxed);
-
-    let panicking = LOCAL_PANICKING.with(|c| c.replace(true));
-
-    if panicking {
-        AbortReason::PanicInHook
-    } else {
-        AbortReason::AlwaysAbort
-    }
-}
-
-/// Entry point of Rust panics
-#[cfg(not(any(test, doctest)))]
+/// Entry point of panics from the core crate (`panic_impl` lang item).
+// #[cfg(not(any(test, doctest)))]
 #[panic_handler]
-fn default_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
-    let abort_reason = begin_panicking();
+pub fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
+    use core::{any::Any, fmt};
 
-    let message = info.message();
+    use alloc::string::String;
+
+    struct FormatStringPayload<'a> {
+        inner: &'a core::panic::PanicMessage<'a>,
+        string: Option<String>,
+    }
+
+    impl FormatStringPayload<'_> {
+        fn fill(&mut self) -> &mut String {
+            let inner = self.inner;
+            // Lazily, the first time this gets called, run the actual string formatting.
+            self.string.get_or_insert_with(|| {
+                let mut s = String::new();
+                let mut fmt = fmt::Formatter::new(&mut s);
+                let _err = fmt::Display::fmt(&inner, &mut fmt);
+                s
+            })
+        }
+    }
+
+    unsafe impl PanicPayload for FormatStringPayload<'_> {
+        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+            // We do two allocations here, unfortunately. But (a) they're required with the current
+            // scheme, and (b) we don't handle panic + OOM properly anyway (see comment in
+            // begin_panic below).
+            let contents = mem::take(self.fill());
+            Box::into_raw(Box::new(contents))
+        }
+
+        fn get(&mut self) -> &(dyn Any + Send) {
+            self.fill()
+        }
+    }
+
+    impl fmt::Display for FormatStringPayload<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if let Some(s) = &self.string {
+                f.write_str(s)
+            } else {
+                fmt::Display::fmt(&self.inner, f)
+            }
+        }
+    }
+
+    struct StaticStrPayload(&'static str);
+
+    unsafe impl PanicPayload for StaticStrPayload {
+        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+            Box::into_raw(Box::new(self.0))
+        }
+
+        fn get(&mut self) -> &(dyn Any + Send) {
+            &self.0
+        }
+
+        fn as_str(&mut self) -> Option<&str> {
+            Some(self.0)
+        }
+    }
+
+    impl fmt::Display for StaticStrPayload {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    let msg = info.message();
     let loc = info.location().unwrap(); // The current implementation always returns Some
-    let context = match abort_reason {
-        AbortReason::AlwaysAbort => "hart panicked, aborting.",
-        AbortReason::PanicInHook => "hart panicked while processing panic. aborting.",
-    };
+    if let Some(s) = msg.as_str() {
+        rust_panic_with_hook(
+            &mut StaticStrPayload(s),
+            loc,
+            info.can_unwind(),
+            info.force_no_backtrace(),
+        );
+    } else {
+        rust_panic_with_hook(
+            &mut FormatStringPayload {
+                inner: &msg,
+                string: None,
+            },
+            loc,
+            info.can_unwind(),
+            info.force_no_backtrace(),
+        );
+    }
+}
 
-    let hook = HOOK.lock();
-    match *hook {
+fn rust_panic_with_hook(
+    payload: &mut dyn PanicPayload,
+    location: &Location<'_>,
+    can_unwind: bool,
+    force_no_backtrace: bool,
+) -> ! {
+    let must_abort = panic_count::increase(true);
+
+    // Check if we need to abort immediately.
+    if let Some(must_abort) = must_abort {
+        match must_abort {
+            panic_count::MustAbort::PanicInHook => {
+                // Don't try to format the message in this case, perhaps that is causing the
+                // recursive panics. However if the message is just a string, no user-defined
+                // code is involved in printing it, so that is risk-free.
+                let message: &str = payload.as_str().unwrap_or_default();
+                heprintln!(
+                    "panicked at {}:\n{}\nthread panicked while processing panic. aborting.\n",
+                    location,
+                    message
+                );
+            }
+            panic_count::MustAbort::AlwaysAbort => {
+                // Unfortunately, this does not print a backtrace, because creating
+                // a `Backtrace` will allocate, which we must avoid here.
+                heprintln!("aborting due to panic at {}:\n{}\n", location, payload);
+            }
+        }
+        crate::arch::abort_internal(1);
+    }
+
+    match *HOOK.read() {
         Hook::Default => {
             default_hook(&PanicHookInfo::new(
-                loc,
-                Some(&format_args!("{message}")),
-                context,
+                location,
+                payload.get(),
+                can_unwind,
+                force_no_backtrace,
             ));
         }
-        Hook::Custom(ref hook) => {
-            hook(&PanicHookInfo::new(
-                loc,
-                Some(&format_args!("{message}")),
-                context,
-            ));
+        Hook::Custom(ref hook) => hook(&PanicHookInfo::new(
+            location,
+            payload.get(),
+            can_unwind,
+            force_no_backtrace,
+        )),
+    }
+
+    panic_count::finished_panic_hook();
+
+    if !can_unwind {
+        // If a thread panics while running destructors or tries to unwind
+        // through a nounwind function (e.g. extern "C") then we cannot continue
+        // unwinding and have to abort immediately.
+        heprintln!("thread caused non-unwinding panic. aborting.\n");
+        crate::arch::abort_internal(1);
+    }
+
+    rust_panic(payload)
+}
+
+pub fn rust_panic_without_hook(payload: Box<dyn Any + Send>) -> ! {
+    panic_count::increase(false);
+
+    struct RewrapBox(Box<dyn Any + Send>);
+
+    unsafe impl PanicPayload for RewrapBox {
+        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+            Box::into_raw(mem::replace(&mut self.0, Box::new(())))
+        }
+
+        fn get(&mut self) -> &(dyn Any + Send) {
+            &*self.0
         }
     }
 
-    rust_panic()
+    impl fmt::Display for RewrapBox {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(payload_as_str(&self.0))
+        }
+    }
+
+    rust_panic(&mut RewrapBox(payload))
 }
 
 /// Mirroring std, this is an unmangled function on which to slap
 /// yer breakpoints for backtracing panics.
 #[no_mangle]
 #[inline(never)]
-extern "Rust" fn rust_panic() -> ! {
-    arch::abort_internal(1);
+extern "Rust" fn rust_panic(msg: &mut dyn PanicPayload) -> ! {
+    // TODO do the stack unwinding
+
+    crate::arch::abort_internal(1);
 }
 
-#[derive(Default)]
-enum Hook {
-    #[default]
-    Default,
-    Custom(fn(&PanicHookInfo<'_>)),
-}
+mod panic_count {
+    use core::{
+        cell::Cell,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
 
-// FIXME replace with RwLock
-static HOOK: Mutex<Hook> = Mutex::new(Hook::Default);
+    use crate::declare_thread_local;
 
-fn default_hook(info: &PanicHookInfo<'_>) {
-    heprintln!("{}", info);
-}
-
-#[allow(clippy::missing_panics_doc)]
-pub fn set_hook(hook: fn(&PanicHookInfo<'_>)) {
-    assert!(
-        !LOCAL_PANICKING.with(core::cell::Cell::get),
-        "cannot modify the panic hook from a panicking thread"
-    );
-
-    let new = Hook::Custom(hook);
-    let mut hook = HOOK.lock();
-    let _ = mem::replace(&mut *hook, new);
-}
-
-pub struct PanicHookInfo<'a> {
-    context: &'a str,
-    message: Option<&'a fmt::Arguments<'a>>,
-    location: &'a Location<'a>,
-}
-
-impl<'a> PanicHookInfo<'a> {
-    #[inline]
-    pub(crate) fn new(
-        location: &'a Location<'a>,
-        message: Option<&'a fmt::Arguments<'a>>,
-        context: &'a str,
-    ) -> Self {
-        PanicHookInfo {
-            context,
-            message,
-            location,
-        }
+    /// A reason for forcing an immediate abort on panic.
+    #[derive(Debug)]
+    pub enum MustAbort {
+        AlwaysAbort,
+        PanicInHook,
     }
 
+    // Panic count for the current thread and whether a panic hook is currently
+    // being executed..
+    declare_thread_local! {
+        static LOCAL_PANIC_COUNT: Cell<(usize, bool)> = const { Cell::new((0, false)) }
+    }
+
+    static GLOBAL_PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    pub fn increase(run_panic_hook: bool) -> Option<MustAbort> {
+        LOCAL_PANIC_COUNT.with(|c| {
+            let (count, in_panic_hook) = c.get();
+            if in_panic_hook {
+                return Some(MustAbort::PanicInHook);
+            }
+            c.set((count + 1, run_panic_hook));
+            None
+        })
+    }
+
+    pub fn finished_panic_hook() {
+        LOCAL_PANIC_COUNT.with(|c| {
+            let (count, _) = c.get();
+            c.set((count, false));
+        });
+    }
+
+    pub fn decrease() {
+        GLOBAL_PANIC_COUNT.fetch_sub(1, Ordering::Relaxed);
+        LOCAL_PANIC_COUNT.with(|c| {
+            let (count, _) = c.get();
+            c.set((count - 1, false));
+        });
+    }
+
+    // Disregards ALWAYS_ABORT_FLAG
+    #[must_use]
+    pub fn get_count() -> usize {
+        LOCAL_PANIC_COUNT.with(|c| c.get().0)
+    }
+
+    // Disregards ALWAYS_ABORT_FLAG
     #[must_use]
     #[inline]
-    pub fn location(&self) -> Option<&Location<'_>> {
-        // NOTE: If this is changed to sometimes return None,
-        // deal with that case in std::panicking::default_hook and core::panicking::panic_fmt.
-        Some(self.location)
+    pub fn count_is_zero() -> bool {
+        if GLOBAL_PANIC_COUNT.load(Ordering::Relaxed) == 0 {
+            // Fast path: if `GLOBAL_PANIC_COUNT` is zero, all threads
+            // (including the current one) will have `LOCAL_PANIC_COUNT`
+            // equal to zero, so TLS access can be avoided.
+            //
+            // In terms of performance, a relaxed atomic load is similar to a normal
+            // aligned memory read (e.g., a mov instruction in x86), but with some
+            // compiler optimization restrictions. On the other hand, a TLS access
+            // might require calling a non-inlinable function (such as `__tls_get_addr`
+            // when using the GD TLS model).
+            true
+        } else {
+            is_zero_slow_path()
+        }
+    }
+
+    // Slow path is in a separate function to reduce the amount of code
+    // inlined from `count_is_zero`.
+    #[inline(never)]
+    #[cold]
+    fn is_zero_slow_path() -> bool {
+        LOCAL_PANIC_COUNT.with(|c| c.get().0 == 0)
     }
 }
 
-impl fmt::Display for PanicHookInfo<'_> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str("panicked at ")?;
-        self.location.fmt(formatter)?;
-        formatter.write_str(":\n")?;
-        if let Some(fmt_args) = self.message {
-            fmt_args.fmt(formatter)?;
-        }
-        formatter.write_str("\n")?;
-        formatter.write_str(self.context)?;
-        Ok(())
+fn payload_as_str(payload: &dyn Any) -> &str {
+    if let Some(&s) = payload.downcast_ref::<&'static str>() {
+        s
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.as_str()
+    } else {
+        "Box<dyn Any>"
     }
+}
+
+/// This function is called by the panic runtime if FFI code catches a Rust
+/// panic but doesn't rethrow it. We don't support this case since it messes
+/// with our panic count.
+// #[cfg(not(test))]
+pub(crate) fn rust_drop_panic() -> ! {
+    heprintln!("Rust panics must be rethrown");
+    crate::arch::abort_internal(1);
+}
+
+/// This function is called by the panic runtime if it catches an exception
+/// object which does not correspond to a Rust panic.
+// #[cfg(not(test))]
+pub(crate) fn rust_foreign_exception() -> ! {
+    heprintln!("Rust cannot catch foreign exceptions");
+    crate::arch::abort_internal(1);
 }

--- a/libs/kstd/src/process.rs
+++ b/libs/kstd/src/process.rs
@@ -1,5 +1,0 @@
-use crate::arch;
-
-pub fn exit(code: i32) -> ! {
-    arch::abort_internal(code)
-}

--- a/libs/kstd/src/sync/mod.rs
+++ b/libs/kstd/src/sync/mod.rs
@@ -1,5 +1,6 @@
 mod once;
 mod raw_mutex;
+mod raw_rwlock;
 
 use core::num::NonZeroUsize;
 use core::ptr::addr_of;
@@ -7,11 +8,22 @@ use lock_api::GetThreadId;
 pub use once::Once;
 
 pub use raw_mutex::RawMutex;
+pub use raw_rwlock::RawRwLock;
 
 pub type Mutex<T> = lock_api::Mutex<RawMutex, T>;
 pub type MutexGuard<'a, T> = lock_api::MutexGuard<'a, RawMutex, T>;
 pub type ReentrantMutex<T> = lock_api::ReentrantMutex<RawMutex, LocalThreadId, T>;
 pub type ReentrantMutexGuard<'a, T> = lock_api::ReentrantMutexGuard<'a, RawMutex, LocalThreadId, T>;
+pub type MappedMutexGuard<'a, T> = lock_api::MappedMutexGuard<'a, RawMutex, T>;
+pub type MappedReentrantMutexGuard<'a, T> =
+    lock_api::MappedReentrantMutexGuard<'a, RawMutex, LocalThreadId, T>;
+
+pub type RwLock<T> = lock_api::RwLock<RawRwLock, T>;
+pub type RwLockReadGuard<'a, T> = lock_api::RwLockReadGuard<'a, RawRwLock, T>;
+pub type RwLockWriteGuard<'a, T> = lock_api::RwLockWriteGuard<'a, RawRwLock, T>;
+pub type RwLockUpgradableReadGuard<'a, T> = lock_api::RwLockUpgradableReadGuard<'a, RawRwLock, T>;
+pub type MappedRwLockReadGuard<'a, T> = lock_api::MappedRwLockReadGuard<'a, RawRwLock, T>;
+pub type MappedRwLockWriteGuard<'a, T> = lock_api::MappedRwLockWriteGuard<'a, RawRwLock, T>;
 
 pub struct LocalThreadId;
 

--- a/libs/kstd/src/sync/raw_rwlock.rs
+++ b/libs/kstd/src/sync/raw_rwlock.rs
@@ -1,0 +1,207 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use lock_api::RawRwLockUpgrade;
+
+pub struct RawRwLock {
+    lock: AtomicUsize,
+}
+
+const READER: usize = 1 << 2;
+const UPGRADED: usize = 1 << 1;
+const WRITER: usize = 1;
+
+impl RawRwLock {
+    fn acquire_reader(&self) -> usize {
+        // An arbitrary cap that allows us to catch overflows long before they happen
+        const MAX_READERS: usize = core::usize::MAX / READER / 2;
+
+        let value = self.lock.fetch_add(READER, Ordering::Acquire);
+
+        if value > MAX_READERS * READER {
+            self.lock.fetch_sub(READER, Ordering::Relaxed);
+            panic!("Too many lock readers, cannot safely proceed");
+        } else {
+            value
+        }
+    }
+
+    fn try_lock_exclusive_internal(&self, strong: bool) -> bool {
+        if compare_exchange(
+            &self.lock,
+            0,
+            WRITER,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+            strong,
+        )
+        .is_ok()
+        {
+            true
+        } else {
+            false
+        }
+    }
+
+    #[inline(always)]
+    fn try_upgrade_internal(&self, strong: bool) -> bool {
+        if compare_exchange(
+            &self.lock,
+            UPGRADED,
+            WRITER,
+            Ordering::Acquire,
+            Ordering::Relaxed,
+            strong,
+        )
+        .is_ok()
+        {
+            true
+        } else {
+            false
+        }
+    }
+}
+
+unsafe impl lock_api::RawRwLock for RawRwLock {
+    const INIT: Self = Self {
+        lock: AtomicUsize::new(0),
+    };
+
+    type GuardMarker = lock_api::GuardSend;
+
+    fn is_locked(&self) -> bool {
+        self.lock.load(Ordering::Relaxed) != 0
+    }
+
+    fn lock_shared(&self) {
+        while !self.try_lock_shared() {
+            core::hint::spin_loop();
+        }
+    }
+
+    fn try_lock_shared(&self) -> bool {
+        let value = self.acquire_reader();
+
+        // We check the UPGRADED bit here so that new readers are prevented when an UPGRADED lock is held.
+        // This helps reduce writer starvation.
+        if value & (WRITER | UPGRADED) != 0 {
+            // Lock is taken, undo.
+            self.lock.fetch_sub(READER, Ordering::Release);
+            false
+        } else {
+            true
+        }
+    }
+
+    unsafe fn unlock_shared(&self) {
+        debug_assert!(self.lock.load(Ordering::Relaxed) & !(WRITER | UPGRADED) > 0);
+        self.lock.fetch_sub(READER, Ordering::Release);
+    }
+
+    fn lock_exclusive(&self) {
+        while !self.try_lock_exclusive_internal(false) {
+            core::hint::spin_loop();
+        }
+    }
+
+    fn try_lock_exclusive(&self) -> bool {
+        self.try_lock_exclusive_internal(true)
+    }
+
+    unsafe fn unlock_exclusive(&self) {
+        debug_assert_eq!(self.lock.load(Ordering::Relaxed) & WRITER, WRITER);
+
+        // Writer is responsible for clearing both WRITER and UPGRADED bits.
+        // The UPGRADED bit may be set if an upgradeable lock attempts an upgrade while this lock is held.
+        self.lock.fetch_and(!(WRITER | UPGRADED), Ordering::Release);
+    }
+}
+
+unsafe impl lock_api::RawRwLockUpgrade for RawRwLock {
+    fn lock_upgradable(&self) {
+        while !self.try_lock_upgradable() {
+            core::hint::spin_loop();
+        }
+    }
+
+    fn try_lock_upgradable(&self) -> bool {
+        if self.lock.fetch_or(UPGRADED, Ordering::Acquire) & (WRITER | UPGRADED) == 0 {
+            true
+        } else {
+            // We can't unflip the UPGRADED bit back just yet as there is another upgradeable or write lock.
+            // When they unlock, they will clear the bit.
+            false
+        }
+    }
+
+    unsafe fn unlock_upgradable(&self) {
+        debug_assert_eq!(
+            self.lock.load(Ordering::Relaxed) & (WRITER | UPGRADED),
+            UPGRADED
+        );
+        self.lock.fetch_sub(UPGRADED, Ordering::AcqRel);
+    }
+
+    unsafe fn upgrade(&self) {
+        while !self.try_upgrade_internal(false) {
+            core::hint::spin_loop();
+        }
+    }
+
+    unsafe fn try_upgrade(&self) -> bool {
+        self.try_upgrade_internal(true)
+    }
+}
+
+unsafe impl lock_api::RawRwLockDowngrade for RawRwLock {
+    unsafe fn downgrade(&self) {
+        // Reserve the read guard for ourselves
+        self.acquire_reader();
+
+        debug_assert_eq!(self.lock.load(Ordering::Relaxed) & WRITER, WRITER);
+
+        // Writer is responsible for clearing both WRITER and UPGRADED bits.
+        // The UPGRADED bit may be set if an upgradeable lock attempts an upgrade while this lock is held.
+        self.lock.fetch_and(!(WRITER | UPGRADED), Ordering::Release);
+    }
+}
+
+unsafe impl lock_api::RawRwLockUpgradeDowngrade for RawRwLock {
+    unsafe fn downgrade_upgradable(&self) {
+        // Reserve the read guard for ourselves
+        self.acquire_reader();
+
+        self.unlock_upgradable();
+    }
+
+    unsafe fn downgrade_to_upgradable(&self) {
+        debug_assert_eq!(
+            self.lock.load(Ordering::Acquire) & (WRITER | UPGRADED),
+            WRITER
+        );
+
+        // Reserve the read guard for ourselves
+        self.lock.store(UPGRADED, Ordering::Release);
+
+        debug_assert_eq!(self.lock.load(Ordering::Relaxed) & WRITER, WRITER);
+
+        // Writer is responsible for clearing both WRITER and UPGRADED bits.
+        // The UPGRADED bit may be set if an upgradeable lock attempts an upgrade while this lock is held.
+        self.lock.fetch_and(!(WRITER | UPGRADED), Ordering::Release);
+    }
+}
+
+#[inline(always)]
+fn compare_exchange(
+    atomic: &AtomicUsize,
+    current: usize,
+    new: usize,
+    success: Ordering,
+    failure: Ordering,
+    strong: bool,
+) -> Result<usize, usize> {
+    if strong {
+        atomic.compare_exchange(current, new, success, failure)
+    } else {
+        atomic.compare_exchange_weak(current, new, success, failure)
+    }
+}

--- a/libs/kstd/src/unwinding/arch/mod.rs
+++ b/libs/kstd/src/unwinding/arch/mod.rs
@@ -1,0 +1,6 @@
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "riscv64")] {
+        mod riscv64;
+        pub use self::riscv64::*;
+    }
+}

--- a/libs/kstd/src/unwinding/arch/mod.rs
+++ b/libs/kstd/src/unwinding/arch/mod.rs
@@ -1,6 +1,0 @@
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "riscv64")] {
-        mod riscv64;
-        pub use self::riscv64::*;
-    }
-}

--- a/libs/kstd/src/unwinding/arch/riscv64.rs
+++ b/libs/kstd/src/unwinding/arch/riscv64.rs
@@ -1,0 +1,249 @@
+use core::arch::asm;
+use core::fmt;
+use core::ops;
+use gimli::{Register, RiscV};
+
+// Match DWARF_FRAME_REGISTERS in libgcc
+pub const MAX_REG_RULES: usize = 65;
+
+pub const SP: Register = RiscV::SP;
+pub const RA: Register = RiscV::RA;
+
+pub const UNWIND_DATA_REG: (Register, Register) = (RiscV::A0, RiscV::A1);
+pub const UNWIND_PRIVATE_DATA_SIZE: usize = 2;
+
+#[cfg(all(target_feature = "f", not(target_feature = "d")))]
+compile_error!("RISC-V with only F extension is not supported");
+
+#[repr(C)]
+#[derive(Clone, Default)]
+pub struct Context {
+    pub gp: [usize; 32],
+    #[cfg(target_feature = "d")]
+    pub fp: [usize; 32],
+}
+
+impl fmt::Debug for Context {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut fmt = fmt.debug_struct("Context");
+        for i in 0..=31 {
+            fmt.field(RiscV::register_name(Register(i as _)).unwrap(), &self.gp[i]);
+        }
+        #[cfg(target_feature = "d")]
+        for i in 0..=31 {
+            fmt.field(
+                RiscV::register_name(Register((i + 32) as _)).unwrap(),
+                &self.fp[i],
+            );
+        }
+        fmt.finish()
+    }
+}
+
+impl ops::Index<Register> for Context {
+    type Output = usize;
+
+    fn index(&self, reg: Register) -> &usize {
+        match reg {
+            Register(0..=31) => &self.gp[reg.0 as usize],
+            #[cfg(target_feature = "d")]
+            Register(32..=63) => &self.fp[(reg.0 - 32) as usize],
+            _ => unimplemented!(),
+        }
+    }
+}
+
+impl ops::IndexMut<gimli::Register> for Context {
+    fn index_mut(&mut self, reg: Register) -> &mut usize {
+        match reg {
+            Register(0..=31) => &mut self.gp[reg.0 as usize],
+            #[cfg(target_feature = "d")]
+            Register(32..=63) => &mut self.fp[(reg.0 - 32) as usize],
+            _ => unimplemented!(),
+        }
+    }
+}
+
+macro_rules! code {
+    (save_gp) => {
+        "
+        sd x0, 0x00(sp)
+        sd ra, 0x08(sp)
+        sd t0, 0x10(sp)
+        sd gp, 0x18(sp)
+        sd tp, 0x20(sp)
+        sd s0, 0x40(sp)
+        sd s1, 0x48(sp)
+        sd s2, 0x90(sp)
+        sd s3, 0x98(sp)
+        sd s4, 0xA0(sp)
+        sd s5, 0xA8(sp)
+        sd s6, 0xB0(sp)
+        sd s7, 0xB8(sp)
+        sd s8, 0xC0(sp)
+        sd s9, 0xC8(sp)
+        sd s10, 0xD0(sp)
+        sd s11, 0xD8(sp)
+        "
+    };
+    (save_fp) => {
+        "
+        fsd fs0, 0x140(sp)
+        fsd fs1, 0x148(sp)
+        fsd fs2, 0x190(sp)
+        fsd fs3, 0x198(sp)
+        fsd fs4, 0x1A0(sp)
+        fsd fs5, 0x1A8(sp)
+        fsd fs6, 0x1B0(sp)
+        fsd fs7, 0x1B8(sp)
+        fsd fs8, 0x1C0(sp)
+        fsd fs9, 0x1C8(sp)
+        fsd fs10, 0x1D0(sp)
+        fsd fs11, 0x1D8(sp)
+        "
+    };
+    (restore_gp) => {
+        "
+        ld ra, 0x08(a0)
+        ld sp, 0x10(a0)
+        ld gp, 0x18(a0)
+        ld tp, 0x20(a0)
+        ld t0, 0x28(a0)
+        ld t1, 0x30(a0)
+        ld t2, 0x38(a0)
+        ld s0, 0x40(a0)
+        ld s1, 0x48(a0)
+        ld a1, 0x58(a0)
+        ld a2, 0x60(a0)
+        ld a3, 0x68(a0)
+        ld a4, 0x70(a0)
+        ld a5, 0x78(a0)
+        ld a6, 0x80(a0)
+        ld a7, 0x88(a0)
+        ld s2, 0x90(a0)
+        ld s3, 0x98(a0)
+        ld s4, 0xA0(a0)
+        ld s5, 0xA8(a0)
+        ld s6, 0xB0(a0)
+        ld s7, 0xB8(a0)
+        ld s8, 0xC0(a0)
+        ld s9, 0xC8(a0)
+        ld s10, 0xD0(a0)
+        ld s11, 0xD8(a0)
+        ld t3, 0xE0(a0)
+        ld t4, 0xE8(a0)
+        ld t5, 0xF0(a0)
+        ld t6, 0xF8(a0)
+        "
+    };
+    (restore_fp) => {
+        "
+        fld ft0, 0x100(a0)
+        fld ft1, 0x108(a0)
+        fld ft2, 0x110(a0)
+        fld ft3, 0x118(a0)
+        fld ft4, 0x120(a0)
+        fld ft5, 0x128(a0)
+        fld ft6, 0x130(a0)
+        fld ft7, 0x138(a0)
+        fld fs0, 0x140(a0)
+        fld fs1, 0x148(a0)
+        fld fa0, 0x150(a0)
+        fld fa1, 0x158(a0)
+        fld fa2, 0x160(a0)
+        fld fa3, 0x168(a0)
+        fld fa4, 0x170(a0)
+        fld fa5, 0x178(a0)
+        fld fa6, 0x180(a0)
+        fld fa7, 0x188(a0)
+        fld fs2, 0x190(a0)
+        fld fs3, 0x198(a0)
+        fld fs4, 0x1A0(a0)
+        fld fs5, 0x1A8(a0)
+        fld fs6, 0x1B0(a0)
+        fld fs7, 0x1B8(a0)
+        fld fs8, 0x1C0(a0)
+        fld fs9, 0x1C8(a0)
+        fld fs10, 0x1D0(a0)
+        fld fs11, 0x1D8(a0)
+        fld ft8, 0x1E0(a0)
+        fld ft9, 0x1E8(a0)
+        fld ft10, 0x1F0(a0)
+        fld ft11, 0x1F8(a0)
+        "
+    };
+}
+
+#[naked]
+pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), ptr: *mut ()) {
+    // No need to save caller-saved registers here.
+    #[cfg(target_feature = "d")]
+    unsafe {
+        asm!(
+            "
+            mv t0, sp
+            add sp, sp, -0x210
+            sd ra, 0x200(sp)
+            ",
+            code!(save_gp),
+            code!(save_fp),
+            "
+            mv t0, a0
+            mv a0, sp
+            jalr t0
+            ld ra, 0x200(sp)
+            add sp, sp, 0x210
+            ret
+            ",
+            options(noreturn)
+        );
+    }
+    #[cfg(not(target_feature = "d"))]
+    unsafe {
+        asm!(
+            "
+            mv t0, sp
+            add sp, sp, -0x110
+            sd ra, 0x100(sp)
+            ",
+            code!(save_gp),
+            "
+            mv t0, a0
+            mv a0, sp
+            jalr t0
+            ld ra, 0x100(sp)
+            add sp, sp, 0x110
+            ret
+            ",
+            options(noreturn)
+        );
+    }
+}
+
+pub unsafe fn restore_context(ctx: &Context) -> ! {
+    #[cfg(target_feature = "d")]
+    unsafe {
+        asm!(
+            code!(restore_fp),
+            code!(restore_gp),
+            "
+            ld a0, 0x50(a0)
+            ret
+            ",
+            in("a0") ctx,
+            options(noreturn)
+        );
+    }
+    #[cfg(not(target_feature = "d"))]
+    unsafe {
+        asm!(
+            code!(restore_gp),
+            "
+            ld a0, 0x50(a0)
+            ret
+            ",
+            in("a0") ctx,
+            options(noreturn)
+        );
+    }
+}

--- a/libs/kstd/src/unwinding/eh_info.rs
+++ b/libs/kstd/src/unwinding/eh_info.rs
@@ -1,0 +1,49 @@
+use crate::sync::LazyLock;
+use gimli::{BaseAddresses, EhFrame, EhFrameHdr, EndianSlice, NativeEndian, ParsedEhFrameHdr};
+
+use super::utils::{deref_pointer, get_unlimited_slice};
+
+// Below is a fun hack: We need a reference to the `.eh_frame` and `.eh_frame_hdr` sections and
+// must therefore force the linker to retain those even in release builds. By abusing mutable statics
+// like below we get a reference to the section start AND force it to not be garbage collected.
+
+#[used(linker)]
+#[link_section = ".eh_frame"]
+static mut EH_FRAME: [u8; 0] = [];
+
+#[used(linker)]
+#[link_section = ".eh_frame_hdr"]
+static mut EH_FRAME_HDR: [u8; 0] = [];
+
+#[derive(Debug)]
+pub struct EhInfo {
+    /// A set of base addresses used for relative addressing.
+    pub bases: BaseAddresses,
+    /// The parsed `.eh_frame_hdr` section.
+    pub hdr: ParsedEhFrameHdr<EndianSlice<'static, NativeEndian>>,
+    /// The parsed `.eh_frame` containing the call frame information.
+    pub eh_frame: EhFrame<EndianSlice<'static, NativeEndian>>,
+}
+
+pub static EH_INFO: LazyLock<EhInfo> = LazyLock::new(|| {
+    let eh_frame_hdr = unsafe { get_unlimited_slice(EH_FRAME_HDR.as_ptr()) };
+
+    let mut bases = BaseAddresses::default()
+        .set_eh_frame_hdr(eh_frame_hdr.as_ptr() as u64)
+        .set_text(0xffffffff80000000); // TODO support dynamic offsets
+
+    let hdr = EhFrameHdr::new(eh_frame_hdr, NativeEndian)
+        .parse(&bases, 8)
+        .unwrap();
+
+    let eh_frame = unsafe { deref_pointer(hdr.eh_frame_ptr()) as *const u8 };
+    bases = bases.set_eh_frame(eh_frame as u64);
+
+    let eh_frame = EhFrame::new(unsafe { get_unlimited_slice(eh_frame) }, NativeEndian);
+
+    EhInfo {
+        bases,
+        hdr,
+        eh_frame,
+    }
+});

--- a/libs/kstd/src/unwinding/eh_info.rs
+++ b/libs/kstd/src/unwinding/eh_info.rs
@@ -30,7 +30,7 @@ pub static EH_INFO: LazyLock<EhInfo> = LazyLock::new(|| {
 
     let mut bases = BaseAddresses::default()
         .set_eh_frame_hdr(eh_frame_hdr.as_ptr() as u64)
-        .set_text(0xffffffff80000000); // TODO support dynamic offsets
+        .set_text(0xffff_ffff_8000_0000); // TODO support dynamic offsets
 
     let hdr = EhFrameHdr::new(eh_frame_hdr, NativeEndian)
         .parse(&bases, 8)

--- a/libs/kstd/src/unwinding/frame.rs
+++ b/libs/kstd/src/unwinding/frame.rs
@@ -1,0 +1,111 @@
+use super::{arch, PersonalityRoutine};
+use gimli::{
+    BaseAddresses, CfaRule, EhFrame, FrameDescriptionEntry, Register, RegisterRule, UnwindTableRow,
+};
+use gimli::{EndianSlice, NativeEndian};
+
+pub type StaticSlice = EndianSlice<'static, NativeEndian>;
+
+struct StoreOnStack;
+
+// gimli's MSRV doesn't allow const generics, so we need to pick a supported array size.
+const fn next_value(x: usize) -> usize {
+    let supported = [0, 1, 2, 3, 4, 8, 16, 32, 64, 128];
+    let mut i = 0;
+    while i < supported.len() {
+        if supported[i] >= x {
+            return supported[i];
+        }
+        i += 1;
+    }
+    192
+}
+
+impl<R: gimli::Reader> gimli::UnwindContextStorage<R> for StoreOnStack {
+    type Rules = [(Register, RegisterRule<R>); next_value(arch::MAX_REG_RULES)];
+    type Stack = [UnwindTableRow<R, Self>; 2];
+}
+
+#[derive(Debug)]
+pub struct Frame<'a> {
+    fde_result: &'static FDESearchResult,
+    row: &'a UnwindTableRow<StaticSlice, StoreOnStack>,
+}
+
+#[derive(Debug)]
+pub struct FDESearchResult {
+    pub fde: FrameDescriptionEntry<StaticSlice>,
+    pub bases: BaseAddresses,
+    pub eh_frame: EhFrame<StaticSlice>,
+}
+
+impl<'a> Frame<'a> {
+    pub fn from_context(ctx: &arch::Context, signal: bool) -> Result<Option<Self>, gimli::Error> {
+        // TODO lazliy load eh_frame
+
+        // let fde_result = match find_fde::get_finder().find_fde(ra as _) {
+        //     Som<e(v) => v,
+        //     None => return Ok(None),
+        // };
+        // let mut unwinder = UnwindContext::<_, StoreOnStack>::new_in();
+        // let row = fde_result
+        //     .fde
+        //     .unwind_info_for_address(
+        //         &fde_result.eh_frame,
+        //         &fde_result.bases,
+        //         &mut unwinder,
+        //         ra as _,
+        //     )?
+        //     .clone();
+
+        // Ok(Some(Self { fde_result, row }))
+
+        todo!()
+    }
+
+    pub fn unwind(&self, ctx: &arch::Context) -> Result<arch::Context, gimli::Error> {
+        let row = &self.row;
+        let mut new_ctx = ctx.clone();
+
+        let cfa = match *row.cfa() {
+            CfaRule::RegisterAndOffset { register, offset } => {
+                ctx[register].wrapping_add(offset as usize)
+            }
+            _ => return Err(gimli::Error::UnsupportedEvaluation),
+        };
+
+        new_ctx[arch::SP] = cfa as _;
+        new_ctx[arch::RA] = 0;
+
+        for (reg, rule) in row.registers() {
+            let value = match *rule {
+                RegisterRule::Undefined | RegisterRule::SameValue => ctx[*reg],
+                RegisterRule::Offset(offset) => unsafe {
+                    *((cfa.wrapping_add(offset as usize)) as *const usize)
+                },
+                RegisterRule::ValOffset(offset) => cfa.wrapping_add(offset as usize),
+                RegisterRule::Expression(_) | RegisterRule::ValExpression(_) => {
+                    return Err(gimli::Error::UnsupportedEvaluation)
+                }
+                RegisterRule::Architectural => unreachable!(),
+                RegisterRule::Constant(value) => value as usize,
+                _ => unreachable!(),
+            };
+            new_ctx[*reg] = value;
+        }
+
+        Ok(new_ctx)
+    }
+
+    pub fn personality(&self) -> Option<PersonalityRoutine> {
+        self.fde_result
+            .fde
+            .personality()
+            .map(|x| unsafe { deref_pointer(x) })
+            .map(|x| unsafe { core::mem::transmute(x) })
+    }
+
+    pub fn is_signal_trampoline(&self) -> bool {
+        self.fde_result.fde.is_signal_trampoline()
+    }
+}

--- a/libs/kstd/src/unwinding/mod.rs
+++ b/libs/kstd/src/unwinding/mod.rs
@@ -1,0 +1,173 @@
+mod arch;
+mod frame;
+
+use core::{
+    ffi::{c_int, c_void},
+    ptr,
+};
+use frame::Frame;
+
+pub struct UnwindContext<'a> {
+    frame: Option<&'a Frame<'a>>,
+    ctx: &'a mut arch::Context,
+    signal: bool,
+}
+
+#[repr(C)]
+pub struct UnwindException {
+    pub exception_class: u64,
+    pub exception_cleanup: Option<UnwindExceptionCleanupFn>,
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct UnwindReasonCode(pub c_int);
+
+#[allow(unused)]
+impl UnwindReasonCode {
+    pub const NO_REASON: Self = Self(0);
+    pub const FOREIGN_EXCEPTION_CAUGHT: Self = Self(1);
+    pub const FATAL_PHASE2_ERROR: Self = Self(2);
+    pub const FATAL_PHASE1_ERROR: Self = Self(3);
+    pub const NORMAL_STOP: Self = Self(4);
+    pub const END_OF_STACK: Self = Self(5);
+    pub const HANDLER_FOUND: Self = Self(6);
+    pub const INSTALL_CONTEXT: Self = Self(7);
+    pub const CONTINUE_UNWIND: Self = Self(8);
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct UnwindAction(pub c_int);
+
+impl UnwindAction {
+    pub const SEARCH_PHASE: Self = Self(1);
+    pub const CLEANUP_PHASE: Self = Self(2);
+    pub const HANDLER_FRAME: Self = Self(4);
+    pub const FORCE_UNWIND: Self = Self(8);
+    pub const END_OF_STACK: Self = Self(16);
+}
+
+pub type PersonalityRoutine = unsafe extern "C" fn(
+    // version
+    c_int,
+    UnwindAction,
+    // exception_class
+    u64,
+    *mut UnwindException,
+    &mut UnwindContext<'_>,
+) -> UnwindReasonCode;
+
+pub type UnwindExceptionCleanupFn = unsafe extern "C" fn(UnwindReasonCode, *mut UnwindException);
+
+pub type UnwindStopFn = unsafe extern "C" fn(
+    // version
+    c_int,
+    UnwindAction,
+    // exception_class
+    u64,
+    *mut UnwindException,
+    &mut UnwindContext<'_>,
+    *mut c_void,
+) -> UnwindReasonCode;
+
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _Unwind_RaiseException(
+    exception: *mut UnwindException,
+) -> UnwindReasonCode {
+    with_context(|ctx| {
+        let mut signal = false;
+        loop {
+            let frame = match Frame::from_context(ctx, signal) {
+                Ok(Some(frame)) => frame,
+                Ok(None) => {
+                    return UnwindReasonCode::END_OF_STACK;
+                }
+                Err(_) => {
+                    return UnwindReasonCode::FATAL_PHASE1_ERROR;
+                }
+            };
+
+            if let Some(personality) = frame.personality() {
+                let result = unsafe {
+                    personality(
+                        1,
+                        UnwindAction::SEARCH_PHASE,
+                        (*exception).exception_class,
+                        exception,
+                        &mut UnwindContext {
+                            frame: Some(&frame),
+                            ctx,
+                            signal,
+                        },
+                    )
+                };
+
+                match result {
+                    UnwindReasonCode::CONTINUE_UNWIND => (),
+                    UnwindReasonCode::HANDLER_FOUND => {
+                        break;
+                    }
+                    _ => return UnwindReasonCode::FATAL_PHASE1_ERROR,
+                }
+            }
+
+            ctx = frame.unwind(ctx).unwrap();
+            signal = frame.is_signal_trampoline();
+        }
+    })
+}
+
+// phase 1: find the handler
+fn raise_exception_phase1() {}
+fn raise_exception_phase2() {}
+
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _Unwind_ForcedUnwind(
+    exception: *mut UnwindException,
+    stop: UnwindStopFn,
+    stop_arg: *mut c_void,
+) -> UnwindReasonCode {
+    todo!()
+}
+
+fn forced_unwind_phase1() {}
+fn forced_unwind_phase2() {}
+
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut UnwindException) -> ! {
+    todo!()
+}
+
+// Helper function to turn `save_context` which takes function pointer to a closure-taking function.
+fn with_context<T, F: FnOnce(&mut arch::Context) -> T>(f: F) -> T {
+    use core::mem::ManuallyDrop;
+
+    union Data<T, F> {
+        f: ManuallyDrop<F>,
+        t: ManuallyDrop<T>,
+    }
+
+    extern "C" fn delegate<T, F: FnOnce(&mut arch::Context) -> T>(
+        ctx: &mut arch::Context,
+        ptr: *mut (),
+    ) {
+        // SAFETY: This function is called exactly once; it extracts the function, call it and
+        // store the return value. This function is `extern "C"` so we don't need to worry about
+        // unwinding past it.
+        unsafe {
+            let data = &mut *ptr.cast::<Data<T, F>>();
+            let t = ManuallyDrop::take(&mut data.f)(ctx);
+            data.t = ManuallyDrop::new(t);
+        }
+    }
+
+    let mut data = Data {
+        f: ManuallyDrop::new(f),
+    };
+    arch::save_context(delegate::<T, F>, ptr::addr_of_mut!(data).cast());
+    unsafe { ManuallyDrop::into_inner(data.t) }
+}

--- a/libs/kstd/src/unwinding/mod.rs
+++ b/libs/kstd/src/unwinding/mod.rs
@@ -1,173 +1,72 @@
-mod arch;
+mod eh_info;
 mod frame;
+mod personality;
+mod unwinder;
+mod utils;
 
-use core::{
-    ffi::{c_int, c_void},
-    ptr,
-};
-use frame::Frame;
+use core::{any::Any, ptr};
 
-pub struct UnwindContext<'a> {
-    frame: Option<&'a Frame<'a>>,
-    ctx: &'a mut arch::Context,
-    signal: bool,
-}
+use crate::{arch, heprintln};
+use alloc::boxed::Box;
+pub use unwinder::*;
+
+static CANARY: u8 = 0;
 
 #[repr(C)]
-pub struct UnwindException {
-    pub exception_class: u64,
-    pub exception_cleanup: Option<UnwindExceptionCleanupFn>,
+struct Exception {
+    _uwe: crate::unwinding::UnwindException,
+    canary: *const u8,
+    cause: Box<dyn Any + Send>,
 }
 
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct UnwindReasonCode(pub c_int);
-
-#[allow(unused)]
-impl UnwindReasonCode {
-    pub const NO_REASON: Self = Self(0);
-    pub const FOREIGN_EXCEPTION_CAUGHT: Self = Self(1);
-    pub const FATAL_PHASE2_ERROR: Self = Self(2);
-    pub const FATAL_PHASE1_ERROR: Self = Self(3);
-    pub const NORMAL_STOP: Self = Self(4);
-    pub const END_OF_STACK: Self = Self(5);
-    pub const HANDLER_FOUND: Self = Self(6);
-    pub const INSTALL_CONTEXT: Self = Self(7);
-    pub const CONTINUE_UNWIND: Self = Self(8);
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct UnwindAction(pub c_int);
-
-impl UnwindAction {
-    pub const SEARCH_PHASE: Self = Self(1);
-    pub const CLEANUP_PHASE: Self = Self(2);
-    pub const HANDLER_FRAME: Self = Self(4);
-    pub const FORCE_UNWIND: Self = Self(8);
-    pub const END_OF_STACK: Self = Self(16);
-}
-
-pub type PersonalityRoutine = unsafe extern "C" fn(
-    // version
-    c_int,
-    UnwindAction,
-    // exception_class
-    u64,
-    *mut UnwindException,
-    &mut UnwindContext<'_>,
-) -> UnwindReasonCode;
-
-pub type UnwindExceptionCleanupFn = unsafe extern "C" fn(UnwindReasonCode, *mut UnwindException);
-
-pub type UnwindStopFn = unsafe extern "C" fn(
-    // version
-    c_int,
-    UnwindAction,
-    // exception_class
-    u64,
-    *mut UnwindException,
-    &mut UnwindContext<'_>,
-    *mut c_void,
-) -> UnwindReasonCode;
-
-#[inline(never)]
-#[no_mangle]
-pub unsafe extern "C-unwind" fn _Unwind_RaiseException(
-    exception: *mut UnwindException,
-) -> UnwindReasonCode {
-    with_context(|ctx| {
-        let mut signal = false;
-        loop {
-            let frame = match Frame::from_context(ctx, signal) {
-                Ok(Some(frame)) => frame,
-                Ok(None) => {
-                    return UnwindReasonCode::END_OF_STACK;
-                }
-                Err(_) => {
-                    return UnwindReasonCode::FATAL_PHASE1_ERROR;
-                }
-            };
-
-            if let Some(personality) = frame.personality() {
-                let result = unsafe {
-                    personality(
-                        1,
-                        UnwindAction::SEARCH_PHASE,
-                        (*exception).exception_class,
-                        exception,
-                        &mut UnwindContext {
-                            frame: Some(&frame),
-                            ctx,
-                            signal,
-                        },
-                    )
-                };
-
-                match result {
-                    UnwindReasonCode::CONTINUE_UNWIND => (),
-                    UnwindReasonCode::HANDLER_FOUND => {
-                        break;
-                    }
-                    _ => return UnwindReasonCode::FATAL_PHASE1_ERROR,
-                }
-            }
-
-            ctx = frame.unwind(ctx).unwrap();
-            signal = frame.is_signal_trampoline();
-        }
-    })
-}
-
-// phase 1: find the handler
-fn raise_exception_phase1() {}
-fn raise_exception_phase2() {}
-
-#[inline(never)]
-#[no_mangle]
-pub unsafe extern "C-unwind" fn _Unwind_ForcedUnwind(
-    exception: *mut UnwindException,
-    stop: UnwindStopFn,
-    stop_arg: *mut c_void,
-) -> UnwindReasonCode {
-    todo!()
-}
-
-fn forced_unwind_phase1() {}
-fn forced_unwind_phase2() {}
-
-#[inline(never)]
-#[no_mangle]
-pub unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut UnwindException) -> ! {
-    todo!()
-}
-
-// Helper function to turn `save_context` which takes function pointer to a closure-taking function.
-fn with_context<T, F: FnOnce(&mut arch::Context) -> T>(f: F) -> T {
-    use core::mem::ManuallyDrop;
-
-    union Data<T, F> {
-        f: ManuallyDrop<F>,
-        t: ManuallyDrop<T>,
-    }
-
-    extern "C" fn delegate<T, F: FnOnce(&mut arch::Context) -> T>(
-        ctx: &mut arch::Context,
-        ptr: *mut (),
+pub fn panic_begin(data: Box<dyn Any + Send>) -> i32 {
+    extern "C" fn exception_cleanup(
+        _unwind_code: crate::unwinding::UnwindReasonCode,
+        exception: *mut crate::unwinding::UnwindException,
     ) {
-        // SAFETY: This function is called exactly once; it extracts the function, call it and
-        // store the return value. This function is `extern "C"` so we don't need to worry about
-        // unwinding past it.
         unsafe {
-            let data = &mut *ptr.cast::<Data<T, F>>();
-            let t = ManuallyDrop::take(&mut data.f)(ctx);
-            data.t = ManuallyDrop::new(t);
+            let _: Box<Exception> = Box::from_raw(exception as *mut Exception);
+            heprintln!("Rust panics must be rethrown");
+            arch::abort_internal(1);
         }
     }
 
-    let mut data = Data {
-        f: ManuallyDrop::new(f),
-    };
-    arch::save_context(delegate::<T, F>, ptr::addr_of_mut!(data).cast());
-    unsafe { ManuallyDrop::into_inner(data.t) }
+    let exception = Box::into_raw(Box::new(Exception {
+        _uwe: crate::unwinding::UnwindException::new(
+            rust_exception_class(),
+            Some(exception_cleanup),
+        ),
+        canary: &CANARY,
+        cause: data,
+    })) as *mut crate::unwinding::UnwindException;
+
+    unsafe { crate::unwinding::_Unwind_RaiseException(exception).0 }
+}
+
+pub unsafe fn panic_cleanup(ptr: *mut u8) -> Box<dyn Any + Send> {
+    let exception = ptr as *mut UnwindException;
+    if (*exception).exception_class != rust_exception_class() {
+        crate::unwinding::_Unwind_DeleteException(exception);
+        heprintln!("Rust cannot catch foreign exceptions");
+        arch::abort_internal(1);
+    }
+
+    let exception = exception.cast::<Exception>();
+    // Just access the canary field, avoid accessing the entire `Exception` as
+    // it can be a foreign Rust exception.
+    let canary = ptr::addr_of!((*exception).canary).read();
+    if !ptr::eq(canary, &CANARY) {
+        heprintln!("Rust cannot catch foreign exceptions");
+        arch::abort_internal(1);
+    }
+
+    let exception = Box::from_raw(exception as *mut Exception);
+    exception.cause
+}
+
+// Rust's exception class identifier.  This is used by personality routines to
+// determine whether the exception was thrown by their own runtime.
+fn rust_exception_class() -> u64 {
+    // M O Z \0  R U S T -- vendor, language
+    0x4d4f5a_00_52555354
 }

--- a/libs/kstd/src/unwinding/personality.rs
+++ b/libs/kstd/src/unwinding/personality.rs
@@ -1,0 +1,182 @@
+use super::{
+    utils::{deref_pointer, get_unlimited_slice},
+    UnwindAction, UnwindContext, UnwindException, UnwindReasonCode,
+};
+use crate::arch;
+use core::{ffi::c_int, mem};
+use gimli::{constants, EndianSlice, NativeEndian, Pointer, Reader};
+
+#[lang = "eh_personality"]
+unsafe fn rust_eh_personality(
+    version: c_int,
+    actions: UnwindAction,
+    _exception_class: u64,
+    exception: *mut UnwindException,
+    unwind_ctx: &mut UnwindContext<'_>,
+) -> UnwindReasonCode {
+    if version != 1 {
+        return UnwindReasonCode::FATAL_PHASE1_ERROR;
+    }
+
+    let lsda = crate::unwinding::_Unwind_GetLanguageSpecificData(unwind_ctx);
+    if lsda.is_null() {
+        return UnwindReasonCode::CONTINUE_UNWIND;
+    }
+
+    let mut lsda = EndianSlice::new(unsafe { get_unlimited_slice(lsda as _) }, NativeEndian);
+    let eh_action = match find_eh_action(&mut lsda, unwind_ctx) {
+        Ok(v) => v,
+        Err(_) => return UnwindReasonCode::FATAL_PHASE1_ERROR,
+    };
+
+    if actions.contains(UnwindAction::SEARCH_PHASE) {
+        match eh_action {
+            EHAction::None | EHAction::Cleanup(_) => UnwindReasonCode::CONTINUE_UNWIND,
+            EHAction::Catch(_) => UnwindReasonCode::HANDLER_FOUND,
+        }
+    } else {
+        match eh_action {
+            EHAction::None => UnwindReasonCode::CONTINUE_UNWIND,
+            EHAction::Cleanup(lpad) | EHAction::Catch(lpad) => {
+                crate::unwinding::_Unwind_SetGR(
+                    unwind_ctx,
+                    arch::unwinding::UNWIND_DATA_REG.0 .0 as _,
+                    exception as usize,
+                );
+                crate::unwinding::_Unwind_SetGR(
+                    unwind_ctx,
+                    arch::unwinding::UNWIND_DATA_REG.1 .0 as _,
+                    0,
+                );
+                crate::unwinding::_Unwind_SetIP(unwind_ctx, lpad);
+                UnwindReasonCode::INSTALL_CONTEXT
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum EHAction {
+    None,
+    Cleanup(usize),
+    Catch(usize),
+}
+
+fn find_eh_action(
+    reader: &mut EndianSlice<'static, NativeEndian>,
+    unwind_ctx: &UnwindContext<'_>,
+) -> gimli::Result<EHAction> {
+    let func_start = crate::unwinding::_Unwind_GetRegionStart(unwind_ctx);
+    let mut ip_before_instr = 0;
+    let ip = crate::unwinding::_Unwind_GetIPInfo(unwind_ctx, &mut ip_before_instr);
+    let ip = if ip_before_instr != 0 { ip } else { ip - 1 };
+
+    let start_encoding = parse_pointer_encoding(reader)?;
+    let lpad_base = if !start_encoding.is_absent() {
+        unsafe { deref_pointer(parse_encoded_pointer(start_encoding, unwind_ctx, reader)?) }
+    } else {
+        func_start
+    };
+
+    let ttype_encoding = parse_pointer_encoding(reader)?;
+    if !ttype_encoding.is_absent() {
+        reader.read_uleb128()?;
+    }
+
+    let call_site_encoding = parse_pointer_encoding(reader)?;
+    let call_site_table_length = reader.read_uleb128()?;
+    reader.truncate(call_site_table_length as _)?;
+
+    while !reader.is_empty() {
+        let cs_start = unsafe {
+            deref_pointer(parse_encoded_pointer(
+                call_site_encoding,
+                unwind_ctx,
+                reader,
+            )?)
+        };
+        let cs_len = unsafe {
+            deref_pointer(parse_encoded_pointer(
+                call_site_encoding,
+                unwind_ctx,
+                reader,
+            )?)
+        };
+        let cs_lpad = unsafe {
+            deref_pointer(parse_encoded_pointer(
+                call_site_encoding,
+                unwind_ctx,
+                reader,
+            )?)
+        };
+        let cs_action = reader.read_uleb128()?;
+        if ip < func_start + cs_start {
+            break;
+        }
+        if ip < func_start + cs_start + cs_len {
+            if cs_lpad == 0 {
+                return Ok(EHAction::None);
+            } else {
+                let lpad = lpad_base + cs_lpad;
+                return Ok(match cs_action {
+                    0 => EHAction::Cleanup(lpad),
+                    _ => EHAction::Catch(lpad),
+                });
+            }
+        }
+    }
+    Ok(EHAction::None)
+}
+
+fn parse_pointer_encoding(
+    input: &mut EndianSlice<'static, NativeEndian>,
+) -> gimli::Result<constants::DwEhPe> {
+    let eh_pe = input.read_u8()?;
+    let eh_pe = constants::DwEhPe(eh_pe);
+
+    if eh_pe.is_valid_encoding() {
+        Ok(eh_pe)
+    } else {
+        Err(gimli::Error::UnknownPointerEncoding)
+    }
+}
+
+fn parse_encoded_pointer(
+    encoding: constants::DwEhPe,
+    unwind_ctx: &UnwindContext<'_>,
+    input: &mut EndianSlice<'static, NativeEndian>,
+) -> gimli::Result<Pointer> {
+    if encoding == constants::DW_EH_PE_omit {
+        return Err(gimli::Error::CannotParseOmitPointerEncoding);
+    }
+
+    let base = match encoding.application() {
+        constants::DW_EH_PE_absptr => 0,
+        constants::DW_EH_PE_pcrel => input.slice().as_ptr() as u64,
+        constants::DW_EH_PE_textrel => crate::unwinding::_Unwind_GetTextRelBase(unwind_ctx) as u64,
+        constants::DW_EH_PE_datarel => crate::unwinding::_Unwind_GetDataRelBase(unwind_ctx) as u64,
+        constants::DW_EH_PE_funcrel => crate::unwinding::_Unwind_GetRegionStart(unwind_ctx) as u64,
+        constants::DW_EH_PE_aligned => return Err(gimli::Error::UnsupportedPointerEncoding),
+        _ => unreachable!(),
+    };
+
+    let offset = match encoding.format() {
+        constants::DW_EH_PE_absptr => input.read_address(mem::size_of::<usize>() as _),
+        constants::DW_EH_PE_uleb128 => input.read_uleb128(),
+        constants::DW_EH_PE_udata2 => input.read_u16().map(u64::from),
+        constants::DW_EH_PE_udata4 => input.read_u32().map(u64::from),
+        constants::DW_EH_PE_udata8 => input.read_u64(),
+        constants::DW_EH_PE_sleb128 => input.read_sleb128().map(|a| a as u64),
+        constants::DW_EH_PE_sdata2 => input.read_i16().map(|a| a as u64),
+        constants::DW_EH_PE_sdata4 => input.read_i32().map(|a| a as u64),
+        constants::DW_EH_PE_sdata8 => input.read_i64().map(|a| a as u64),
+        _ => unreachable!(),
+    }?;
+
+    let address = base.wrapping_add(offset);
+    Ok(if encoding.is_indirect() {
+        Pointer::Indirect(address)
+    } else {
+        Pointer::Direct(address)
+    })
+}

--- a/libs/kstd/src/unwinding/unwinder.rs
+++ b/libs/kstd/src/unwinding/unwinder.rs
@@ -1,0 +1,350 @@
+use bitflags::bitflags;
+use core::{
+    ffi::{c_int, c_void},
+    fmt, ptr,
+};
+use gimli::Register;
+
+use crate::arch;
+
+use super::{frame::Frame, utils::with_context};
+
+#[derive(Debug, onlyerror::Error)]
+enum UnwindError {
+    #[error("failed to construct frame {0:?}")]
+    ConstructFrame(gimli::Error),
+    #[error("failed to unwind frame {0:?}")]
+    UnwindFrame(gimli::Error),
+    #[error("end of stack")]
+    EndOfStack,
+    #[error("personality routine failed with reason code {0:?}")]
+    PersonalityFailure(UnwindReasonCode),
+}
+
+impl UnwindError {
+    pub fn into_phase1_reason_code(self) -> UnwindReasonCode {
+        match self {
+            Self::ConstructFrame(_) | Self::UnwindFrame(_) => UnwindReasonCode::FATAL_PHASE1_ERROR,
+            Self::EndOfStack => UnwindReasonCode::END_OF_STACK,
+            Self::PersonalityFailure(code) => code,
+        }
+    }
+
+    pub fn into_phase2_reason_code(self) -> UnwindReasonCode {
+        match self {
+            UnwindError::PersonalityFailure(code) => code,
+            _ => UnwindReasonCode::FATAL_PHASE2_ERROR,
+        }
+    }
+}
+
+pub(crate) struct UnwindContext<'a> {
+    frame: Option<&'a Frame>,
+    ctx: &'a mut arch::unwinding::Context,
+    signal: bool,
+}
+
+// ===================================
+// Now comes all the nasty FFI stuff
+// ===================================
+
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct UnwindReasonCode(pub c_int);
+
+#[allow(unused)]
+impl UnwindReasonCode {
+    pub const NO_REASON: Self = Self(0);
+    pub const FOREIGN_EXCEPTION_CAUGHT: Self = Self(1);
+    pub const FATAL_PHASE2_ERROR: Self = Self(2);
+    pub const FATAL_PHASE1_ERROR: Self = Self(3);
+    pub const NORMAL_STOP: Self = Self(4);
+    pub const END_OF_STACK: Self = Self(5);
+    pub const HANDLER_FOUND: Self = Self(6);
+    pub const INSTALL_CONTEXT: Self = Self(7);
+    pub const CONTINUE_UNWIND: Self = Self(8);
+}
+
+impl fmt::Debug for UnwindReasonCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "UnwindReasonCode(")?;
+        match *self {
+            Self::NO_REASON => write!(f, "NO_REASON")?,
+            Self::FOREIGN_EXCEPTION_CAUGHT => write!(f, "FOREIGN_EXCEPTION_CAUGHT")?,
+            Self::FATAL_PHASE2_ERROR => write!(f, "FATAL_PHASE2_ERROR")?,
+            Self::FATAL_PHASE1_ERROR => write!(f, "FATAL_PHASE1_ERROR")?,
+            Self::NORMAL_STOP => write!(f, "NORMAL_STOP")?,
+            Self::END_OF_STACK => write!(f, "END_OF_STACK")?,
+            Self::HANDLER_FOUND => write!(f, "HANDLER_FOUND")?,
+            Self::INSTALL_CONTEXT => write!(f, "INSTALL_CONTEXT")?,
+            Self::CONTINUE_UNWIND => write!(f, "CONTINUE_UNWIND")?,
+            _ => write!(f, "<invalid>")?,
+        }
+        write!(f, ")")
+    }
+}
+
+bitflags! {
+    #[repr(transparent)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct UnwindAction: c_int {
+        const SEARCH_PHASE = 1;
+        const CLEANUP_PHASE = 2;
+        const HANDLER_FRAME = 4;
+        const FORCE_UNWIND = 8;
+        const END_OF_STACK = 16;
+    }
+}
+
+#[repr(C)]
+pub struct UnwindException {
+    pub exception_class: u64,
+    pub exception_cleanup: Option<UnwindExceptionCleanupFn>,
+    pub(crate) stop_fn: Option<*const c_void>,
+    pub(crate) handler_cfa: usize,
+}
+
+impl UnwindException {
+    pub fn new(exception_class: u64, exception_cleanup: Option<UnwindExceptionCleanupFn>) -> Self {
+        Self {
+            exception_class,
+            exception_cleanup,
+            stop_fn: None,
+            handler_cfa: 0,
+        }
+    }
+}
+
+pub type UnwindExceptionCleanupFn = unsafe extern "C" fn(UnwindReasonCode, *mut UnwindException);
+
+pub type PersonalityRoutine = unsafe extern "C" fn(
+    c_int,
+    UnwindAction,
+    u64,
+    *mut UnwindException,
+    &mut UnwindContext<'_>,
+) -> UnwindReasonCode;
+
+pub type UnwindTraceFn =
+    extern "C" fn(ctx: &UnwindContext<'_>, arg: *mut c_void) -> UnwindReasonCode;
+
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _Unwind_RaiseException(
+    exception: *mut UnwindException,
+) -> UnwindReasonCode {
+    with_context(|saved_ctx| {
+        let mut ctx = saved_ctx.clone();
+
+        let signal = match raise_exception_phase1(exception, &mut ctx) {
+            Ok(signal) => signal,
+            Err(err) => return err.into_phase1_reason_code(),
+        };
+
+        // Disambiguate normal frame and signal frame.
+        let handler_cfa = ctx[arch::unwinding::SP] - signal as usize;
+
+        unsafe {
+            (*exception).stop_fn = None;
+            (*exception).handler_cfa = handler_cfa;
+        }
+
+        if let Err(err) = raise_exception_phase2(exception, saved_ctx, handler_cfa) {
+            return err.into_phase2_reason_code();
+        };
+
+        arch::unwinding::restore_context(saved_ctx);
+    })
+}
+
+fn raise_exception_phase1(
+    exception: *mut UnwindException,
+    ctx: &mut arch::unwinding::Context,
+) -> Result<bool, UnwindError> {
+    let mut signal = false;
+
+    loop {
+        if let Some(frame) =
+            Frame::from_context(&ctx, signal).map_err(UnwindError::ConstructFrame)?
+        {
+            if let Some(personality) = frame.personality() {
+                let result = unsafe {
+                    personality(
+                        1,
+                        UnwindAction::SEARCH_PHASE,
+                        (*exception).exception_class,
+                        exception,
+                        &mut UnwindContext {
+                            frame: Some(&frame),
+                            ctx,
+                            signal,
+                        },
+                    )
+                };
+
+                match result {
+                    UnwindReasonCode::CONTINUE_UNWIND => (),
+                    UnwindReasonCode::HANDLER_FOUND => {
+                        break Ok(signal);
+                    }
+                    code => return Err(UnwindError::PersonalityFailure(code)),
+                }
+            }
+
+            *ctx = frame.unwind(&ctx).map_err(UnwindError::UnwindFrame)?;
+            signal = frame.is_signal_trampoline();
+        } else {
+            return Err(UnwindError::EndOfStack);
+        }
+    }
+}
+
+fn raise_exception_phase2(
+    exception: *mut UnwindException,
+    ctx: &mut arch::unwinding::Context,
+    handler_cfa: usize,
+) -> Result<(), UnwindError> {
+    let mut signal = false;
+
+    loop {
+        if let Some(frame) =
+            Frame::from_context(&ctx, signal).map_err(UnwindError::ConstructFrame)?
+        {
+            let frame_cfa = ctx[arch::unwinding::SP] - signal as usize;
+            if let Some(personality) = frame.personality() {
+                let code = unsafe {
+                    personality(
+                        1,
+                        UnwindAction::CLEANUP_PHASE
+                            | if frame_cfa == handler_cfa {
+                                UnwindAction::HANDLER_FRAME
+                            } else {
+                                UnwindAction::empty()
+                            },
+                        (*exception).exception_class,
+                        exception,
+                        &mut UnwindContext {
+                            frame: Some(&frame),
+                            ctx,
+                            signal,
+                        },
+                    )
+                };
+
+                match code {
+                    UnwindReasonCode::CONTINUE_UNWIND => (),
+                    UnwindReasonCode::INSTALL_CONTEXT => {
+                        frame.adjust_stack_for_args(ctx);
+                        return Ok(());
+                    }
+                    code => return Err(UnwindError::PersonalityFailure(code)),
+                }
+            }
+
+            *ctx = frame.unwind(ctx).map_err(UnwindError::UnwindFrame)?;
+            signal = frame.is_signal_trampoline();
+        } else {
+            return Err(UnwindError::EndOfStack);
+        }
+    }
+}
+
+/// Resume unwinding a given exception.
+///
+/// This function funnily enough is the only thing in the whole `unwinder` module that actually
+/// needs the whole complicated C++/libunwind compatible ABI since it will be called by code-generated
+/// landing pads when they want to resume the unwinding process
+/// (to my knowledge unwind landing pads are generated for all `Drop` implementations as well as for every ``catch_unwind`)
+#[inline(never)]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut UnwindException) -> ! {
+    with_context(|ctx| {
+        match unsafe { (*exception).stop_fn } {
+            None => {
+                let handler_cfa = unsafe { (*exception).handler_cfa };
+                if let Err(_err) = raise_exception_phase2(exception, ctx, handler_cfa) {
+                    arch::abort_internal(1);
+                }
+            }
+            Some(_stop) => {
+                arch::abort_internal(1);
+            }
+        }
+
+        unsafe { arch::unwinding::restore_context(ctx) }
+    })
+}
+
+// #[inline(never)]
+// #[no_mangle]
+// pub unsafe extern "C-unwind" fn _Unwind_ForcedUnwind(
+//     exception: *mut UnwindException,
+//     stop: UnwindStopFn,
+//     stop_arg: *mut c_void,
+// ) -> UnwindReasonCode {
+//     with_context(|ctx| {})
+// }
+
+#[no_mangle]
+pub extern "C" fn _Unwind_GetLanguageSpecificData(unwind_ctx: &UnwindContext<'_>) -> *mut c_void {
+    unwind_ctx
+        .frame
+        .map(|f| f.lsda() as *mut c_void)
+        .unwrap_or(ptr::null_mut())
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_GetRegionStart(unwind_ctx: &UnwindContext<'_>) -> usize {
+    unwind_ctx.frame.map(|f| f.initial_address()).unwrap_or(0)
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_SetGR(unwind_ctx: &mut UnwindContext<'_>, index: c_int, value: usize) {
+    unwind_ctx.ctx[Register(index as u16)] = value;
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_SetIP(unwind_ctx: &mut UnwindContext<'_>, value: usize) {
+    unwind_ctx.ctx[arch::unwinding::RA] = value;
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_GetIPInfo(
+    unwind_ctx: &UnwindContext<'_>,
+    ip_before_insn: &mut c_int,
+) -> usize {
+    *ip_before_insn = unwind_ctx.signal as _;
+    unwind_ctx.ctx[arch::unwinding::RA]
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_GetTextRelBase(unwind_ctx: &UnwindContext<'_>) -> usize {
+    unwind_ctx
+        .frame
+        .map(|f| f.bases().eh_frame.text.unwrap() as _)
+        .unwrap_or(0)
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_GetDataRelBase(unwind_ctx: &UnwindContext<'_>) -> usize {
+    unwind_ctx
+        .frame
+        .map(|f| f.bases().eh_frame.data.unwrap() as _)
+        .unwrap_or(0)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn _Unwind_DeleteException(exception: *mut UnwindException) {
+    if let Some(cleanup) = unsafe { (*exception).exception_cleanup } {
+        unsafe { cleanup(UnwindReasonCode::FOREIGN_EXCEPTION_CAUGHT, exception) };
+    }
+}
+
+// #[inline(never)]
+// #[no_mangle]
+// pub extern "C-unwind" fn _Unwind_Backtrace(
+//     trace: UnwindTraceFn,
+//     trace_argument: *mut c_void,
+// ) -> UnwindReasonCode {
+//     with_context(|ctx| {})
+// }

--- a/libs/kstd/src/unwinding/utils.rs
+++ b/libs/kstd/src/unwinding/utils.rs
@@ -1,0 +1,50 @@
+use core::ptr;
+
+use gimli::Pointer;
+
+use crate::arch;
+
+pub unsafe fn get_unlimited_slice<'a>(start: *const u8) -> &'a [u8] {
+    // Create the largest possible slice for this address.
+    let start = start as usize;
+    let end = start.saturating_add(isize::MAX as _);
+    let len = end - start;
+    unsafe { core::slice::from_raw_parts(start as *const _, len) }
+}
+
+pub unsafe fn deref_pointer(ptr: Pointer) -> usize {
+    match ptr {
+        Pointer::Direct(x) => x as _,
+        Pointer::Indirect(x) => unsafe { *(x as *const _) },
+    }
+}
+
+// Helper function to turn `save_context` which takes function pointer to a closure-taking function.
+pub fn with_context<T, F: FnOnce(&mut arch::unwinding::Context) -> T>(f: F) -> T {
+    use core::mem::ManuallyDrop;
+
+    union Data<T, F> {
+        f: ManuallyDrop<F>,
+        t: ManuallyDrop<T>,
+    }
+
+    extern "C" fn delegate<T, F: FnOnce(&mut arch::unwinding::Context) -> T>(
+        ctx: &mut arch::unwinding::Context,
+        ptr: *mut (),
+    ) {
+        // SAFETY: This function is called exactly once; it extracts the function, call it and
+        // store the return value. This function is `extern "C"` so we don't need to worry about
+        // unwinding past it.
+        unsafe {
+            let data = &mut *ptr.cast::<Data<T, F>>();
+            let t = ManuallyDrop::take(&mut data.f)(ctx);
+            data.t = ManuallyDrop::new(t);
+        }
+    }
+
+    let mut data = Data {
+        f: ManuallyDrop::new(f),
+    };
+    arch::unwinding::save_context(delegate::<T, F>, ptr::addr_of_mut!(data).cast());
+    unsafe { ManuallyDrop::into_inner(data.t) }
+}

--- a/libs/kstd/src/unwinding/utils.rs
+++ b/libs/kstd/src/unwinding/utils.rs
@@ -14,8 +14,8 @@ pub unsafe fn get_unlimited_slice<'a>(start: *const u8) -> &'a [u8] {
 
 pub unsafe fn deref_pointer(ptr: Pointer) -> usize {
     match ptr {
-        Pointer::Direct(x) => x as _,
-        Pointer::Indirect(x) => unsafe { *(x as *const _) },
+        Pointer::Direct(x) => usize::try_from(x).unwrap(),
+        Pointer::Indirect(x) => unsafe { *(x as *const usize) },
     }
 }
 

--- a/libs/ktest/macros/src/lib.rs
+++ b/libs/ktest/macros/src/lib.rs
@@ -59,7 +59,7 @@ pub fn setup_harness(args: TokenStream, item: TokenStream) -> TokenStream {
         #[#crate_path::__private::loader_api::entry(#loader_cfg)]
         #[cfg(target_os = "none")]
         #[loader_api(crate = #crate_path::__private::loader_api)]
-        fn ktest_runner(hartid: usize, boot_info: &'static mut #crate_path::__private::loader_api::BootInfo) -> ! {
+        fn ktest_runner(hartid: usize, boot_info: &'static #crate_path::__private::loader_api::BootInfo) -> ! {
             struct Log;
 
             impl ::core::fmt::Write for Log {

--- a/libs/ktest/src/__private.rs
+++ b/libs/ktest/src/__private.rs
@@ -8,7 +8,7 @@ pub use loader_api;
 #[allow(unreachable_code)]
 pub fn exit(code: i32) -> ! {
     #[cfg(target_os = "none")]
-    kstd::process::exit(code);
+    kstd::abort(code);
 
     #[cfg(not(target_os = "none"))]
     ::std::process::exit(code);

--- a/libs/ktest/src/lib.rs
+++ b/libs/ktest/src/lib.rs
@@ -111,12 +111,12 @@ impl Conclusion {
 pub struct SetupInfo {
     pub is_std: bool,
     #[cfg(target_os = "none")]
-    pub boot_info: &'static mut loader_api::BootInfo,
+    pub boot_info: &'static loader_api::BootInfo,
 }
 
 impl SetupInfo {
     #[cfg(target_os = "none")]
-    pub fn new(boot_info: &'static mut loader_api::BootInfo) -> Self {
+    pub fn new(boot_info: &'static loader_api::BootInfo) -> Self {
         Self {
             is_std: false,
             boot_info,

--- a/loader/api/macros/src/lib.rs
+++ b/loader/api/macros/src/lib.rs
@@ -24,9 +24,9 @@ pub fn entry(args: TokenStream, item: TokenStream) -> TokenStream {
 
         #[no_mangle]
         #[export_name = "_start"]
-        pub extern "C" fn __start_impl(hartid: usize, boot_info: &'static mut #crate_path::BootInfo) -> ! {
+        pub extern "C" fn __start_impl(hartid: usize, boot_info: &'static #crate_path::BootInfo) -> ! {
             // validate the signature of the program entry point
-            let f: fn(usize, &'static mut #crate_path::BootInfo) -> ! = #func_ident;
+            let f: fn(usize, &'static #crate_path::BootInfo) -> ! = #func_ident;
 
             f(hartid, boot_info)
         }

--- a/loader/build.rs
+++ b/loader/build.rs
@@ -10,6 +10,7 @@ fn main() {
     let ld_path = out_dir.join("linker.x");
     fs::write(&ld_path, LINKER).unwrap();
     println!("cargo::rustc-link-arg=-T{}", ld_path.display());
+    println!("cargo::rerun-if-env-changed={}", ld_path.display());
     println!("cargo::rerun-if-env-changed=K23_VERIFYING_KEY_PATH");
     println!("cargo::rerun-if-env-changed=K23_PAYLOAD_PATH");
 

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -1,6 +1,6 @@
 #![no_std]
 #![no_main]
-#![feature(naked_functions, asm_const, maybe_uninit_slice)]
+#![feature(naked_functions, asm_const, maybe_uninit_slice, used_with_arg)]
 #![allow(clippy::items_after_statements, clippy::needless_continue)]
 
 mod arch;

--- a/targets/riscv64gc-k23-kernel.json
+++ b/targets/riscv64gc-k23-kernel.json
@@ -1,0 +1,17 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "eh-frame-header": true,
+  "features": "+m,+a,+f,+d,+c",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64d",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "panic-strategy": "unwind",
+  "relocation-model": "pie",
+  "supported-sanitizers": ["kernel-address"],
+  "target-pointer-width": "64"
+}

--- a/targets/riscv64imac-k23-loader.json
+++ b/targets/riscv64imac-k23-loader.json
@@ -1,0 +1,15 @@
+{
+  "arch": "riscv64",
+  "code-model": "medium",
+  "cpu": "generic-rv64",
+  "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",
+  "features": "+m,+a,+c",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-target": "riscv64",
+  "max-atomic-width": 64,
+  "panic-strategy": "abort",
+  "relocation-model": "static",
+  "supported-sanitizers": ["kernel-address"],
+  "target-pointer-width": "64"
+}


### PR DESCRIPTION
This PR adds support for DWARF based stack unwinding to the kernel based on `libunwind` and the Rust port [`unwinding`](https://crates.io/crates/unwinding). The main motivation is to support stack traces on kernel panics, as well as allow the test harness to catch panics from test cases. 
The first use case will greatly simplify debugging since we won't be required to use LLDB to obtain stack traces on panic and the second use case will allow us to run vastly more tests and complete the current test suite even in the presence of panics from either our code or dependencies.