### PR TITLE
refactor: cleanup wast crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "wasm-encoder"
 version = "0.1.0"
 dependencies = [
+ "ktest",
  "leb128",
 ]
 
@@ -698,6 +699,7 @@ dependencies = [
  "bumpalo",
  "gimli",
  "hashbrown 0.14.5",
+ "ktest",
  "leb128",
  "memchr",
  "tls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -294,6 +294,7 @@ name = "leb128"
 version = "0.1.0"
 dependencies = [
  "ktest",
+ "onlyerror",
 ]
 
 [[package]]

--- a/libs/ktest/src/lib.rs
+++ b/libs/ktest/src/lib.rs
@@ -84,18 +84,16 @@ impl Conclusion {
     }
 
     /// Exits the application with an appropriate error code (0 if all tests
-    /// have passed, 101 if there have been failures). This uses
-    /// [`process::exit`], meaning that destructors are not ran. Consider
-    /// using [`Self::exit_code`] instead for a proper program cleanup.
+    /// have passed, 101 if there have been failures). **This will not run any destructors.**
+    /// Consider using [`Self::exit_code`] instead for a proper program cleanup.
     pub fn exit(&self) -> ! {
         // self.exit_if_failed();
         __private::exit(0)
     }
 
     /// Exits the application with error code 101 if there were any failures.
-    /// Otherwise, returns normally. This uses [`process::exit`], meaning that
-    /// destructors are not ran. Consider using [`Self::exit_code`] instead for
-    /// a proper program cleanup.
+    /// Otherwise, returns normally. **This will not run any destructors.**
+    /// Consider using [`Self::exit_code`] instead for a proper program cleanup.
     pub fn exit_if_failed(&self) {
         if self.has_failed() {
             __private::exit(101)

--- a/libs/leb128/Cargo.toml
+++ b/libs/leb128/Cargo.toml
@@ -8,5 +8,8 @@ license.workspace = true
 [lints]
 workspace = true
 
+[dependencies]
+onlyerror.workspace = true
+
 [dev-dependencies]
 ktest.workspace = true

--- a/libs/wasm-encoder/Cargo.toml
+++ b/libs/wasm-encoder/Cargo.toml
@@ -20,3 +20,6 @@ workspace = true
 
 [dependencies]
 leb128.workspace = true
+
+[dev-dependencies]
+ktest.workspace = true

--- a/libs/wasm-encoder/src/core/code.rs
+++ b/libs/wasm-encoder/src/core/code.rs
@@ -1,6 +1,7 @@
 use crate::{encode_section, Encode, HeapType, RefType, Section, SectionId, ValType};
 use alloc::borrow::Cow;
 use alloc::{vec, vec::Vec};
+use leb128::Leb128Read;
 
 /// An encoder for the code section.
 ///
@@ -3884,7 +3885,8 @@ impl ConstExpr {
         if prefix != 0xd2 {
             return None;
         }
-        leb128::read::unsigned(&mut &self.bytes[1..])
+        (&mut self.bytes.as_slice())
+            .read_uleb128()
             .ok()?
             .try_into()
             .ok()

--- a/libs/wasm-encoder/src/lib.rs
+++ b/libs/wasm-encoder/src/lib.rs
@@ -83,6 +83,7 @@ pub use self::core::*;
 pub use self::raw::*;
 
 use alloc::vec::Vec;
+use leb128::Leb128Write;
 
 /// Implemented by types that can be encoded into a byte sink.
 pub trait Encode {
@@ -128,25 +129,25 @@ impl Encode for usize {
 
 impl Encode for u32 {
     fn encode(&self, sink: &mut Vec<u8>) {
-        leb128::write::unsigned(sink, (*self).into()).unwrap();
+        sink.as_mut_slice().write_uleb128((*self).into()).unwrap();
     }
 }
 
 impl Encode for i32 {
     fn encode(&self, sink: &mut Vec<u8>) {
-        leb128::write::signed(sink, (*self).into()).unwrap();
+        sink.as_mut_slice().write_sleb128((*self).into()).unwrap();
     }
 }
 
 impl Encode for u64 {
     fn encode(&self, sink: &mut Vec<u8>) {
-        leb128::write::unsigned(sink, *self).unwrap();
+        sink.as_mut_slice().write_uleb128(*self).unwrap();
     }
 }
 
 impl Encode for i64 {
     fn encode(&self, sink: &mut Vec<u8>) {
-        leb128::write::signed(sink, *self).unwrap();
+        sink.as_mut_slice().write_sleb128(*self).unwrap();
     }
 }
 
@@ -194,7 +195,7 @@ where
 
 fn encoding_size(n: u32) -> usize {
     let mut buf = [0u8; 5];
-    leb128::write::unsigned(&mut &mut buf[..], n.into()).unwrap()
+    buf.as_mut_slice().write_uleb128(n.into()).unwrap()
 }
 
 fn encode_section(sink: &mut Vec<u8>, count: u32, bytes: &[u8]) {

--- a/libs/wast/Cargo.toml
+++ b/libs/wast/Cargo.toml
@@ -28,6 +28,9 @@ memchr.workspace = true
 bumpalo.workspace = true
 tls.workspace = true
 
+[dev-dependencies]
+ktest.workspace = true
+
 [features]
 default = ['wasm-module']
 

--- a/libs/wast/src/component/binary.rs
+++ b/libs/wast/src/component/binary.rs
@@ -3,6 +3,7 @@ use crate::core;
 use crate::core::EncodeOptions;
 use crate::token::{Id, Index, NameAnnotation, Span};
 use alloc::{vec, vec::Vec};
+use leb128::Leb128Write;
 use wasm_encoder::{
     CanonicalFunctionSection, ComponentAliasSection, ComponentDefinedTypeEncoder,
     ComponentExportSection, ComponentImportSection, ComponentInstanceSection, ComponentNameSection,
@@ -555,9 +556,7 @@ fn get_name<'a>(id: &Option<Id<'a>>, name: &Option<NameAnnotation<'a>>) -> Optio
 impl wasm_encoder::Encode for Custom<'_> {
     fn encode(&self, sink: &mut Vec<u8>) {
         let mut buf = [0u8; 5];
-        let encoded_name_len =
-            leb128::write::unsigned(&mut &mut buf[..], u64::try_from(self.name.len()).unwrap())
-                .unwrap();
+        let encoded_name_len = buf.as_mut_slice().write_uleb128(u64::try_from(self.name.len()).unwrap()).unwrap();
         let data_len = self.data.iter().fold(0, |acc, s| acc + s.len());
 
         // name length

--- a/libs/wast/src/encode.rs
+++ b/libs/wast/src/encode.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use leb128::Leb128Write;
 
 pub(crate) trait Encode {
     fn encode(&self, e: &mut Vec<u8>);
@@ -53,26 +54,26 @@ impl Encode for u8 {
 }
 
 impl Encode for u32 {
-    fn encode(&self, e: &mut Vec<u8>) {
-        leb128::write::unsigned(e, (*self).into()).unwrap();
+    fn encode(&self, sink: &mut Vec<u8>) {
+        sink.as_mut_slice().write_uleb128((*self).into()).unwrap();
     }
 }
 
 impl Encode for i32 {
-    fn encode(&self, e: &mut Vec<u8>) {
-        leb128::write::signed(e, (*self).into()).unwrap();
+    fn encode(&self, sink: &mut Vec<u8>) {
+        sink.as_mut_slice().write_sleb128((*self).into()).unwrap();
     }
 }
 
 impl Encode for u64 {
-    fn encode(&self, e: &mut Vec<u8>) {
-        leb128::write::unsigned(e, *self).unwrap();
+    fn encode(&self, sink: &mut Vec<u8>) {
+        sink.as_mut_slice().write_uleb128(*self).unwrap();
     }
 }
 
 impl Encode for i64 {
-    fn encode(&self, e: &mut Vec<u8>) {
-        leb128::write::signed(e, *self).unwrap();
+    fn encode(&self, sink: &mut Vec<u8>) {
+        sink.as_mut_slice().write_sleb128(*self).unwrap();
     }
 }
 

--- a/libs/wast/src/lexer.rs
+++ b/libs/wast/src/lexer.rs
@@ -1262,8 +1262,9 @@ fn is_confusing_unicode(ch: char) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::format;
 
-    #[test]
+    #[ktest::test]
     fn ws_smoke() {
         fn get_whitespace(input: &str) -> &str {
             let token = get_token(input);
@@ -1279,7 +1280,7 @@ mod tests {
         assert_eq!(get_whitespace("  ;"), "  ");
     }
 
-    #[test]
+    #[ktest::test]
     fn line_comment_smoke() {
         fn get_line_comment(input: &str) -> &str {
             let token = get_token(input);
@@ -1297,7 +1298,7 @@ mod tests {
         assert_eq!(get_line_comment(";;   \r\nabc"), ";;   ");
     }
 
-    #[test]
+    #[ktest::test]
     fn block_comment_smoke() {
         fn get_block_comment(input: &str) -> &str {
             let token = get_token(input);
@@ -1318,17 +1319,17 @@ mod tests {
             .expect("no token")
     }
 
-    #[test]
+    #[ktest::test]
     fn lparen() {
         assert_eq!(get_token("((").kind, TokenKind::LParen);
     }
 
-    #[test]
+    #[ktest::test]
     fn rparen() {
         assert_eq!(get_token(")(").kind, TokenKind::RParen);
     }
 
-    #[test]
+    #[ktest::test]
     fn strings() {
         fn get_string(input: &str) -> Vec<u8> {
             let token = get_token(input);
@@ -1363,7 +1364,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[ktest::test]
     fn id() {
         fn get_id(input: &str) -> String {
             let token = get_token(input);
@@ -1381,7 +1382,7 @@ mod tests {
         assert_eq!(get_id("$\"x\" ;;"), "x");
     }
 
-    #[test]
+    #[ktest::test]
     fn annotation() {
         fn get_annotation(input: &str) -> String {
             let token = get_token(input);
@@ -1397,7 +1398,7 @@ mod tests {
         assert_eq!(get_annotation("@0 "), "0");
     }
 
-    #[test]
+    #[ktest::test]
     fn keyword() {
         fn get_keyword(input: &str) -> &str {
             let token = get_token(input);
@@ -1413,7 +1414,7 @@ mod tests {
         assert_eq!(get_keyword("x_z "), "x_z");
     }
 
-    #[test]
+    #[ktest::test]
     fn reserved() {
         fn get_reserved(input: &str) -> &str {
             let token = get_token(input);
@@ -1425,7 +1426,7 @@ mod tests {
         assert_eq!(get_reserved("^_x "), "^_x");
     }
 
-    #[test]
+    #[ktest::test]
     fn integer() {
         fn get_integer(input: &str) -> String {
             let token = get_token(input);
@@ -1445,7 +1446,7 @@ mod tests {
         assert_eq!(get_integer("0x10"), "10");
     }
 
-    #[test]
+    #[ktest::test]
     fn float() {
         fn get_float(input: &str) -> Float<'_> {
             let token = get_token(input);

--- a/libs/wast/src/lib.rs
+++ b/libs/wast/src/lib.rs
@@ -50,7 +50,7 @@
 //! [`Parse`]: parser::Parse
 //! [`LexError`]: lexer::LexError
 
-#![cfg_attr(not(test), no_std)]
+#![no_std]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![feature(thread_local)]

--- a/libs/wast/src/token.rs
+++ b/libs/wast/src/token.rs
@@ -689,7 +689,7 @@ impl Peek for RParen {
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[ktest::test]
     fn hex_strtof() {
         macro_rules! f {
             ($a:tt) => (f!(@mk $a, None, None));


### PR DESCRIPTION
The wast & wasm-encoder crates vendored from the `wasm-tools` repo weren't playing nice withe the rest of the setup, this PR cleans them up a bit and makes esp. tests work with the ktest setup  