### PR TITLE
feat: setjmp longjmp

### DIFF
--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -1,7 +1,10 @@
 pub mod trap_handler;
+mod setjmp_longjmp;
 
 use riscv::sstatus::FS;
 use riscv::{interrupt, sie, sstatus};
+
+pub use setjmp_longjmp::{JumpBuf, setjmp, longjmp};
 
 pub fn finish_processor_init() {
     unsafe {

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -1,10 +1,10 @@
-pub mod trap_handler;
 mod setjmp_longjmp;
+pub mod trap_handler;
 
 use riscv::sstatus::FS;
 use riscv::{interrupt, sie, sstatus};
 
-pub use setjmp_longjmp::{JumpBuf, setjmp, longjmp};
+pub use setjmp_longjmp::{longjmp, setjmp, JumpBuf};
 
 pub fn finish_processor_init() {
     unsafe {

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -1,0 +1,270 @@
+//! https://github.com/llvm/llvm-project/blob/bbf2ad026eb0b399364a889799ef6b45878cd299/libc/src/setjmp/riscv/setjmp.cpp
+//! https://github.com/llvm/llvm-project/blob/1ae0dae368e4bbf2177603d5c310e794c4fd0bd8/libc/src/setjmp/riscv/longjmp.cpp
+
+use core::arch::asm;
+
+#[repr(C)]
+#[derive(Clone, Debug, Default)]
+pub struct JumpBuf {
+    pc: usize,
+    s: [usize; 12],
+    sp: usize,
+    fs: [usize; 12]
+}
+
+impl JumpBuf {
+    pub const fn new() -> Self {
+        Self {
+            pc: 0,
+            sp: 0,
+            s: [0; 12],
+            fs: [0; 12]
+        }
+    }
+}
+
+macro_rules! define_op {
+    ($ins:literal, $reg:ident, $ptr_width:literal, $pos:expr, $ptr:ident) => {
+        concat!(
+            $ins,
+            " ",
+            stringify!($reg),
+            ", ",
+            stringify!($ptr_width),
+            "*",
+            $pos,
+            '(',
+            stringify!($ptr),
+            ')'
+        )
+    };
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_pointer_width = "32")] {
+        macro_rules! save_gp {
+            ($reg:ident => $ptr:ident[$pos:expr]) => {
+                define_op!("sw", $reg, 4, $pos, $ptr)
+            }
+        }
+        macro_rules! load_gp {
+            ($ptr:ident[$pos:expr] => $reg:ident) => {
+                define_op!("lw", $reg, 4, $pos, $ptr)
+            }
+        }
+        macro_rules! save_fp {
+            ($reg:ident => $ptr:ident[$pos:expr]) => {
+                define_op!("fsw", $reg, 4, $pos, $ptr)
+            }
+        }
+        macro_rules! load_fp {
+            ($ptr:ident[$pos:expr] => $reg:ident) => {
+                define_op!("flw", $reg, 4, $pos, $ptr)
+            }
+        }
+    } else if #[cfg(target_pointer_width = "64")] {
+        macro_rules! load_gp {
+            ($ptr:ident[$pos:expr] => $reg:ident) => {
+                define_op!("ld", $reg, 8, $pos, $ptr)
+            }
+        }
+        macro_rules! save_gp {
+            ($reg:ident => $ptr:ident[$pos:expr]) => {
+                define_op!("sd", $reg, 8, $pos, $ptr)
+            }
+        }
+        macro_rules! load_fp {
+            ($ptr:ident[$pos:expr] => $reg:ident) => {
+                define_op!("fld", $reg, 8, $pos, $ptr)
+            }
+        }
+        macro_rules! save_fp {
+            ($reg:ident => $ptr:ident[$pos:expr]) => {
+                define_op!("fsd", $reg, 8, $pos, $ptr)
+            }
+        }
+    }
+}
+
+#[naked]
+pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
+    cfg_if::cfg_if! {
+        if #[cfg(target_feature = "d")] {
+            asm! {
+                save_gp!(ra => a0[0]),
+                save_gp!(s0 => a0[1]),
+                save_gp!(s1 => a0[2]),
+                save_gp!(s2 => a0[3]),
+                save_gp!(s3 => a0[4]),
+                save_gp!(s4 => a0[5]),
+                save_gp!(s5 => a0[6]),
+                save_gp!(s6 => a0[7]),
+                save_gp!(s7 => a0[8]),
+                save_gp!(s8 => a0[9]),
+                save_gp!(s9 => a0[10]),
+                save_gp!(s10 => a0[11]),
+                save_gp!(s11 => a0[12]),
+                save_gp!(sp => a0[13]),
+                
+                save_fp!(fs0 => a0[14]),
+                save_fp!(fs1 => a0[15]),
+                save_fp!(fs2 => a0[16]),
+                save_fp!(fs3 => a0[17]),
+                save_fp!(fs4 => a0[18]),
+                save_fp!(fs5 => a0[19]),
+                save_fp!(fs6 => a0[20]),
+                save_fp!(fs7 => a0[21]),
+                save_fp!(fs8 => a0[22]),
+                save_fp!(fs9 => a0[23]),
+                save_fp!(fs10 => a0[24]),
+                save_fp!(fs11 => a0[25]),
+                
+                "mv a0, zero",
+                "ret",
+                options(noreturn)
+            }
+        } else {
+            asm! {
+                save_gp!(ra => a0[0]),
+                save_gp!(s0 => a0[1]),
+                save_gp!(s1 => a0[2]),
+                save_gp!(s2 => a0[3]),
+                save_gp!(s3 => a0[4]),
+                save_gp!(s4 => a0[5]),
+                save_gp!(s5 => a0[6]),
+                save_gp!(s6 => a0[7]),
+                save_gp!(s7 => a0[8]),
+                save_gp!(s8 => a0[9]),
+                save_gp!(s9 => a0[10]),
+                save_gp!(s10 => a0[11]),
+                save_gp!(s11 => a0[12]),
+                save_gp!(sp => a0[13]),
+                
+                "mv a0, zero",
+                "ret",
+                options(noreturn)
+            }
+        }
+    }
+}
+
+#[naked]
+pub unsafe extern "C" fn longjmp(buf: *mut JumpBuf, val: isize) -> ! {
+    cfg_if::cfg_if! {
+        if #[cfg(target_feature = "d")] {
+            asm! {
+                load_gp!(a0[0] => ra),
+                load_gp!(a0[1] => s0),
+                load_gp!(a0[2] => s1),
+                load_gp!(a0[3] => s2),
+                load_gp!(a0[4] => s3),
+                load_gp!(a0[5] => s4),
+                load_gp!(a0[6] => s5),
+                load_gp!(a0[7] => s6),
+                load_gp!(a0[8] => s7),
+                load_gp!(a0[9] => s8),
+                load_gp!(a0[10] => s9),
+                load_gp!(a0[11] => s10),
+                load_gp!(a0[12] => s11),
+                load_gp!(a0[13] => sp),
+                
+                load_fp!(a0[14] => fs0),
+                load_fp!(a0[15] => fs1),
+                load_fp!(a0[16] => fs2),
+                load_fp!(a0[17] => fs3),
+                load_fp!(a0[18] => fs4),
+                load_fp!(a0[19] => fs5),
+                load_fp!(a0[20] => fs6),
+                load_fp!(a0[21] => fs7),
+                load_fp!(a0[22] => fs8),
+                load_fp!(a0[23] => fs9),
+                load_fp!(a0[24] => fs10),
+                load_fp!(a0[25] => fs11),
+                
+                "add a0, a1, zero",
+                "ret",
+                options(noreturn)
+            }
+        } else {
+            asm! {
+                load_gp!(a0[0] => ra),
+                load_gp!(a0[1] => s0),
+                load_gp!(a0[2] => s1),
+                load_gp!(a0[3] => s2),
+                load_gp!(a0[4] => s3),
+                load_gp!(a0[5] => s4),
+                load_gp!(a0[6] => s5),
+                load_gp!(a0[7] => s6),
+                load_gp!(a0[8] => s7),
+                load_gp!(a0[9] => s8),
+                load_gp!(a0[10] => s9),
+                load_gp!(a0[11] => s10),
+                load_gp!(a0[12] => s11),
+                load_gp!(a0[13] => sp),
+                
+                "add a0, a1, zero",
+                "ret",
+                options(noreturn)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ptr::addr_of_mut;
+    use core::ptr;
+    use super::*;
+
+    #[ktest::test]
+    fn setjmp_longjmp_simple() {
+        unsafe {
+            let mut c = 0;
+            let mut buf = JumpBuf::new();
+
+            let r = setjmp(ptr::from_mut(&mut buf));
+            c += 1;
+            if r == 0 {
+                assert_eq!(c, 1);
+                longjmp(ptr::from_mut(&mut buf), 1234567);
+            }
+            assert_eq!(c, 2);
+            assert_eq!(r, 1234567);
+        }
+    }
+
+    static mut BUFFER_A: JumpBuf = JumpBuf::new();
+    static mut BUFFER_B: JumpBuf = JumpBuf::new();
+
+    #[ktest::test]
+    fn setjmp_longjmp_complex() {
+        unsafe fn routine_a() {
+            let r = setjmp(addr_of_mut!(BUFFER_A));
+            if r == 0 { routine_b() }
+            assert_eq!(r, 10001);
+
+            let r = setjmp(addr_of_mut!(BUFFER_A));
+            if r == 0 { longjmp(addr_of_mut!(BUFFER_B), 20001); }
+            assert_eq!(r, 10002);
+
+            let r = setjmp(addr_of_mut!(BUFFER_A));
+            if r == 0 { longjmp(addr_of_mut!(BUFFER_B), 20002); }
+            debug_assert!(r == 10003);
+        }
+
+        unsafe fn routine_b() {
+            let r = setjmp(addr_of_mut!(BUFFER_B));
+            if r == 0 { longjmp(addr_of_mut!(BUFFER_A), 10001); }
+            assert_eq!(r, 20001);
+
+            let r = setjmp(addr_of_mut!(BUFFER_B));
+            if r == 0 { longjmp(addr_of_mut!(BUFFER_A), 10002); }
+            assert_eq!(r, 20002);
+
+            let r = setjmp(addr_of_mut!(BUFFER_B));
+            if r == 0 { longjmp(addr_of_mut!(BUFFER_A), 10003); }
+        }
+
+        unsafe { routine_a(); }
+    }
+}

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -109,7 +109,7 @@ unsafe extern "C" fn default_trap_entry() {
         fsd fs9, 0x1C8(sp)
         fsd fs10, 0x1D0(sp)
         fsd fs11, 0x1D8(sp)
-        ",
+    ",
 
     "mv a0, sp",
 
@@ -184,7 +184,7 @@ unsafe extern "C" fn default_trap_entry() {
         fld ft9, 0x1E8(a0)
         fld ft10, 0x1F0(a0)
         fld ft11, 0x1F8(a0)
-        ",
+    ",
 
     "add sp, sp, 0x210",
     "csrrw sp, sscratch, sp",

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -18,4 +18,4 @@ mod frame_alloc;
 pub mod kconfig;
 pub mod runtime;
 mod start;
-mod tests;
+// mod tests;

--- a/libs/unwind2/src/arch/riscv64.rs
+++ b/libs/unwind2/src/arch/riscv64.rs
@@ -184,7 +184,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
     // No need to save caller-saved registers here.
     #[cfg(target_feature = "d")]
     unsafe {
-        asm!(
+        asm! {
             "
             mv t0, sp
             add sp, sp, -0x210
@@ -205,11 +205,11 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             ret
             ",
             options(noreturn)
-        );
+        };
     }
     #[cfg(not(target_feature = "d"))]
     unsafe {
-        asm!(
+        asm! {
             "
             mv t0, sp
             add sp, sp, -0x110
@@ -229,7 +229,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             ret
             ",
             options(noreturn)
-        );
+        };
     }
 }
 

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -90,7 +90,7 @@ fn zero_bss() {
 }
 
 /// Fill the stack with a canary pattern (0xACE0BACE) so that we can identify unused stack memory
-/// in dumps & calculate stack usage. This is also really great (don't ask my why I know this) to identify 
+/// in dumps & calculate stack usage. This is also really great (don't ask my why I know this) to identify
 /// when we tried executing stack memory.
 ///
 /// # Safety

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -7,7 +7,7 @@ use object::elf::{ProgramHeader64, PT_LOAD};
 use object::read::elf::ProgramHeader;
 use object::{Endianness, Object, ObjectSection};
 
-/// The inlined, compressed kernel 
+/// The inlined, compressed kernel
 pub static KERNEL_BYTES: &[u8] = include_bytes!(env!("KERNEL"));
 
 /// The decompressed and parsed kernel ELF plus the embedded loader configuration data

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -36,7 +36,7 @@ pub type Result<T> = core::result::Result<T, Error>;
 
 static BOOT_HART: AtomicUsize = AtomicUsize::new(0);
 
-/// Main, architecture independent, per-hart functionality. 
+/// Main, architecture independent, per-hart functionality.
 /// This function gets called by each arch-specific start function in `arch/<arch>.rs`
 fn main(hartid: usize) -> ! {
     static INIT: sync::OnceLock<(PageTableResult, &'static BootInfo)> = sync::OnceLock::new();
@@ -75,7 +75,7 @@ fn main(hartid: usize) -> ! {
 }
 
 /// Main, architecture independent, global functionality.
-/// 
+///
 /// This is essentially the one-time init portion of the `main` function.
 fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     let machine_info = arch::machine_info();
@@ -117,7 +117,7 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
     // decompress & parse kernel
     log::trace!("parsing kernel...");
     let kernel = Kernel::from_compressed(kernel::KERNEL_BYTES, &mut frame_alloc)?;
-    
+
     log::trace!("initializing page tables...");
     let page_table_result =
         PageTableBuilder::from_alloc(&mut frame_alloc, physical_memory_offset, &mut page_alloc)?

--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -6,7 +6,7 @@ use rand::prelude::IteratorRandom;
 use rand_chacha::ChaCha20Rng;
 
 /// Virtual memory allocator for setting up initial mappings.
-/// 
+///
 /// All regions will be huge page (1GiB) aligned.
 #[derive(Debug)]
 pub struct PageAllocator {
@@ -19,7 +19,7 @@ pub struct PageAllocator {
 
 impl PageAllocator {
     /// Create a new `PageAllocator` with KASLR enabled.
-    /// 
+    ///
     /// This means regions will be randomly placed in the higher half of the address space.
     pub fn new(rng: ChaCha20Rng) -> Self {
         Self {
@@ -29,7 +29,7 @@ impl PageAllocator {
     }
 
     /// Create a new `PageAllocator` with KASLR **disabled**.
-    /// 
+    ///
     /// Allocated regions will be placed consecutively in the higher half of the address space.
     pub fn new_no_kaslr() -> Self {
         Self {
@@ -37,7 +37,7 @@ impl PageAllocator {
             rng: None,
         }
     }
-    
+
     pub fn reserve_pages(&mut self, num_pages: usize) -> usize {
         // find a consecutive range of `num` entries that are not used
         let mut free_pages = self

--- a/loader/src/paging.rs
+++ b/loader/src/paging.rs
@@ -170,9 +170,9 @@ impl<'a> PageTableBuilder<'a> {
     }
 
     /// Map the physical memory into kernel address space.
-    /// 
+    ///
     /// This can be used by the kernel for direct physical memory access or (on Risc-V) to access
-    /// page tables (there is no recursive mapping). 
+    /// page tables (there is no recursive mapping).
     pub fn map_physical_memory(mut self, machine_info: &MachineInfo) -> Result<Self, kmm::Error> {
         for region_phys in &machine_info.memories {
             let region_virt =
@@ -190,9 +190,8 @@ impl<'a> PageTableBuilder<'a> {
         Ok(self)
     }
 
-    
     /// Identity map the loader itself (this binary).
-    /// 
+    ///
     /// we're already running in s-mode which means that once we switch on the MMU it takes effect *immediately*
     /// as opposed to m-mode where it would take effect after jump tp u-mode.
     /// This means we need to temporarily identity map the loader here, so we can continue executing our own code.
@@ -307,18 +306,18 @@ impl PageTableResult {
             allocation.initialize_for_hart(hartid);
         }
     }
-    
+
     /// Active the page table.
-    /// 
+    ///
     /// This will switch to the new page table, and flush the TLB.
-    /// 
+    ///
     /// # Safety
-    /// 
+    ///
     /// This function is probably **the** most unsafe function in the entire loader,
-    /// it will invalidate all pointers and references that are not covered by the 
+    /// it will invalidate all pointers and references that are not covered by the
     /// loaders identity mapping (everything that doesn't live in the loader data/rodata/bss sections
-    /// or on the loader stack). 
-    /// 
+    /// or on the loader stack).
+    ///
     /// Extreme care must be taken to ensure that pointers passed to the kernel have been "translated"
     /// to virtual addresses before leaving the kernel.
     pub unsafe fn activate_table(&self) {


### PR DESCRIPTION
In preparation for merging the work on the k23VM WebAssembly runtime, this PR adds implementations for `setjmp` and `longjmp`. 

In the current execution mode where JIT-compiled WASM code reuses the hosts stack `setjmp` and `longjmp` are essential for transferring control back to the host on traps. 
We call `setjmp` right before we first transfer control from the host to WASM and when we reach a trap (either by catching a hardware trap or through a builtin) we call `longjmp` back to the original context (plus some cleanup and stack tracing).

In essence we use ugly non-local control transfer to turn hardware traps that are ugly non-local control transfers back into nice, convenient and easy to reason about Rust results returned from the `call` function.