### PR TITLE
feat(loader-api): pass physical payload location

### DIFF
--- a/kernel/src/start.rs
+++ b/kernel/src/start.rs
@@ -58,6 +58,7 @@ fn init_global(boot_info: &'static BootInfo) {
         Ok(())
     })
     .expect("failed to initialize frame allocator");
+
     log::info!("Welcome to k23 {}", env!("CARGO_PKG_VERSION"));
 }
 

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -36,6 +36,7 @@ pub struct BootInfo {
 }
 
 impl BootInfo {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         boot_hart: usize,
         physical_memory_offset: VirtualAddress,
@@ -54,7 +55,7 @@ impl BootInfo {
             fdt_virt,
             loader_virt,
             free_virt,
-            payload_phys
+            payload_phys,
         }
     }
 }

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -29,6 +29,8 @@ pub struct BootInfo {
     pub fdt_virt: VirtualAddress,
     /// The virtual memory occupied by the bootloader.
     pub loader_virt: Range<VirtualAddress>,
+    /// The physical memory occupied by the payload elf.
+    pub payload_phys: Range<PhysicalAddress>,
     /// The range of addresses that the kernel can freely allocate from.
     pub free_virt: Range<VirtualAddress>,
 }
@@ -42,6 +44,7 @@ impl BootInfo {
         fdt_virt: VirtualAddress,
         loader_virt: Range<VirtualAddress>,
         free_virt: Range<VirtualAddress>,
+        payload_phys: Range<PhysicalAddress>,
     ) -> Self {
         Self {
             boot_hart,
@@ -51,6 +54,7 @@ impl BootInfo {
             fdt_virt,
             loader_virt,
             free_virt,
+            payload_phys
         }
     }
 }

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -1,5 +1,6 @@
 use crate::kconfig;
 use crate::paging::PageTableResult;
+use crate::payload::Payload;
 use core::mem::MaybeUninit;
 use core::ops::Div;
 use core::slice;
@@ -11,6 +12,7 @@ pub fn init_boot_info(
     boot_hart: usize,
     page_table_result: &PageTableResult,
     fdt_virt: VirtualAddress,
+    payload: &Payload,
 ) -> crate::Result<&'static BootInfo> {
     let frame = alloc.allocate_frame()?;
 
@@ -37,6 +39,11 @@ pub fn init_boot_info(
         fdt_virt,
         page_table_result.loader_virt.clone(),
         page_table_result.free_range_virt.clone(),
+        {
+            let r = payload.elf_file.data().as_ptr_range();
+
+            PhysicalAddress::new(r.start as usize)..PhysicalAddress::new(r.end as usize)
+        },
     ));
 
     // lastly, do the physical ptr -> virtual ptr translation

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -88,7 +88,6 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     let mut rand = kaslr::init(&machine_info);
 
     // TODO crate allocation plan for payload, stacks, TLS & physical memory
-
     let physmem_off = VirtualAddress::new(0xffff_ffd8_0000_0000);
 
     // Move the FDT to a safe location, so we don't accidentally overwrite it

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -87,7 +87,7 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     init_global_allocator(machine_info);
 
     // decompress & parse payload
-    log::trace!("parsing payload... {:p}", payload::PAYLOAD.as_ptr());
+    log::trace!("parsing payload...");
     let payload = Payload::from_compressed(payload::PAYLOAD, &mut frame_alloc)?;
 
     log::trace!("initializing page tables...");
@@ -109,7 +109,13 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     let hartid = BOOT_HART.load(Ordering::Relaxed);
 
     // init boot info
-    let boot_info = init_boot_info(&mut frame_alloc, hartid, &page_table_result, fdt_virt)?;
+    let boot_info = init_boot_info(
+        &mut frame_alloc,
+        hartid,
+        &page_table_result,
+        fdt_virt,
+        &payload,
+    )?;
 
     Ok((page_table_result, boot_info))
 }


### PR DESCRIPTION
This changes passes information about the location of the payload in physical memory to the payload itself so it can perform introspection into its own elf file if desired (e.g. to access eh_frame info for stack unwinding for debug info for symbolization).