### PR TITLE
feat(kstd): `Once`, `OnceLock`, and `LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,7 @@ name = "kstd"
 version = "0.1.0"
 dependencies = [
  "cfg-if",
+ "ktest",
  "lock_api",
  "onlyerror",
 ]

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -22,7 +22,7 @@ fn setup(hartid: usize, boot_info: &'static mut loader_api::BootInfo) {
     trap::init();
 
     static INIT: Once = Once::new();
-    INIT.get_or_init(|| {
+    INIT.call_once(|| {
         let mut usable = ArrayVec::<_, 16>::new();
 
         for region in boot_info.memory_regions.iter() {

--- a/kernel/src/tests.rs
+++ b/kernel/src/tests.rs
@@ -80,4 +80,19 @@ mod kstd_tests {
         Ok(())
     }
 
+    #[ktest::test]
+    fn kstd_lazy_lock() -> ktest::TestResult {
+        let mut called = AtomicU8::default();
+        let lock = LazyLock::new(|| {
+            called.fetch_add(1, Ordering::Relaxed);
+            42
+        });
+        ktest::assert_eq!(called.load(Ordering::Acquire), 0);
+        ktest::assert_eq!(*lock, 42);
+        ktest::assert_eq!(called.load(Ordering::Acquire), 1);
+        ktest::assert_eq!(*lock, 42);
+        ktest::assert_eq!(called.load(Ordering::Acquire), 1);
+
+        Ok(())
+    }
 }

--- a/kernel/src/tests.rs
+++ b/kernel/src/tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests {
+mod compile_tests {
     use crate::runtime::{Engine, Linker, Module, Store};
     use cranelift_codegen::settings::Configurable;
 
@@ -35,4 +35,49 @@ mod tests {
 
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod kstd_tests {
+    use core::sync::atomic::{AtomicU8, Ordering};
+
+    use kstd::sync::{LazyLock, Once, OnceLock};
+
+    #[ktest::test]
+    fn kstd_once() -> ktest::TestResult {
+        let once = Once::new();
+
+        ktest::assert!(!once.is_completed());
+
+        let mut called = false;
+        once.call_once(|| {
+            called = true;
+        });
+        ktest::assert!(called);
+
+        let mut called_twice = false;
+        once.call_once(|| {
+            called_twice = true;
+        });
+        ktest::assert!(!called_twice);
+
+        ktest::assert!(once.is_completed());
+
+        Ok(())
+    }
+
+    #[ktest::test]
+    fn kstd_once_lock() -> ktest::TestResult {
+        let lock = OnceLock::new();
+
+        ktest::assert!(lock.get().is_none());
+
+        let val = lock.get_or_init(|| 42);
+        ktest::assert_eq!(*val, 42);
+
+        ktest::assert_eq!(lock.get(), Some(&42));
+
+        Ok(())
+    }
+
 }

--- a/libs/kstd/Cargo.toml
+++ b/libs/kstd/Cargo.toml
@@ -8,7 +8,13 @@ license.workspace = true
 [lints]
 workspace = true
 
+[lib]
+harness = false
+
 [dependencies]
 cfg-if.workspace = true
 onlyerror.workspace = true
 lock_api.workspace = true
+
+[dev-dependencies]
+ktest.workspace = true

--- a/libs/kstd/src/sync/lazy_lock.rs
+++ b/libs/kstd/src/sync/lazy_lock.rs
@@ -1,0 +1,132 @@
+//! Spin-based port of the `std::sync::LazyLock` type.
+
+use super::{once::ExclusiveState, Once};
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    mem::ManuallyDrop,
+    ops::Deref,
+    panic::{RefUnwindSafe, UnwindSafe},
+    ptr,
+};
+
+union Data<T, F> {
+    value: ManuallyDrop<T>,
+    f: ManuallyDrop<F>,
+}
+
+pub struct LazyLock<T, F = fn() -> T> {
+    once: Once,
+    data: UnsafeCell<Data<T, F>>,
+}
+
+impl<T, F: FnOnce() -> T> LazyLock<T, F> {
+    pub const fn new(f: F) -> Self {
+        Self {
+            once: Once::new(),
+            data: UnsafeCell::new(Data {
+                f: ManuallyDrop::new(f),
+            }),
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns the initialization closure as the error in case the lock is not yet initialized.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn into_inner(mut this: Self) -> Result<T, F> {
+        let state = this.once.state();
+        match state {
+            ExclusiveState::Poisoned => panic!("LazyLock instance has previously been poisoned"),
+            state => {
+                let this = ManuallyDrop::new(this);
+                let data = unsafe { ptr::read(&this.data) }.into_inner();
+                match state {
+                    ExclusiveState::Incomplete => Err(ManuallyDrop::into_inner(unsafe { data.f })),
+                    ExclusiveState::Complete => Ok(ManuallyDrop::into_inner(unsafe { data.value })),
+                    ExclusiveState::Poisoned => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[inline]
+    pub fn force(this: &LazyLock<T, F>) -> &T {
+        this.once.call_once(|| {
+            // SAFETY: `call_once` only runs this closure once, ever.
+            let data = unsafe { &mut *this.data.get() };
+            let f = unsafe { ManuallyDrop::take(&mut data.f) };
+            let value = f();
+            data.value = ManuallyDrop::new(value);
+        });
+
+        unsafe { &(*this.data.get()).value }
+    }
+}
+
+impl<T, F> LazyLock<T, F> {
+    /// Get the inner value if it has already been initialized.
+    fn get(&self) -> Option<&T> {
+        if self.once.is_completed() {
+            // SAFETY:
+            // The closure has been run successfully, so `value` has been initialized
+            // and will not be modified again.
+            Some(unsafe { &*(*self.data.get()).value })
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, F: FnOnce() -> T> Deref for LazyLock<T, F> {
+    type Target = T;
+
+    /// Dereferences the value.
+    ///
+    /// This method will block the calling thread if another initialization
+    /// routine is currently running.
+    ///
+    #[inline]
+    fn deref(&self) -> &T {
+        LazyLock::force(self)
+    }
+}
+
+impl<T, F> Drop for LazyLock<T, F> {
+    fn drop(&mut self) {
+        match self.once.state() {
+            ExclusiveState::Incomplete => unsafe { ManuallyDrop::drop(&mut self.data.get_mut().f) },
+            ExclusiveState::Complete => unsafe {
+                ManuallyDrop::drop(&mut self.data.get_mut().value);
+            },
+            ExclusiveState::Poisoned => {}
+        }
+    }
+}
+
+impl<T: Default> Default for LazyLock<T> {
+    /// Creates a new lazy value using `Default` as the initializing function.
+    #[inline]
+    fn default() -> LazyLock<T> {
+        LazyLock::new(T::default)
+    }
+}
+
+impl<T: fmt::Debug, F> fmt::Debug for LazyLock<T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_tuple("LazyLock");
+        match self.get() {
+            Some(v) => d.field(v),
+            None => d.field(&format_args!("<uninit>")),
+        };
+        d.finish()
+    }
+}
+
+unsafe impl<T: Sync + Send, F: Send> Sync for LazyLock<T, F> {}
+
+impl<T: RefUnwindSafe + UnwindSafe, F: UnwindSafe> RefUnwindSafe for LazyLock<T, F> {}
+impl<T: UnwindSafe, F: UnwindSafe> UnwindSafe for LazyLock<T, F> {}

--- a/libs/kstd/src/sync/mod.rs
+++ b/libs/kstd/src/sync/mod.rs
@@ -1,9 +1,11 @@
+mod lazy_lock;
 mod once;
 mod once_lock;
 mod raw_mutex;
 
 use core::num::NonZeroUsize;
 use core::ptr::addr_of;
+pub use lazy_lock::LazyLock;
 use lock_api::GetThreadId;
 pub use once::Once;
 pub use once_lock::OnceLock;

--- a/libs/kstd/src/sync/mod.rs
+++ b/libs/kstd/src/sync/mod.rs
@@ -1,10 +1,12 @@
 mod once;
+mod once_lock;
 mod raw_mutex;
 
 use core::num::NonZeroUsize;
 use core::ptr::addr_of;
 use lock_api::GetThreadId;
 pub use once::Once;
+pub use once_lock::OnceLock;
 
 pub use raw_mutex::RawMutex;
 

--- a/libs/kstd/src/sync/once_lock.rs
+++ b/libs/kstd/src/sync/once_lock.rs
@@ -1,0 +1,120 @@
+use core::{
+    cell::UnsafeCell,
+    fmt,
+    mem::MaybeUninit,
+    panic::{RefUnwindSafe, UnwindSafe},
+};
+
+use super::Once;
+
+pub struct OnceLock<T> {
+    once: Once,
+    data: UnsafeCell<MaybeUninit<T>>,
+}
+
+impl<T> OnceLock<T> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            once: Once::new(),
+            data: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// # Panics
+    ///
+    /// Panics if the closure panics.
+    pub fn get_or_init<F: FnOnce() -> T>(&self, f: F) -> &T {
+        self.once.call_once(|| {
+            // SAFETY: `Once` ensures this is only called once
+            unsafe {
+                (*self.data.get()).as_mut_ptr().write(f());
+            }
+        });
+
+        // SAFETY: `Once` ensures this is only called once
+        unsafe { self.force_get() }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the given closure errors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the closure panics.
+    pub fn get_or_try_init<F, E>(&self, f: F) -> Result<&T, E>
+    where
+        F: FnOnce() -> Result<T, E>,
+    {
+        let mut error = None;
+
+        self.once.call_once(|| {
+            match f() {
+                Ok(val) => {
+                    // SAFETY: `Once` ensures this is only called once
+                    unsafe {
+                        (*self.data.get()).as_mut_ptr().write(val);
+                    }
+                }
+                Err(err) => error = Some(err),
+            }
+        });
+
+        if let Some(err) = error {
+            Err(err)
+        } else {
+            // SAFETY: `Once` ensures this is only called once
+            unsafe { Ok(self.force_get()) }
+        }
+    }
+
+    pub fn get(&self) -> Option<&T> {
+        self.once
+            .is_completed()
+            .then(|| unsafe { self.force_get() })
+    }
+
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        self.once
+            .is_completed()
+            .then(|| unsafe { self.force_get_mut() })
+    }
+
+    unsafe fn force_get(&self) -> &T {
+        // SAFETY:
+        // * `UnsafeCell`/inner deref: data never changes again
+        // * `MaybeUninit`/outer deref: data was initialized
+        &*(*self.data.get()).as_ptr()
+    }
+
+    unsafe fn force_get_mut(&mut self) -> &mut T {
+        // SAFETY:
+        // * `UnsafeCell`/inner deref: data never changes again
+        // * `MaybeUninit`/outer deref: data was initialized
+        &mut *(*self.data.get()).as_mut_ptr()
+    }
+}
+
+unsafe impl<T: Sync + Send> Sync for OnceLock<T> {}
+unsafe impl<T: Send> Send for OnceLock<T> {}
+
+impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceLock<T> {}
+impl<T: UnwindSafe> UnwindSafe for OnceLock<T> {}
+
+impl<T> Default for OnceLock<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for OnceLock<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_tuple("OnceLock");
+        match self.get() {
+            Some(v) => d.field(v),
+            None => d.field(&format_args!("<uninit>")),
+        };
+        d.finish()
+    }
+}

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -3,7 +3,7 @@ use crate::{kconfig, logger};
 use core::arch::asm;
 use core::ops::Range;
 use core::ptr::addr_of_mut;
-use kstd::sync::Once;
+use kstd::sync::OnceLock;
 use loader_api::BootInfo;
 use vmm::VirtualAddress;
 
@@ -103,7 +103,7 @@ fn start(hartid: usize, opaque: *const u8) -> ! {
 
     logger::init();
 
-    static MACHINE_INFO: Once<MachineInfo> = Once::new();
+    static MACHINE_INFO: OnceLock<MachineInfo> = OnceLock::new();
 
     let machine_info = MACHINE_INFO.get_or_init(|| MachineInfo::from_dtb(opaque));
     log::debug!("{machine_info:?}");

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -26,7 +26,7 @@ use core::mem::MaybeUninit;
 use core::ops::Range;
 use core::ptr::addr_of;
 use core::{ptr, slice};
-use kstd::sync::Once;
+use kstd::sync::OnceLock;
 use linked_list_allocator::LockedHeap;
 use loader_api::{MemoryRegion, MemoryRegionKind};
 use vmm::{
@@ -37,7 +37,7 @@ use vmm::{
 static ALLOC: LockedHeap = LockedHeap::empty();
 
 fn main(hartid: usize, machine_info: &'static MachineInfo) -> ! {
-    static MAPPINGS: Once<Mappings> = Once::new();
+    static MAPPINGS: OnceLock<Mappings> = OnceLock::new();
 
     log::info!("Hart {hartid} started");
 


### PR DESCRIPTION
This renamed the previous `Once` one-time initialization primitive to `OnceLock`, adds a new type called `Once` that provides lower-level one-time functionality and a `LazyLock` type that provides an on-demand lazy initialization container.