### PR TITLE
feat: Kernel Address Space Layout Randomization (KASLR)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +347,7 @@ dependencies = [
  "object",
  "onlyerror",
  "panic",
+ "rand_chacha",
  "riscv",
  "semihosting-logger",
  "sync",
@@ -447,6 +454,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,6 +479,22 @@ checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "regalloc2"
@@ -752,6 +784,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/configs/riscv64-qemu.toml
+++ b/configs/riscv64-qemu.toml
@@ -16,3 +16,4 @@ target-triple = "riscv64imac-k23-none-loader"
 linker-script = "./configs/loader-riscv64-qemu.ld"
 stack-size-pages = 32
 log-level = "trace"
+enable-kaslr = true

--- a/configs/riscv64gc-k23-none-kernel.json
+++ b/configs/riscv64gc-k23-none-kernel.json
@@ -16,6 +16,7 @@
   "relocation-model": "pic",
   "tls-model": "local-exec",
   "position-independent-executables": true,
+  "relro-level": "full",
   "supported-sanitizers": [
     "kernel-address"
   ],

--- a/justfile
+++ b/justfile
@@ -207,6 +207,7 @@ _make_bootimg config payload *CARGO_ARGS="":
         -p loader
         --target $config.loader.target
         --profile {{profile}}
+        ...(if ($config.loader.enable-kaslr == true) { echo "--features" "kaslr" } else { [] })
         --message-format=json
         {{_buildstd}}
         {{CARGO_ARGS}})

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -31,7 +31,11 @@ lz4_flex.workspace = true
 linked_list_allocator.workspace = true
 onlyerror.workspace = true
 kconfig-declare.workspace = true
+rand_chacha = { version = "0.3.1", default-features = false, optional = true }
 #ed25519-dalek.workspace = true
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
 riscv.workspace = true
+
+[features]
+kaslr = ["dep:rand_chacha"]

--- a/loader/src/kaslr.rs
+++ b/loader/src/kaslr.rs
@@ -1,0 +1,63 @@
+use crate::kconfig;
+use crate::machine_info::MachineInfo;
+use crate::payload::Payload;
+use kmm::{Mode, VirtualAddress};
+use rand_chacha::rand_core::{RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
+
+pub fn init(machine_info: &MachineInfo) -> ChaChaRng {
+    let seed = &machine_info.rng_seed.expect("missing RNG seed")[0..32];
+
+    ChaChaRng::from_seed(seed.try_into().unwrap())
+}
+
+pub fn random_offset_for_payload(rand: &mut ChaChaRng, payload: &Payload) -> VirtualAddress {
+    let start = kconfig::MEMORY_MODE::PHYS_OFFSET as u64;
+    let stop = u64::MAX - payload.mem_size();
+    log::trace!("sampling between {start:#x}..{stop:#x}",);
+
+    let addr = sample_single_inclusive(start, stop, rand);
+
+    log::info!("KASLR offset {addr:#x}");
+    VirtualAddress::new(addr as usize).align_down(kconfig::PAGE_SIZE)
+}
+
+#[inline]
+fn sample_single_inclusive(low: u64, high: u64, rng: &mut ChaChaRng) -> u64 {
+    assert!(
+        low <= high,
+        "UniformSampler::sample_single_inclusive: low > high"
+    );
+    let range = high.wrapping_sub(low).wrapping_add(1);
+    // If the above resulted in wrap-around to 0, the range is $ty::MIN..=$ty::MAX,
+    // and any integer will do.
+    if range == 0 {
+        return rng.next_u64();
+    }
+
+    let zone = if u64::MAX <= u16::MAX as u64 {
+        // Using a modulus is faster than the approximation for
+        // i8 and i16. I suppose we trade the cost of one
+        // modulus for near-perfect branch prediction.
+        let unsigned_max = u64::MAX;
+        let ints_to_reject = (unsigned_max - range + 1) % range;
+        unsigned_max - ints_to_reject
+    } else {
+        // conservative but fast approximation. `- 1` is necessary to allow the
+        // same comparison without bias.
+        (range << range.leading_zeros()).wrapping_sub(1)
+    };
+
+    loop {
+        let v: u64 = rng.next_u64();
+        let (hi, lo) = wmul(v, range);
+        if lo <= zone {
+            return low.wrapping_add(hi);
+        }
+    }
+}
+
+fn wmul(a: u64, b: u64) -> (u64, u64) {
+    let tmp = (a as u128) * (b as u128);
+    ((tmp >> 64) as u64, tmp as u64)
+}

--- a/loader/src/kconfig.rs
+++ b/loader/src/kconfig.rs
@@ -19,6 +19,10 @@ const fn parse_log_lvl(s: &str) -> log::Level {
 #[kconfig_declare::symbol("loader.stack-size-pages")]
 pub const STACK_SIZE_PAGES: usize = 128;
 
+/// Whether to enable Kernel Address Space Layout Randomization (KASLR)
+#[kconfig_declare::symbol("loader.enable-kaslr")]
+pub const ENABLE_KASLR: bool = true;
+
 // TODO: This should be configurable
 #[allow(non_camel_case_types)]
 pub type MEMORY_MODE = kmm::Riscv64Sv39;

--- a/loader/src/payload.rs
+++ b/loader/src/payload.rs
@@ -74,4 +74,18 @@ impl<'a> Payload<'a> {
             loader_config,
         })
     }
+
+    #[cfg(feature = "kaslr")]
+    pub fn mem_size(&self) -> u64 {
+        use object::read::elf::ProgramHeader;
+        use object::Endianness;
+
+        let mem_size = self
+            .elf_file
+            .elf_program_headers()
+            .iter()
+            .fold(0, |acc, ph| acc + ph.p_memsz(Endianness::default()));
+
+        mem_size
+    }
 }


### PR DESCRIPTION
This change builds off of the support for position independent code added in #93 to implement KASLR in the `loader` crate.

This is done by using the `rng-seed`  provided by the FDT (i.e. by the previous stage loader) to seed a `ChaCha20`-based random number generator. The generator is then used to generate a cryptographically secure base address for the payload.
Note that a page-aligned address is chosen in a window between `PHYS_OFFSET` and the highest possible, i.e. `PHYS_OFFSET..(u64::MAX - kernel_size)` which is around `2^25` depending on the kernel size (the entropy will get smaller as the kernel grows).