### PR TITLE
Windows compatibility for Justfile added

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,5 +1,7 @@
 ##!/usr/bin/env just --justfile
 
+set windows-shell := ["powershell.exe", "-c"]
+
 # Overrides the default Rust toolchain set in `rust-toolchain.toml`.
 toolchain := ""
 


### PR DESCRIPTION
Running `just` commands on Windows failed due to shell issues which are fixed in this PR