### PR TITLE
refactor: remove backtrace feature from panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,6 @@ dependencies = [
 name = "panic"
 version = "0.1.0"
 dependencies = [
- "backtrace",
  "cfg-if",
  "log",
  "riscv",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -19,7 +19,7 @@ toml.workspace = true
 kmm.workspace = true
 loader-api.workspace = true
 log.workspace = true
-panic = { workspace = true, features = ["unwind", "backtrace"] }
+panic = { workspace = true, features = ["unwind"] }
 semihosting-logger = { workspace = true, features = ["hartid"] }
 sync.workspace = true
 talc.workspace = true

--- a/libs/panic/Cargo.toml
+++ b/libs/panic/Cargo.toml
@@ -17,7 +17,6 @@ sync.workspace = true
 log.workspace = true
 tls = { workspace = true, optional = true }
 unwind = { workspace = true, optional = true }
-backtrace = { workspace = true, optional = true }
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
 riscv.workspace = true
@@ -25,4 +24,3 @@ riscv.workspace = true
 [features]
 abort = []
 unwind = ["dep:tls", "dep:unwind"]
-backtrace = ["dep:backtrace"]

--- a/libs/panic/src/panicking.rs
+++ b/libs/panic/src/panicking.rs
@@ -258,15 +258,6 @@ fn default_hook(info: &PanicHookInfo<'_>) {
     let msg = payload_as_str(info.payload());
 
     log::error!("hart panicked at {location}:\n{msg}");
-
-    #[cfg(feature = "backtrace")]
-    unsafe {
-        backtrace::trace_unsynchronized(|frame| {
-            log::error!("{:?}", frame);
-
-            true
-        });
-    }
 }
 
 fn payload_as_str(payload: &dyn Any) -> &str {


### PR DESCRIPTION
This change removes the backtrace feature from the `panic` crate and the backtrace printing from the default panic hook. Instead a custom panic hook should be used.