### PR TITLE
feat(kstd): `trace_unsynchronized` and panic backtraces

### DIFF
--- a/libs/kstd/src/backtrace/mod.rs
+++ b/libs/kstd/src/backtrace/mod.rs
@@ -1,0 +1,83 @@
+use crate::unwinding;
+use core::ffi::c_void;
+use core::ptr::addr_of_mut;
+use core::{fmt, mem};
+
+pub enum Frame<'a> {
+    Raw(&'a unwinding::UnwindContext<'a>),
+    Cloned {
+        ip: *mut c_void,
+        sp: *mut c_void,
+        symbol_address: *mut c_void,
+    },
+}
+
+impl<'a> Frame<'a> {
+    /// Returns the current instruction pointer of this frame.
+    pub fn ip(&self) -> *mut c_void {
+        match self {
+            Frame::Raw(ctx) => unwinding::_Unwind_GetIP(ctx) as *mut c_void,
+            Frame::Cloned { ip, .. } => *ip,
+        }
+    }
+
+    /// Returns the current stack pointer of this frame.
+    pub fn sp(&self) -> *mut c_void {
+        match self {
+            Frame::Raw(ctx) => unwinding::_Unwind_GetCFA(ctx) as *mut c_void,
+            Frame::Cloned { sp, .. } => *sp,
+        }
+    }
+
+    /// Returns the starting symbol address of the frame of this function.
+    pub fn symbol_address(&self) -> *mut c_void {
+        if let Frame::Cloned { symbol_address, .. } = *self {
+            return symbol_address;
+        }
+
+        unwinding::_Unwind_FindEnclosingFunction(self.ip())
+    }
+}
+
+impl<'a> fmt::Debug for Frame<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Frame")
+            .field("ip", &self.ip())
+            .field("sp", &self.sp())
+            .field("symbol_address", &self.symbol_address())
+            .finish()
+    }
+}
+
+pub unsafe fn trace_unsynchronized<F: FnMut(&Frame) -> bool>(mut cb: F) {
+    trace_imp(&mut cb)
+}
+
+fn trace_imp(mut cb: &mut dyn FnMut(&Frame) -> bool) {
+    unwinding::_Unwind_Backtrace(trace_fn, addr_of_mut!(cb).cast());
+
+    extern "C" fn trace_fn(
+        ctx: &unwinding::UnwindContext,
+        arg: *mut c_void,
+    ) -> unwinding::UnwindReasonCode {
+        let cb = unsafe { &mut *arg.cast::<&mut dyn FnMut(&Frame) -> bool>() };
+
+        let guard = DropGuard;
+        let keep_going = cb(&Frame::Raw(ctx));
+        mem::forget(guard);
+
+        if keep_going {
+            unwinding::UnwindReasonCode::NO_REASON
+        } else {
+            unwinding::UnwindReasonCode::FATAL_PHASE1_ERROR
+        }
+    }
+}
+
+struct DropGuard;
+
+impl Drop for DropGuard {
+    fn drop(&mut self) {
+        panic!("cannot panic during the backtrace function");
+    }
+}

--- a/libs/kstd/src/lib.rs
+++ b/libs/kstd/src/lib.rs
@@ -29,6 +29,8 @@ pub mod sync;
 
 // DWARF-based stack unwinding
 #[cfg(feature = "panic-unwind")]
+pub mod backtrace;
+#[cfg(feature = "panic-unwind")]
 pub mod unwinding;
 
 // Public-facing panic API

--- a/libs/kstd/src/panicking.rs
+++ b/libs/kstd/src/panicking.rs
@@ -348,6 +348,15 @@ fn default_hook(info: &PanicHookInfo<'_>) {
     let msg = payload_as_str(info.payload());
 
     heprintln!("thread '{}' panicked at {}:\n{}", thread_id, location, msg);
+
+    #[cfg(feature = "panic-unwind")]
+    unsafe {
+        crate::bascktrace::trace_unsynchronized(|frame| {
+            heprintln!("{:?}", frame);
+
+            true
+        })
+    }
 }
 
 fn payload_as_str(payload: &dyn Any) -> &str {

--- a/libs/kstd/src/panicking.rs
+++ b/libs/kstd/src/panicking.rs
@@ -351,11 +351,11 @@ fn default_hook(info: &PanicHookInfo<'_>) {
 
     #[cfg(feature = "panic-unwind")]
     unsafe {
-        crate::bascktrace::trace_unsynchronized(|frame| {
+        crate::backtrace::trace_unsynchronized(|frame| {
             heprintln!("{:?}", frame);
 
             true
-        })
+        });
     }
 }
 

--- a/libs/kstd/src/unwinding/mod.rs
+++ b/libs/kstd/src/unwinding/mod.rs
@@ -1,3 +1,24 @@
+//! DWARF based stack unwinding.
+//!
+//! # libunwind compatability
+//!
+//! The functions mirror the [`libunwind`][libunwind] ABI and therefore this module is littered
+//! with ugly externs, C ABI types, pointers and the like.
+//! *In theory* there is no requirement for this ABI compatability (aside from the `_Unwind_Resume` function)
+//! and much of the baggage *could* be dropped from this module since we don't do any FFI in the kernel,
+//! but stack unwinding is complicated and intricate enough that sticking with established patterns.
+//!
+//! Rewriting this to have a nice, sane API remains a TODO for later.
+//!
+//! # Acknowledgement
+//!
+//! Much of the unwinding code is taken from the great [`unwinding`][unwinding] crate, with some
+//! inspiration from stdlib too, both licensed under MIT/Apache 2.0.
+//!
+//! [libunwind]: https://www.ucw.cz/~hubicka/papers/abi/node25.html#SECTION00923100000000000000
+//! [unwinding]: https://github.com/nbdd0121/unwinding
+
+
 mod eh_info;
 mod frame;
 mod personality;

--- a/libs/kstd/src/unwinding/mod.rs
+++ b/libs/kstd/src/unwinding/mod.rs
@@ -18,7 +18,6 @@
 //! [libunwind]: https://www.ucw.cz/~hubicka/papers/abi/node25.html#SECTION00923100000000000000
 //! [unwinding]: https://github.com/nbdd0121/unwinding
 
-
 mod eh_info;
 mod frame;
 mod personality;

--- a/libs/kstd/src/unwinding/mod.rs
+++ b/libs/kstd/src/unwinding/mod.rs
@@ -1,10 +1,10 @@
 //! DWARF based stack unwinding.
 //!
-//! # libunwind compatability
+//! # libunwind compatibility
 //!
 //! The functions mirror the [`libunwind`][libunwind] ABI and therefore this module is littered
 //! with ugly externs, C ABI types, pointers and the like.
-//! *In theory* there is no requirement for this ABI compatability (aside from the `_Unwind_Resume` function)
+//! *In theory* there is no requirement for this ABI compatibility (aside from the `_Unwind_Resume` function)
 //! and much of the baggage *could* be dropped from this module since we don't do any FFI in the kernel,
 //! but stack unwinding is complicated and intricate enough that sticking with established patterns.
 //!

--- a/libs/kstd/src/unwinding/unwinder.rs
+++ b/libs/kstd/src/unwinding/unwinder.rs
@@ -362,7 +362,7 @@ pub extern "C" fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void 
         return ptr::null_mut();
     };
 
-    fde.initial_address() as usize as _
+    usize::try_from(fde.initial_address()).unwrap() as _
 }
 
 #[no_mangle]

--- a/libs/kstd/src/unwinding/unwinder.rs
+++ b/libs/kstd/src/unwinding/unwinder.rs
@@ -2,12 +2,13 @@
 
 use super::{frame::Frame, utils::with_context};
 use crate::arch;
+use crate::unwinding::eh_info::EH_INFO;
 use bitflags::bitflags;
 use core::{
     ffi::{c_int, c_void},
     fmt, ptr,
 };
-use gimli::Register;
+use gimli::{EhFrame, Register, UnwindSection};
 
 #[derive(Debug, onlyerror::Error)]
 enum UnwindError {
@@ -305,8 +306,18 @@ pub extern "C" fn _Unwind_SetGR(unwind_ctx: &mut UnwindContext<'_>, index: c_int
 }
 
 #[no_mangle]
+pub extern "C" fn _Unwind_GetCFA(unwind_ctx: &UnwindContext<'_>) -> usize {
+    unwind_ctx.ctx[arch::unwinding::SP]
+}
+
+#[no_mangle]
 pub extern "C" fn _Unwind_SetIP(unwind_ctx: &mut UnwindContext<'_>, value: usize) {
     unwind_ctx.ctx[arch::unwinding::RA] = value;
+}
+
+#[no_mangle]
+pub extern "C" fn _Unwind_GetIP(unwind_ctx: &UnwindContext<'_>) -> usize {
+    unwind_ctx.ctx[arch::unwinding::RA]
 }
 
 #[no_mangle]
@@ -333,17 +344,71 @@ pub extern "C" fn _Unwind_GetDataRelBase(unwind_ctx: &UnwindContext<'_>) -> usiz
 }
 
 #[no_mangle]
+pub extern "C" fn _Unwind_FindEnclosingFunction(pc: *mut c_void) -> *mut c_void {
+    if pc.is_null() {
+        return ptr::null_mut();
+    }
+
+    let Some(table) = EH_INFO.hdr.table() else {
+        return ptr::null_mut();
+    };
+
+    let Ok(fde) = table.fde_for_address(
+        &EH_INFO.eh_frame,
+        &EH_INFO.bases,
+        pc as u64 - 1,
+        EhFrame::cie_from_offset,
+    ) else {
+        return ptr::null_mut();
+    };
+
+    fde.initial_address() as usize as _
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn _Unwind_DeleteException(exception: *mut UnwindException) {
     if let Some(cleanup) = unsafe { (*exception).exception_cleanup } {
         unsafe { cleanup(UnwindReasonCode::FOREIGN_EXCEPTION_CAUGHT, exception) };
     }
 }
 
-// #[inline(never)]
-// #[no_mangle]
-// pub extern "C-unwind" fn _Unwind_Backtrace(
-//     trace: UnwindTraceFn,
-//     trace_argument: *mut c_void,
-// ) -> UnwindReasonCode {
-//     with_context(|ctx| {})
-// }
+#[inline(never)]
+#[no_mangle]
+pub extern "C-unwind" fn _Unwind_Backtrace(
+    trace: UnwindTraceFn,
+    trace_argument: *mut c_void,
+) -> UnwindReasonCode {
+    with_context(|ctx| {
+        let mut ctx = ctx.clone();
+        let mut signal = false;
+
+        loop {
+            let Ok(maybe_frame) = Frame::from_context(&ctx, signal) else {
+                return UnwindReasonCode::FATAL_PHASE1_ERROR;
+            };
+
+            let code = trace(
+                &UnwindContext {
+                    frame: maybe_frame.as_ref(),
+                    ctx: &mut ctx,
+                    signal,
+                },
+                trace_argument,
+            );
+            match code {
+                UnwindReasonCode::NO_REASON => (),
+                _ => return UnwindReasonCode::FATAL_PHASE1_ERROR,
+            }
+
+            if let Some(frame) = maybe_frame {
+                let Ok(new_ctx) = frame.unwind(&ctx) else {
+                    return UnwindReasonCode::FATAL_PHASE1_ERROR;
+                };
+                ctx = new_ctx;
+                signal = frame.is_signal_trampoline();
+            } else {
+                return UnwindReasonCode::END_OF_STACK;
+            }
+        }
+    })
+}

--- a/libs/ktest/macros/Cargo.toml
+++ b/libs/ktest/macros/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [lib]
+doc = false
 proc-macro = true
 
 [dependencies]

--- a/loader/api/macros/Cargo.toml
+++ b/loader/api/macros/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 
 [lib]
+doc = false
 proc-macro = true
 
 [dependencies]


### PR DESCRIPTION
This change adds the `kstd::backtrace` module which uses the unwind machinery introduced in previous changes to provide a `trace_unsynchronized` function, which in-turn allows us to capture a stack trace at a given point.

Backtraces are currently unsymbolized, i.e. only the instruction pointer, stack pointer and symbol address are given since no_std symbolization is a larger endeavor and using `addr2line` on the command line already works