### PR TITLE
refactor: remove hardcoded `PHYS_OFFSET` constant

### DIFF
--- a/kernel/src/frame_alloc.rs
+++ b/kernel/src/frame_alloc.rs
@@ -20,7 +20,7 @@ where
         }
     }
 
-    let bump_alloc = unsafe { BumpAllocator::new(&memories) };
+    let bump_alloc = unsafe { BumpAllocator::new(&memories, boot_info.physical_memory_offset) };
     let mut alloc = BitMapAllocator::new(bump_alloc).unwrap();
     let r = f(&mut alloc);
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -16,7 +16,7 @@ mod tests;
 
 use loader_api::BootInfo;
 
-pub fn kmain(_hartid: usize, _boot_info: &'static BootInfo) -> ! {
+pub fn kmain(_hartid: usize, boot_info: &'static BootInfo) -> ! {
     // Eventually this will all be hidden behind other abstractions (the scheduler, etc.) and this
     // function will just jump into the scheduling loop
 
@@ -35,7 +35,7 @@ pub fn kmain(_hartid: usize, _boot_info: &'static BootInfo) -> ! {
 
     let engine = Engine::new(target_isa);
 
-    let mut store = Store::new(0);
+    let mut store = Store::new(0, boot_info.physical_memory_offset);
 
     let module = Module::from_binary(&engine, &store, wasm);
     log::debug!("{module:#?}");

--- a/kernel/src/runtime/guest_memory/guest_allocator.rs
+++ b/kernel/src/runtime/guest_memory/guest_allocator.rs
@@ -47,11 +47,14 @@ pub struct GuestAllocatorInner {
 }
 
 impl GuestAllocator {
-    pub unsafe fn new_in_kernel_space(virt_offset: VirtualAddress) -> Result<Self, AllocError> {
+    pub unsafe fn new_in_kernel_space(
+        virt_offset: VirtualAddress,
+        physmem_off: VirtualAddress,
+    ) -> Result<Self, AllocError> {
         let root_table = kconfig::MEMORY_MODE::get_active_table(0);
 
         let mut inner = GuestAllocatorInner {
-            root_table: kconfig::MEMORY_MODE::phys_to_virt(root_table),
+            root_table: physmem_off.add(root_table.as_raw()),
             asid: 0,
             inner: Heap::empty(),
             virt: virt_offset..virt_offset,

--- a/kernel/src/runtime/store.rs
+++ b/kernel/src/runtime/store.rs
@@ -21,11 +21,12 @@ pub struct Store<'wasm> {
 }
 
 impl<'wasm> Store<'wasm> {
-    pub fn new(asid: usize) -> Self {
+    pub fn new(asid: usize, physmem_off: VirtualAddress) -> Self {
         log::trace!("Setting up new Store instance with ASID: {asid}");
         Self {
             allocator: unsafe {
-                GuestAllocator::new_in_kernel_space(VirtualAddress::new(0x1000)).unwrap()
+                GuestAllocator::new_in_kernel_space(VirtualAddress::new(0x1000), physmem_off)
+                    .unwrap()
             },
             instances: PrimaryMap::new(),
             vmctx2instance: HashMap::default(),

--- a/libs/kmm/src/alloc/mod.rs
+++ b/libs/kmm/src/alloc/mod.rs
@@ -45,6 +45,9 @@ pub trait FrameAllocator<M: crate::Mode> {
     /// Information about the number of physical frames used, and available
     fn frame_usage(&self) -> FrameUsage;
 
+    /// Converts a physical address to a virtual address
+    fn phys_to_virt(&self, phys: PhysicalAddress) -> crate::VirtualAddress;
+
     /// Allocates a frame and zeroes it.
     ///
     /// # Errors
@@ -52,10 +55,11 @@ pub trait FrameAllocator<M: crate::Mode> {
     /// Returns an error if the frame cannot be allocated.
     fn allocate_frame_zeroed(&mut self) -> crate::Result<PhysicalAddress> {
         let page_phys = self.allocate_frames(1)?;
-        let page_virt = M::phys_to_virt(page_phys);
+        let page_virt = self.phys_to_virt(page_phys);
         zero_frames::<M>(page_virt.as_raw() as *mut u64, 1);
         Ok(page_phys)
     }
+
     /// Allocates a number of frames and zero them.
     ///
     /// # Errors
@@ -63,7 +67,7 @@ pub trait FrameAllocator<M: crate::Mode> {
     /// Returns an error if the frames cannot be allocated.
     fn allocate_frames_zeroed(&mut self, frames: usize) -> crate::Result<PhysicalAddress> {
         let page_phys = self.allocate_frames(frames)?;
-        let page_virt = M::phys_to_virt(page_phys);
+        let page_virt = self.phys_to_virt(page_phys);
         zero_frames::<M>(page_virt.as_raw() as *mut u64, frames);
         Ok(page_phys)
     }

--- a/libs/kmm/src/arch/emulate.rs
+++ b/libs/kmm/src/arch/emulate.rs
@@ -62,8 +62,6 @@ impl EmulateMode {
 impl Mode for EmulateMode {
     type EntryFlags = EmulateEntryFlags;
 
-    const PHYS_OFFSET: usize = 0xffff_ffd8_0000_0000;
-
     const PAGE_SIZE: usize = 4096;
 
     const PAGE_TABLE_LEVELS: usize = 2; // L0, L1, L2
@@ -99,9 +97,5 @@ impl Mode for EmulateMode {
         entry
             .get_flags()
             .intersects(EmulateEntryFlags::READ | EmulateEntryFlags::EXECUTE)
-    }
-
-    fn phys_to_virt(phys: PhysicalAddress) -> VirtualAddress {
-        VirtualAddress::new(phys.as_raw())
     }
 }

--- a/libs/kmm/src/arch/riscv64.rs
+++ b/libs/kmm/src/arch/riscv64.rs
@@ -62,8 +62,6 @@ pub struct Riscv64Sv39;
 impl Mode for Riscv64Sv39 {
     type EntryFlags = EntryFlags;
 
-    const PHYS_OFFSET: usize = 0xffff_ffd8_0000_0000;
-
     const PAGE_SIZE: usize = PAGE_SIZE;
     const PAGE_TABLE_LEVELS: usize = 3; // L0, L1, L2
     const PAGE_TABLE_ENTRIES: usize = PAGE_TABLE_ENTRIES;
@@ -113,8 +111,6 @@ pub struct Riscv64Sv48;
 impl Mode for Riscv64Sv48 {
     type EntryFlags = EntryFlags;
 
-    const PHYS_OFFSET: usize = 0xffff_bfff_8000_0000;
-
     const PAGE_SIZE: usize = PAGE_SIZE;
     const PAGE_TABLE_LEVELS: usize = 4; // L0, L1, L2, L3
     const PAGE_TABLE_ENTRIES: usize = PAGE_TABLE_ENTRIES;
@@ -163,8 +159,6 @@ pub struct Riscv64Sv57;
 
 impl Mode for Riscv64Sv57 {
     type EntryFlags = EntryFlags;
-
-    const PHYS_OFFSET: usize = 0xff7f_ffff_8000_0000;
 
     const PAGE_SIZE: usize = PAGE_SIZE;
     const PAGE_TABLE_LEVELS: usize = 5; // L0, L1, L2, L3, L4

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -9,6 +9,13 @@ use kmm::VirtualAddress;
 use loader_api::BootInfo;
 use sync::OnceLock;
 
+static MACHINE_INFO: OnceLock<MachineInfo> = OnceLock::new();
+static RAW_MACHINE_INFO: AtomicPtr<u8> = AtomicPtr::new(ptr::null_mut());
+
+pub fn machine_info() -> &'static MachineInfo<'static> {
+    MACHINE_INFO.get().expect("MachineInfo not initialized")
+}
+
 /// The main entry point for the loader
 ///
 /// This sets up the global and stack pointer, as well as filling the stack with a known debug pattern.
@@ -95,13 +102,6 @@ unsafe extern "C" fn fillstack() {
         "ret",
         options(noreturn)
     )
-}
-
-static MACHINE_INFO: OnceLock<MachineInfo> = OnceLock::new();
-static RAW_MACHINE_INFO: AtomicPtr<u8> = AtomicPtr::new(ptr::null_mut());
-
-pub fn machine_info() -> &'static MachineInfo<'static> {
-    MACHINE_INFO.get().expect("MachineInfo not initialized")
 }
 
 pub unsafe fn switch_to_payload(

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -3,14 +3,15 @@ use crate::paging::PageTableResult;
 use core::mem::MaybeUninit;
 use core::ops::Div;
 use core::slice;
-use kmm::{BumpAllocator, FrameAllocator, Mode, PhysicalAddress, VirtualAddress, INIT};
+use kmm::{BumpAllocator, FrameAllocator, PhysicalAddress, VirtualAddress};
 use loader_api::{BootInfo, MemoryRegion, MemoryRegionKind};
 
 pub fn init_boot_info(
-    alloc: &mut BumpAllocator<INIT<kconfig::MEMORY_MODE>>,
+    alloc: &mut BumpAllocator<kconfig::MEMORY_MODE>,
     boot_hart: usize,
     page_table_result: &PageTableResult,
     fdt_virt: VirtualAddress,
+    physmem_off: VirtualAddress,
 ) -> crate::Result<&'static BootInfo> {
     let frame = alloc.allocate_frame()?;
 
@@ -19,16 +20,14 @@ pub fn init_boot_info(
     // memory_regions: &'static mut [MemoryRegion] is a reference to physical memory, but going forward
     // we need it to be a reference to virtual memory.
     let memory_regions = unsafe {
-        let ptr = memory_regions
-            .as_mut_ptr()
-            .byte_add(kconfig::MEMORY_MODE::PHYS_OFFSET);
+        let ptr = memory_regions.as_mut_ptr().byte_add(physmem_off.as_raw());
         slice::from_raw_parts_mut(ptr, memory_regions.len())
     };
 
     let boot_info = unsafe { &mut *(frame.as_raw() as *mut MaybeUninit<BootInfo>) };
     let boot_info = boot_info.write(BootInfo::new(
         boot_hart,
-        VirtualAddress::new(kconfig::MEMORY_MODE::PHYS_OFFSET),
+        physmem_off,
         memory_regions,
         page_table_result
             .maybe_tls_allocation
@@ -40,11 +39,11 @@ pub fn init_boot_info(
     ));
 
     // lastly, do the physical ptr -> virtual ptr translation
-    Ok(unsafe { phys_to_virt_ref(boot_info) })
+    Ok(unsafe { phys_to_virt_ref(physmem_off, boot_info) })
 }
 
 fn init_boot_info_memory_regions(
-    alloc: &BumpAllocator<INIT<kconfig::MEMORY_MODE>>,
+    alloc: &BumpAllocator<kconfig::MEMORY_MODE>,
     frame: PhysicalAddress,
 ) -> &'static mut [MemoryRegion] {
     // first we need to calculate total slice of regions we could fit in the frame
@@ -80,8 +79,8 @@ fn init_boot_info_memory_regions(
     unsafe { MaybeUninit::slice_assume_init_mut(&mut raw_regions[0..next_region]) }
 }
 
-unsafe fn phys_to_virt_ref<T>(phys: &T) -> &T {
-    let ptr = (phys as *const T).byte_add(kconfig::MEMORY_MODE::PHYS_OFFSET);
+unsafe fn phys_to_virt_ref<T>(physmem_off: VirtualAddress, phys: &T) -> &T {
+    let ptr = (phys as *const T).byte_add(physmem_off.as_raw());
 
     &*ptr
 }

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -26,9 +26,7 @@ use core::ptr::addr_of;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{ptr, slice};
 use error::Error;
-use kmm::{
-    AddressRangeExt, BumpAllocator, FrameAllocator, Mode, PhysicalAddress, VirtualAddress, INIT,
-};
+use kmm::{AddressRangeExt, BumpAllocator, FrameAllocator, PhysicalAddress, VirtualAddress};
 use linked_list_allocator::LockedHeap;
 use loader_api::BootInfo;
 
@@ -46,7 +44,13 @@ fn main(hartid: usize) -> ! {
         .expect("failed to initialize system");
 
     log::debug!("Activating page table for hart {hartid}...");
-    page_table_result.activate_table();
+    // SAFETY: This will invalidate all pointers and references that aren't on the loader stack
+    // (the FDT slice and importantly the frame allocator) so care has to be taken to either
+    // not access these anymore (which should be easy, this is one of the last steps we perform before hading off
+    // to the payload) or to map them into virtual memory first!
+    unsafe {
+        page_table_result.activate_table();
+    }
 
     log::debug!("Initializing TLS region for hart {hartid}...");
     page_table_result.init_tls_region_for_hart(hartid);
@@ -72,16 +76,24 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     log::trace!("{loader_regions:?}");
 
     // init frame allocator
-    let mut frame_alloc: BumpAllocator<INIT<kconfig::MEMORY_MODE>> = unsafe {
-        BumpAllocator::new_with_lower_bound(&machine_info.memories, loader_regions.read_write.end)
+    let mut frame_alloc: BumpAllocator<kconfig::MEMORY_MODE> = unsafe {
+        BumpAllocator::new_with_lower_bound(
+            &machine_info.memories,
+            loader_regions.read_write.end,
+            VirtualAddress::default(), // while we haven't activated the virtual memory we have not offset
+        )
     };
 
     #[cfg(feature = "kaslr")]
     let mut rand = kaslr::init(&machine_info);
 
+    // TODO crate allocation plan for payload, stacks, TLS & physical memory
+
+    let physmem_off = VirtualAddress::new(0xffff_ffd8_0000_0000);
+
     // Move the FDT to a safe location, so we don't accidentally overwrite it
     log::trace!("copying FDT to safe location...");
-    let fdt_virt = allocate_and_copy_fdt(machine_info, &mut frame_alloc)?;
+    let fdt_virt = allocate_and_copy_fdt(machine_info, &mut frame_alloc, physmem_off)?;
 
     // init heap allocator
     init_global_allocator(machine_info);
@@ -92,7 +104,7 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
 
     log::trace!("initializing page tables...");
     #[allow(unused_mut)]
-    let mut builder = PageTableBuilder::from_alloc(&mut frame_alloc)?;
+    let mut builder = PageTableBuilder::from_alloc(&mut frame_alloc, physmem_off)?;
 
     #[cfg(feature = "kaslr")]
     {
@@ -109,7 +121,13 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     let hartid = BOOT_HART.load(Ordering::Relaxed);
 
     // init boot info
-    let boot_info = init_boot_info(&mut frame_alloc, hartid, &page_table_result, fdt_virt)?;
+    let boot_info = init_boot_info(
+        &mut frame_alloc,
+        hartid,
+        &page_table_result,
+        fdt_virt,
+        physmem_off,
+    )?;
 
     Ok((page_table_result, boot_info))
 }
@@ -122,7 +140,8 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
 /// Returns an error if allocation fails.
 pub fn allocate_and_copy_fdt(
     machine_info: &MachineInfo,
-    alloc: &mut BumpAllocator<INIT<kconfig::MEMORY_MODE>>,
+    alloc: &mut BumpAllocator<kconfig::MEMORY_MODE>,
+    physmem_off: VirtualAddress,
 ) -> Result<VirtualAddress> {
     let frames = machine_info.fdt.len().div_ceil(kconfig::PAGE_SIZE);
     let base = alloc.allocate_frames(frames)?;
@@ -133,7 +152,7 @@ pub fn allocate_and_copy_fdt(
         ptr::copy_nonoverlapping(machine_info.fdt.as_ptr(), dst.as_mut_ptr(), dst.len());
     }
 
-    Ok(kconfig::MEMORY_MODE::phys_to_virt(base))
+    Ok(physmem_off.add(base.as_raw()))
 }
 
 fn init_global_allocator(machine_info: &MachineInfo) {

--- a/loader/src/paging.rs
+++ b/loader/src/paging.rs
@@ -5,7 +5,6 @@ use core::ops::Range;
 use core::{ptr, slice};
 use kmm::{
     BumpAllocator, EntryFlags, Flush, Mapper, Mode, PhysicalAddress, TlsTemplate, VirtualAddress,
-    INIT,
 };
 use object::Object;
 
@@ -17,18 +16,17 @@ pub struct PageTableBuilder<'a> {
     /// The highest available virtual address
     free_range_end: VirtualAddress,
 
-    mapper: Mapper<'a, INIT<kconfig::MEMORY_MODE>>,
-    flush: Flush<INIT<kconfig::MEMORY_MODE>>,
+    mapper: Mapper<'a, kconfig::MEMORY_MODE>,
+    flush: Flush<kconfig::MEMORY_MODE>,
 
     result: PageTableResult,
 }
 
 impl<'a> PageTableBuilder<'a> {
     pub fn from_alloc(
-        frame_allocator: &'a mut BumpAllocator<'_, INIT<kconfig::MEMORY_MODE>>,
+        frame_allocator: &'a mut BumpAllocator<'_, kconfig::MEMORY_MODE>,
+        physical_memory_offset: VirtualAddress,
     ) -> crate::Result<Self> {
-        let physical_memory_offset = VirtualAddress::new(kconfig::MEMORY_MODE::PHYS_OFFSET);
-
         let mapper = Mapper::new(0, frame_allocator)?;
 
         Ok(Self {
@@ -277,7 +275,7 @@ impl PageTableResult {
         Some(self.maybe_tls_allocation.as_ref()?.region_for_hart(hartid))
     }
 
-    pub fn activate_table(&self) {
+    pub unsafe fn activate_table(&self) {
         kconfig::MEMORY_MODE::activate_table(0, self.page_table_addr);
     }
 

--- a/loader/src/payload.rs
+++ b/loader/src/payload.rs
@@ -2,7 +2,7 @@ use core::slice;
 // use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use crate::error::Error;
 use crate::kconfig;
-use kmm::{BumpAllocator, FrameAllocator, INIT};
+use kmm::{BumpAllocator, FrameAllocator};
 use loader_api::LoaderConfig;
 use object::{Object, ObjectSection};
 
@@ -35,7 +35,7 @@ impl<'a> Payload<'a> {
 
     pub fn from_compressed(
         compressed: &'a [u8],
-        alloc: &mut BumpAllocator<'_, INIT<kconfig::MEMORY_MODE>>,
+        alloc: &mut BumpAllocator<'_, kconfig::MEMORY_MODE>,
     ) -> crate::Result<Self> {
         log::info!("Decompressing payload...");
         let (uncompressed_size, input) =


### PR DESCRIPTION
This change removes the hardcoded `PHYS_OFFSET` constant from the `kmm` crate making it possible to configure the location of the physical memory mapping at runtime.

Actually making the position dynamic (randomized as part of KASLR is left for a later change)