### PR TITLE
feat: make kernel compression optional

### DIFF
--- a/justfile
+++ b/justfile
@@ -162,6 +162,5 @@ _build_bootimg $KERNEL:
         -p loader \
         --target loader/riscv64imac-k23-none-loader.json \
         --profile {{ profile }} \
-        --features compress \
         {{ _buildstd }} \
         {{ _fmt }}

--- a/justfile
+++ b/justfile
@@ -162,5 +162,6 @@ _build_bootimg $KERNEL:
         -p loader \
         --target loader/riscv64imac-k23-none-loader.json \
         --profile {{ profile }} \
+        --features compress \
         {{ _buildstd }} \
         {{ _fmt }}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -18,4 +18,4 @@ mod frame_alloc;
 pub mod kconfig;
 pub mod runtime;
 mod start;
-// mod tests;
+mod tests;

--- a/libs/kmm/src/elf.rs
+++ b/libs/kmm/src/elf.rs
@@ -40,7 +40,7 @@ impl<'p, 'a, M: Mode> ElfMapper<'p, 'a, M> {
         let physical_base = PhysicalAddress::new(elf_file.data().as_ptr() as usize);
         assert!(
             physical_base.is_aligned(M::PAGE_SIZE),
-            "Loaded ELF file is not sufficiently aligned"
+            "Loaded ELF file is not sufficiently aligned. Expected aligned to {} page size, but base pointer was {physical_base:?}", M::PAGE_SIZE
         );
 
         debug_print_sections(elf_file);

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -28,10 +28,13 @@ cfg-if.workspace = true
 log.workspace = true
 arrayvec.workspace = true
 object = { workspace = true, features = ["read_core", "elf"] }
-lz4_flex.workspace = true
+lz4_flex = { workspace = true, optional = true }
 onlyerror.workspace = true
 rand_chacha = { version = "0.3.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
 riscv.workspace = true
+
+[features]
+compress = ["dep:lz4_flex"]

--- a/loader/build.rs
+++ b/loader/build.rs
@@ -7,8 +7,11 @@ fn main() {
 
     println!("cargo::rerun-if-env-changed=KERNEL");
     if let Some(kernel) = env::var_os("KERNEL") {
-        let kernel = PathBuf::from(kernel);
-        let kernel = compress_kernel(&out_dir, &workspace_root.join(kernel));
+        let kernel = workspace_root.join(PathBuf::from(kernel));
+
+        #[cfg(feature = "compress")]
+        let kernel = compress_kernel(&out_dir, &kernel);
+
         println!("cargo::rerun-if-changed={}", kernel.display());
         println!("cargo::rustc-env=KERNEL={}", kernel.display());
     }
@@ -16,6 +19,7 @@ fn main() {
     copy_linker_script();
 }
 
+#[cfg(feature = "compress")]
 fn compress_kernel(out_dir: &Path, kernel: &Path) -> PathBuf {
     let kernel_compressed = out_dir.join("kernel.lz4");
 

--- a/loader/src/error.rs
+++ b/loader/src/error.rs
@@ -3,6 +3,7 @@ pub enum Error {
     /// Failed to set up page tables
     Kmm(#[from] kmm::Error),
     /// Failed to decompress the kernel
+    #[cfg(feature = "compress")]
     Decompression(lz4_flex::block::DecompressError),
     /// Failed to convert number
     TryFromInt(#[from] core::num::TryFromIntError),

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -8,7 +8,11 @@ use object::read::elf::ProgramHeader;
 use object::{Endianness, Object, ObjectSection};
 
 /// The inlined, compressed kernel
-pub static KERNEL_BYTES: &[u8] = include_bytes!(env!("KERNEL"));
+pub static KERNEL_BYTES: KernelBytes = KernelBytes(*include_bytes!(env!("KERNEL")));
+
+/// Wrapper type for the inlined bytes to ensure proper alignment
+#[repr(C, align(4096))]
+pub struct KernelBytes(pub [u8; include_bytes!(env!("KERNEL")).len()]);
 
 /// The decompressed and parsed kernel ELF plus the embedded loader configuration data
 pub struct Kernel<'a> {
@@ -17,6 +21,7 @@ pub struct Kernel<'a> {
 }
 
 impl<'a> Kernel<'a> {
+    #[cfg(feature = "compress")]
     pub fn from_compressed(
         compressed: &'a [u8],
         alloc: &mut BumpAllocator<'_, kconfig::MEMORY_MODE>,

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -116,7 +116,10 @@ fn init_global() -> Result<(PageTableResult, &'static BootInfo)> {
 
     // decompress & parse kernel
     log::trace!("parsing kernel...");
-    let kernel = Kernel::from_compressed(kernel::KERNEL_BYTES, &mut frame_alloc)?;
+    #[cfg(feature = "compress")]
+    let kernel = Kernel::from_compressed(&kernel::KERNEL_BYTES.0, &mut frame_alloc)?;
+    #[cfg(not(feature = "compress"))]
+    let kernel = Kernel::from_bytes(&kernel::KERNEL_BYTES.0)?;
 
     log::trace!("initializing page tables...");
     let page_table_result =


### PR DESCRIPTION
This PR makes compression of the kernel in the loader optional and disables it by default. This will drastically reduce startup time and make development more enjoyable. Still need to figure out why decompression is so slow though (#114)