### PR TITLE
chore: update Rust nightly version to 2024-11-20 (1.84)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724224976,
-        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724293269,
-        "narHash": "sha256-x/XhOAszT/ejditCHUtGOjQcVg2AQhrC/QVew3i7kTI=",
+        "lastModified": 1732069891,
+        "narHash": "sha256-moKx8AVJrViCSdA0e0nSsG8b1dAsObI4sRAtbqbvBY8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6dc6d34a3a217457d7044dcce32b6d537480a6a1",
+        "rev": "8509a51241c407d583b1963d5079585a992506e8",
         "type": "github"
       },
       "original": {

--- a/justfile
+++ b/justfile
@@ -50,6 +50,10 @@ Variables can be set using `just VARIABLE=VALUE ...` or
 
 # env var to set the cargo runner for the riscv64 target
 export CARGO_TARGET_RISCV64GC_K23_NONE_KERNEL_RUNNER := "just _run_riscv64"
+# as of recent Rust nightly versions the old `CARGO_RUSTC_CURRENT_DIR` we used to locate the kernel artifact from the
+# loader build script got removed :/ This is a stopgap until they come up with a replacement.
+# https://github.com/rust-lang/cargo/issues/3946
+export __K23_CARGO_RUSTC_CURRENT_DIR := `dirname "$(cargo locate-project --workspace --message-format plain)"`
 
 # default recipe to display help information
 _default:

--- a/kernel/riscv64gc-k23-none-kernel.json
+++ b/kernel/riscv64gc-k23-none-kernel.json
@@ -18,6 +18,7 @@
   "position-independent-executables": true,
   "relro-level": "full",
   "supported-sanitizers": [
+    "shadow-call-stack",
     "kernel-address"
   ],
   "target-pointer-width": "64"

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -36,7 +36,7 @@
 //! result. In a nested calls scenario (e.g. host->wasm->host->wasm) it is therefore up to each host function
 //! to propagate the trap and each host function therefore gets to clean up all its resources.
 
-use core::arch::asm;
+use core::arch::naked_asm;
 use core::ptr;
 
 /// A store for the register state used by `setjmp` and `longjmp`.
@@ -146,7 +146,7 @@ cfg_if::cfg_if! {
 pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
     cfg_if::cfg_if! {
         if #[cfg(target_feature = "d")] {
-            asm! {
+            naked_asm! {
                 save_gp!(ra => a0[0]),
                 save_gp!(s0 => a0[1]),
                 save_gp!(s1 => a0[2]),
@@ -177,10 +177,9 @@ pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
 
                 "mv a0, zero",
                 "ret",
-                options(noreturn)
             }
         } else {
-            asm! {
+            naked_asm! {
                 save_gp!(ra => a0[0]),
                 save_gp!(s0 => a0[1]),
                 save_gp!(s1 => a0[2]),
@@ -197,7 +196,6 @@ pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
                 save_gp!(sp => a0[13]),
                 "mv a0, zero",
                 "ret",
-                options(noreturn)
             }
         }
     }
@@ -217,7 +215,7 @@ pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
 pub unsafe extern "C" fn longjmp(buf: *mut JumpBuf, val: isize) -> ! {
     cfg_if::cfg_if! {
         if #[cfg(target_feature = "d")] {
-            asm! {
+            naked_asm! {
                 load_gp!(a0[0] => ra),
                 load_gp!(a0[1] => s0),
                 load_gp!(a0[2] => s1),
@@ -248,10 +246,9 @@ pub unsafe extern "C" fn longjmp(buf: *mut JumpBuf, val: isize) -> ! {
 
                 "add a0, a1, zero",
                 "ret",
-                options(noreturn)
             }
         } else {
-            asm! {
+            naked_asm! {
                 load_gp!(a0[0] => ra),
                 load_gp!(a0[1] => s0),
                 load_gp!(a0[2] => s1),
@@ -269,7 +266,6 @@ pub unsafe extern "C" fn longjmp(buf: *mut JumpBuf, val: isize) -> ! {
 
                 "add a0, a1, zero",
                 "ret",
-                options(noreturn)
             }
         }
     }

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -1,5 +1,5 @@
 use crate::kconfig;
-use core::arch::asm;
+use core::arch::{asm, naked_asm};
 use riscv::scause::{Exception, Trap};
 use riscv::{scause, sepc, sstatus, stval, stvec};
 use thread_local::declare_thread_local;
@@ -44,154 +44,152 @@ unsafe extern "C" fn trap_vec() {
     //
     // We can use this to direct some traps that don't need
     // expensive SBI call handling to cheaper handlers (like timers)
-    asm! (
-    ".align 2",
-    ".option push",
-    ".option norvc",
-    "j {default}", // exception
-    "j {default}", // supervisor software interrupt
-    "j {default}", // reserved
-    "j {default}", // reserved
-    "j {default}", // reserved
-    "j {default}", // supervisor timer interrupt
-    "j {default}", // reserved
-    "j {default}", // reserved
-    "j {default}", // reserved
-    "j {default}", // supervisor external interrupt
-    ".option pop",
-    default = sym default_trap_entry,
-    options(noreturn)
-    )
+    naked_asm! {
+        ".align 2",
+        ".option push",
+        ".option norvc",
+        "j {default}", // exception
+        "j {default}", // supervisor software interrupt
+        "j {default}", // reserved
+        "j {default}", // reserved
+        "j {default}", // reserved
+        "j {default}", // supervisor timer interrupt
+        "j {default}", // reserved
+        "j {default}", // reserved
+        "j {default}", // reserved
+        "j {default}", // supervisor external interrupt
+        ".option pop",
+        default = sym default_trap_entry,
+    }
 }
 
 #[allow(clippy::too_many_lines)]
 #[naked]
 unsafe extern "C" fn default_trap_entry() {
-    asm! {
-    ".align 2",
+    naked_asm! {
+        ".align 2",
 
-    "mv t0, sp", // save the correct stack pointer
-    "csrrw sp, sscratch, sp", // t6 points to the TrapFrame
-    "add sp, sp, -0x210",
+        "mv t0, sp", // save the correct stack pointer
+        "csrrw sp, sscratch, sp", // t6 points to the TrapFrame
+        "add sp, sp, -0x210",
 
-    // save gp
-    "
-        sd x0, 0x00(sp)
-        sd ra, 0x08(sp)
-        sd t0, 0x10(sp)
-        sd gp, 0x18(sp)
-        sd tp, 0x20(sp)
-        sd s0, 0x40(sp)
-        sd s1, 0x48(sp)
-        sd s2, 0x90(sp)
-        sd s3, 0x98(sp)
-        sd s4, 0xA0(sp)
-        sd s5, 0xA8(sp)
-        sd s6, 0xB0(sp)
-        sd s7, 0xB8(sp)
-        sd s8, 0xC0(sp)
-        sd s9, 0xC8(sp)
-        sd s10, 0xD0(sp)
-        sd s11, 0xD8(sp)
+        // save gp
+        "
+            sd x0, 0x00(sp)
+            sd ra, 0x08(sp)
+            sd t0, 0x10(sp)
+            sd gp, 0x18(sp)
+            sd tp, 0x20(sp)
+            sd s0, 0x40(sp)
+            sd s1, 0x48(sp)
+            sd s2, 0x90(sp)
+            sd s3, 0x98(sp)
+            sd s4, 0xA0(sp)
+            sd s5, 0xA8(sp)
+            sd s6, 0xB0(sp)
+            sd s7, 0xB8(sp)
+            sd s8, 0xC0(sp)
+            sd s9, 0xC8(sp)
+            sd s10, 0xD0(sp)
+            sd s11, 0xD8(sp)
+            ",
+
+        // save fp
+        "
+            fsd fs0, 0x140(sp)
+            fsd fs1, 0x148(sp)
+            fsd fs2, 0x190(sp)
+            fsd fs3, 0x198(sp)
+            fsd fs4, 0x1A0(sp)
+            fsd fs5, 0x1A8(sp)
+            fsd fs6, 0x1B0(sp)
+            fsd fs7, 0x1B8(sp)
+            fsd fs8, 0x1C0(sp)
+            fsd fs9, 0x1C8(sp)
+            fsd fs10, 0x1D0(sp)
+            fsd fs11, 0x1D8(sp)
         ",
 
-    // save fp
-    "
-        fsd fs0, 0x140(sp)
-        fsd fs1, 0x148(sp)
-        fsd fs2, 0x190(sp)
-        fsd fs3, 0x198(sp)
-        fsd fs4, 0x1A0(sp)
-        fsd fs5, 0x1A8(sp)
-        fsd fs6, 0x1B0(sp)
-        fsd fs7, 0x1B8(sp)
-        fsd fs8, 0x1C0(sp)
-        fsd fs9, 0x1C8(sp)
-        fsd fs10, 0x1D0(sp)
-        fsd fs11, 0x1D8(sp)
-    ",
+        "mv a0, sp",
 
-    "mv a0, sp",
+        "call {trap_handler}",
 
-    "call {trap_handler}",
+        "mv sp, a0",
 
-    "mv sp, a0",
+        // restore gp
+        "ld ra, 0x08(a0)",
+        // skip sp since it is saved in sscratch
+        "ld gp, 0x18(a0)
+            ld tp, 0x20(a0)
+            ld t0, 0x28(a0)
+            ld t1, 0x30(a0)
+            ld t2, 0x38(a0)
+            ld s0, 0x40(a0)
+            ld s1, 0x48(a0)
+            ld a1, 0x58(a0)
+            ld a2, 0x60(a0)
+            ld a3, 0x68(a0)
+            ld a4, 0x70(a0)
+            ld a5, 0x78(a0)
+            ld a6, 0x80(a0)
+            ld a7, 0x88(a0)
+            ld s2, 0x90(a0)
+            ld s3, 0x98(a0)
+            ld s4, 0xA0(a0)
+            ld s5, 0xA8(a0)
+            ld s6, 0xB0(a0)
+            ld s7, 0xB8(a0)
+            ld s8, 0xC0(a0)
+            ld s9, 0xC8(a0)
+            ld s10, 0xD0(a0)
+            ld s11, 0xD8(a0)
+            ld t3, 0xE0(a0)
+            ld t4, 0xE8(a0)
+            ld t5, 0xF0(a0)
+            ld t6, 0xF8(a0)
+            ",
 
-    // restore gp
-    "ld ra, 0x08(a0)",
-    // skip sp since it is saved in sscratch
-    "ld gp, 0x18(a0)
-        ld tp, 0x20(a0)
-        ld t0, 0x28(a0)
-        ld t1, 0x30(a0)
-        ld t2, 0x38(a0)
-        ld s0, 0x40(a0)
-        ld s1, 0x48(a0)
-        ld a1, 0x58(a0)
-        ld a2, 0x60(a0)
-        ld a3, 0x68(a0)
-        ld a4, 0x70(a0)
-        ld a5, 0x78(a0)
-        ld a6, 0x80(a0)
-        ld a7, 0x88(a0)
-        ld s2, 0x90(a0)
-        ld s3, 0x98(a0)
-        ld s4, 0xA0(a0)
-        ld s5, 0xA8(a0)
-        ld s6, 0xB0(a0)
-        ld s7, 0xB8(a0)
-        ld s8, 0xC0(a0)
-        ld s9, 0xC8(a0)
-        ld s10, 0xD0(a0)
-        ld s11, 0xD8(a0)
-        ld t3, 0xE0(a0)
-        ld t4, 0xE8(a0)
-        ld t5, 0xF0(a0)
-        ld t6, 0xF8(a0)
+        // restore fp
+        "
+            fld ft0, 0x100(a0)
+            fld ft1, 0x108(a0)
+            fld ft2, 0x110(a0)
+            fld ft3, 0x118(a0)
+            fld ft4, 0x120(a0)
+            fld ft5, 0x128(a0)
+            fld ft6, 0x130(a0)
+            fld ft7, 0x138(a0)
+            fld fs0, 0x140(a0)
+            fld fs1, 0x148(a0)
+            fld fa0, 0x150(a0)
+            fld fa1, 0x158(a0)
+            fld fa2, 0x160(a0)
+            fld fa3, 0x168(a0)
+            fld fa4, 0x170(a0)
+            fld fa5, 0x178(a0)
+            fld fa6, 0x180(a0)
+            fld fa7, 0x188(a0)
+            fld fs2, 0x190(a0)
+            fld fs3, 0x198(a0)
+            fld fs4, 0x1A0(a0)
+            fld fs5, 0x1A8(a0)
+            fld fs6, 0x1B0(a0)
+            fld fs7, 0x1B8(a0)
+            fld fs8, 0x1C0(a0)
+            fld fs9, 0x1C8(a0)
+            fld fs10, 0x1D0(a0)
+            fld fs11, 0x1D8(a0)
+            fld ft8, 0x1E0(a0)
+            fld ft9, 0x1E8(a0)
+            fld ft10, 0x1F0(a0)
+            fld ft11, 0x1F8(a0)
         ",
 
-    // restore fp
-    "
-        fld ft0, 0x100(a0)
-        fld ft1, 0x108(a0)
-        fld ft2, 0x110(a0)
-        fld ft3, 0x118(a0)
-        fld ft4, 0x120(a0)
-        fld ft5, 0x128(a0)
-        fld ft6, 0x130(a0)
-        fld ft7, 0x138(a0)
-        fld fs0, 0x140(a0)
-        fld fs1, 0x148(a0)
-        fld fa0, 0x150(a0)
-        fld fa1, 0x158(a0)
-        fld fa2, 0x160(a0)
-        fld fa3, 0x168(a0)
-        fld fa4, 0x170(a0)
-        fld fa5, 0x178(a0)
-        fld fa6, 0x180(a0)
-        fld fa7, 0x188(a0)
-        fld fs2, 0x190(a0)
-        fld fs3, 0x198(a0)
-        fld fs4, 0x1A0(a0)
-        fld fs5, 0x1A8(a0)
-        fld fs6, 0x1B0(a0)
-        fld fs7, 0x1B8(a0)
-        fld fs8, 0x1C0(a0)
-        fld fs9, 0x1C8(a0)
-        fld fs10, 0x1D0(a0)
-        fld fs11, 0x1D8(a0)
-        fld ft8, 0x1E0(a0)
-        fld ft9, 0x1E8(a0)
-        fld ft10, 0x1F0(a0)
-        fld ft11, 0x1F8(a0)
-    ",
+        "add sp, sp, 0x210",
+        "csrrw sp, sscratch, sp",
+        "sret",
 
-    "add sp, sp, 0x210",
-    "csrrw sp, sscratch, sp",
-    "sret",
-
-    trap_handler = sym default_trap_handler,
-    options(noreturn)
+        trap_handler = sym default_trap_handler,
     }
 }
 

--- a/kernel/src/runtime/errors.rs
+++ b/kernel/src/runtime/errors.rs
@@ -5,7 +5,7 @@ pub enum CompileError {
     #[error("Cranelift IR to machine code compilation failed {0}")]
     Compile(cranelift_codegen::CodegenError),
 }
-impl<'a> From<cranelift_codegen::CompileError<'a>> for CompileError {
+impl From<cranelift_codegen::CompileError<'_>> for CompileError {
     fn from(error: cranelift_codegen::CompileError) -> Self {
         Self::Compile(error.inner)
     }

--- a/kernel/src/runtime/instance.rs
+++ b/kernel/src/runtime/instance.rs
@@ -53,7 +53,7 @@ impl Instance {
             data: &'a InstanceData<'wasm>,
         }
 
-        impl<'a, 'wasm> fmt::Debug for Dbg<'a, 'wasm> {
+        impl fmt::Debug for Dbg<'_, '_> {
             fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
                 unsafe {
                     f.debug_struct("VMContext")
@@ -96,7 +96,7 @@ pub struct InstanceData<'wasm> {
     pub memories: PrimaryMap<DefinedMemoryIndex, Memory>,
 }
 
-impl<'wasm> InstanceData<'wasm> {
+impl InstanceData<'_> {
     unsafe fn vmctx_magic(&self) -> u32 {
         *self.vmctx_plus_offset::<u32>(self.vmctx_plan.vmctx_magic())
     }

--- a/kernel/src/runtime/translate/func_env.rs
+++ b/kernel/src/runtime/translate/func_env.rs
@@ -90,7 +90,7 @@ impl<'module_env, 'wasm> FunctionEnvironment<'module_env, 'wasm> {
     }
 }
 
-impl<'module_env, 'wasm> TargetEnvironment for FunctionEnvironment<'module_env, 'wasm> {
+impl TargetEnvironment for FunctionEnvironment<'_, '_> {
     fn target_config(&self) -> TargetFrontendConfig {
         self.isa.frontend_config()
     }
@@ -113,7 +113,7 @@ impl<'module_env, 'wasm> TargetEnvironment for FunctionEnvironment<'module_env, 
     }
 }
 
-impl<'module_env, 'wasm> TypeConvert for FunctionEnvironment<'module_env, 'wasm> {
+impl TypeConvert for FunctionEnvironment<'_, '_> {
     fn lookup_heap_type(&self, index: UnpackedIndex) -> WasmHeapType {
         todo!()
     }
@@ -126,9 +126,7 @@ impl<'module_env, 'wasm> TypeConvert for FunctionEnvironment<'module_env, 'wasm>
     }
 }
 
-impl<'module_env, 'wasm> cranelift_wasm::FuncEnvironment
-    for FunctionEnvironment<'module_env, 'wasm>
-{
+impl cranelift_wasm::FuncEnvironment for FunctionEnvironment<'_, '_> {
     fn param_needs_stack_map(&self, _signature: &Signature, index: usize) -> bool {
         false
     }

--- a/kernel/src/runtime/translate/mod.rs
+++ b/kernel/src/runtime/translate/mod.rs
@@ -208,7 +208,7 @@ pub struct MemoryInitializer<'wasm> {
     pub bytes: &'wasm [u8],
 }
 
-impl<'wasm> TranslatedModule<'wasm> {
+impl TranslatedModule<'_> {
     pub fn num_imported_functions(&self) -> u32 {
         self.num_imported_functions
     }

--- a/kernel/src/runtime/translate/module_env.rs
+++ b/kernel/src/runtime/translate/module_env.rs
@@ -26,7 +26,7 @@ pub struct ModuleEnvironment<'a, 'wasm> {
     validator: &'a mut Validator,
 }
 
-impl<'a, 'wasm> TypeConvert for ModuleEnvironment<'a, 'wasm> {
+impl TypeConvert for ModuleEnvironment<'_, '_> {
     fn lookup_heap_type(&self, _index: UnpackedIndex) -> WasmHeapType {
         todo!()
     }

--- a/libs/backtrace/src/lib.rs
+++ b/libs/backtrace/src/lib.rs
@@ -27,7 +27,7 @@ impl<'a, 'data> Backtrace<'a, 'data> {
 
 // FIXME: This *will* dealock rn, since we can't log from within this impl
 // it will lead to a deadlock since we already hold the stdouts lock
-impl<'a, 'data> fmt::Display for Backtrace<'a, 'data> {
+impl fmt::Display for Backtrace<'_, '_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "stack backtrace:")?;
         let mut frame_idx = 0;

--- a/libs/backtrace/src/symbolize.rs
+++ b/libs/backtrace/src/symbolize.rs
@@ -18,7 +18,7 @@ pub enum Symbol<'a> {
     Symtab { name: &'a str },
 }
 
-impl<'a> Symbol<'a> {
+impl Symbol<'_> {
     pub fn name(&self) -> Option<SymbolName<'_>> {
         match self {
             Symbol::Frame { name, .. } => {
@@ -61,7 +61,7 @@ impl<'a> Symbol<'a> {
     }
 }
 
-impl<'a> fmt::Debug for Symbol<'a> {
+impl fmt::Debug for Symbol<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_struct("Symbol");
         d.field("name", &self.name());
@@ -93,7 +93,7 @@ impl<'a> SymbolName<'a> {
     }
 }
 
-impl<'a> fmt::Display for SymbolName<'a> {
+impl fmt::Display for SymbolName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref s) = self.demangled {
             return s.fmt(f);
@@ -103,7 +103,7 @@ impl<'a> fmt::Display for SymbolName<'a> {
     }
 }
 
-impl<'a> fmt::Debug for SymbolName<'a> {
+impl fmt::Debug for SymbolName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref s) = self.demangled {
             return s.fmt(f);

--- a/libs/dtb-parser/src/debug.rs
+++ b/libs/dtb-parser/src/debug.rs
@@ -17,7 +17,7 @@ impl<'a, T: fmt::Write> DebugVisitor<'a, T> {
     }
 }
 
-impl<'a, 'dt, T: fmt::Write> Visitor<'dt> for DebugVisitor<'a, T> {
+impl<'dt, T: fmt::Write> Visitor<'dt> for DebugVisitor<'_, T> {
     type Error = Error;
 
     fn visit_subnode(&mut self, name: &'dt str, node: Node<'dt>) -> crate::Result<()> {

--- a/libs/dtb-parser/src/lib.rs
+++ b/libs/dtb-parser/src/lib.rs
@@ -239,7 +239,7 @@ pub struct ReserveEntries<'dt> {
     done: bool,
 }
 
-impl<'dt> ReserveEntries<'dt> {
+impl ReserveEntries<'_> {
     fn read_u64(&mut self) -> Result<u64> {
         let bytes = self
             .buf

--- a/libs/kmm/src/alloc/bump.rs
+++ b/libs/kmm/src/alloc/bump.rs
@@ -83,7 +83,7 @@ pub struct FreeRegions<'a> {
     inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<PhysicalAddress>>>>,
 }
 
-impl<'a> Iterator for FreeRegions<'a> {
+impl Iterator for FreeRegions<'_> {
     type Item = Range<PhysicalAddress>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -109,7 +109,7 @@ pub struct UsedRegions<'a> {
     inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<PhysicalAddress>>>>,
 }
 
-impl<'a> Iterator for UsedRegions<'a> {
+impl Iterator for UsedRegions<'_> {
     type Item = Range<PhysicalAddress>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -129,7 +129,7 @@ impl<'a> Iterator for UsedRegions<'a> {
     }
 }
 
-impl<'a, M: Mode> FrameAllocator<M> for BumpAllocator<'a, M> {
+impl<M: Mode> FrameAllocator<M> for BumpAllocator<'_, M> {
     fn allocate_frames(&mut self, frames: usize) -> crate::Result<PhysicalAddress> {
         let requested_size = frames * M::PAGE_SIZE;
         let mut offset = self.offset;

--- a/libs/kmm/src/elf.rs
+++ b/libs/kmm/src/elf.rs
@@ -22,7 +22,7 @@ pub struct ElfMapper<'p, 'a, M> {
     virtual_base: VirtualAddress,
 }
 
-impl<'p, 'a, M: Mode> ElfMapper<'p, 'a, M> {
+impl<M: Mode> ElfMapper<'_, '_, M> {
     /// Maps an ELF file into virtual memory.
     ///
     /// # Errors
@@ -377,7 +377,7 @@ struct ProgramHeader<'a> {
     ph: &'a ProgramHeader64<Endianness>,
 }
 
-impl<'a> ProgramHeader<'a> {
+impl ProgramHeader<'_> {
     pub fn parse_rela(&self, elf_file: &ElfFile64) -> Option<RelaInfo> {
         if self.p_type == PT_DYNAMIC {
             let fields = self

--- a/libs/ktest/src/run.rs
+++ b/libs/ktest/src/run.rs
@@ -115,7 +115,7 @@ pub struct MachineInfo<'dt> {
 }
 
 #[cfg(target_os = "none")]
-impl<'dt> MachineInfo<'dt> {
+impl MachineInfo<'_> {
     /// # Safety
     ///
     /// The caller has to ensure the provided pointer actually points to a FDT in memory.

--- a/libs/leb128/src/lib.rs
+++ b/libs/leb128/src/lib.rs
@@ -61,7 +61,7 @@ pub trait Leb128Read {
     fn read_sleb128(&mut self) -> Result<i64>;
 }
 
-impl<'a> Leb128Read for &'a [u8] {
+impl Leb128Read for &'_ [u8] {
     fn read_byte(&mut self) -> Result<u8> {
         let (byte, rest) = self.split_first().ok_or(Error::UnexpectedEof)?;
         *self = rest;
@@ -133,7 +133,7 @@ pub trait Leb128Write {
     fn write_sleb128(&mut self, val: i64) -> Result<usize>;
 }
 
-impl<'a> Leb128Write for &'a mut [u8] {
+impl Leb128Write for &'_ mut [u8] {
     #[inline]
     fn write_byte(&mut self, val: u8) -> Result<()> {
         let (a, b) = mem::take(self)

--- a/libs/sync/src/once.rs
+++ b/libs/sync/src/once.rs
@@ -131,7 +131,7 @@ struct PanicGuard<'a> {
     status: &'a AtomicU8,
 }
 
-impl<'a> Drop for PanicGuard<'a> {
+impl Drop for PanicGuard<'_> {
     fn drop(&mut self) {
         self.status.store(STATUS_POISONED, Ordering::Relaxed);
     }

--- a/libs/unwind2/src/arch/riscv64.rs
+++ b/libs/unwind2/src/arch/riscv64.rs
@@ -1,5 +1,5 @@
 //! RISC-V specific unwinding code, mostly saving and restoring registers.
-use core::arch::asm;
+use core::arch::{naked_asm, asm};
 use core::fmt;
 use core::ops;
 use gimli::{Register, RiscV};
@@ -184,7 +184,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
     // No need to save caller-saved registers here.
     #[cfg(target_feature = "d")]
     unsafe {
-        asm! {
+        naked_asm! {
             "
             mv t0, sp
             add sp, sp, -0x210
@@ -203,13 +203,12 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             .cfi_def_cfa_offset 0
             .cfi_restore ra
             ret
-            ",
-            options(noreturn)
+            "
         };
     }
     #[cfg(not(target_feature = "d"))]
     unsafe {
-        asm! {
+        naked_asm! {
             "
             mv t0, sp
             add sp, sp, -0x110
@@ -228,7 +227,6 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Context, *mut ()), p
             .cfi_restore ra
             ret
             ",
-            options(noreturn)
         };
     }
 }

--- a/libs/unwind2/src/arch/riscv64.rs
+++ b/libs/unwind2/src/arch/riscv64.rs
@@ -1,5 +1,5 @@
 //! RISC-V specific unwinding code, mostly saving and restoring registers.
-use core::arch::{naked_asm, asm};
+use core::arch::{asm, naked_asm};
 use core::fmt;
 use core::ops;
 use gimli::{Register, RiscV};

--- a/libs/unwind2/src/eh_info.rs
+++ b/libs/unwind2/src/eh_info.rs
@@ -25,6 +25,7 @@ pub struct EhInfo {
 }
 
 pub static EH_INFO: LazyLock<EhInfo> = LazyLock::new(|| {
+    #[allow(static_mut_refs)]
     let eh_frame_hdr = unsafe { get_unlimited_slice(EH_FRAME_HDR.as_ptr()) };
 
     let mut bases = BaseAddresses::default().set_eh_frame_hdr(eh_frame_hdr.as_ptr() as u64);

--- a/libs/wasm-encoder/src/component/types.rs
+++ b/libs/wasm-encoder/src/component/types.rs
@@ -79,7 +79,7 @@ impl Encode for ModuleType {
 #[derive(Debug)]
 pub struct CoreTypeEncoder<'a>(pub(crate) &'a mut Vec<u8>);
 
-impl<'a> CoreTypeEncoder<'a> {
+impl CoreTypeEncoder<'_> {
     /// Define a function type.
     pub fn function<P, R>(self, params: P, results: R)
     where

--- a/libs/wast/src/component/component.rs
+++ b/libs/wast/src/component/component.rs
@@ -30,7 +30,7 @@ pub enum ComponentKind<'a> {
     Binary(Vec<&'a [u8]>),
 }
 
-impl<'a> Component<'a> {
+impl Component<'_> {
     /// Performs a name resolution pass on this [`Component`], resolving all
     /// symbolic names to indices.
     ///

--- a/libs/wast/src/component/component.rs
+++ b/libs/wast/src/component/component.rs
@@ -158,7 +158,7 @@ pub enum ComponentField<'a> {
 }
 
 impl<'a> ComponentField<'a> {
-    fn parse_remaining(parser: Parser<'a>) -> Result<Vec<ComponentField>> {
+    fn parse_remaining(parser: Parser<'a>) -> Result<Vec<ComponentField<'a>>> {
         let mut fields = Vec::new();
         while !parser.is_empty() {
             fields.push(parser.parens(ComponentField::parse)?);

--- a/libs/wast/src/component/import.rs
+++ b/libs/wast/src/component/import.rs
@@ -80,7 +80,7 @@ impl<'a> Parse<'a> for ItemSigNoName<'a> {
 
 fn parse_item_sig<'a>(parser: Parser<'a>, name: bool) -> Result<ItemSig<'a>> {
     let mut l = parser.lookahead1();
-    let (span, parse_kind): (_, fn(Parser<'a>) -> Result<ItemSigKind>) = if l.peek::<kw::core>()? {
+    let (span, parse_kind): (_, fn(Parser<'a>) -> Result<ItemSigKind<'a>>) = if l.peek::<kw::core>()? {
         let span = parser.parse::<kw::core>()?.0;
         parser.parse::<kw::module>()?;
         (span, |parser| Ok(ItemSigKind::CoreModule(parser.parse()?)))

--- a/libs/wast/src/component/item_ref.rs
+++ b/libs/wast/src/component/item_ref.rs
@@ -65,7 +65,7 @@ impl<'a, K: Parse<'a>> Parse<'a> for CoreItemRef<'a, K> {
     }
 }
 
-impl<'a, K: Peek> Peek for CoreItemRef<'a, K> {
+impl<K: Peek> Peek for CoreItemRef<'_, K> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         peek::<K>(cursor)
     }
@@ -102,7 +102,7 @@ impl<'a, K: Parse<'a>> Parse<'a> for ItemRef<'a, K> {
     }
 }
 
-impl<'a, K: Peek> Peek for ItemRef<'a, K> {
+impl<K: Peek> Peek for ItemRef<'_, K> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         peek::<K>(cursor)
     }

--- a/libs/wast/src/core/binary.rs
+++ b/libs/wast/src/core/binary.rs
@@ -400,7 +400,7 @@ impl Encode for Option<Id<'_>> {
     }
 }
 
-impl<'a> Encode for ValType<'a> {
+impl Encode for ValType<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             ValType::I32 => e.push(0x7f),
@@ -415,7 +415,7 @@ impl<'a> Encode for ValType<'a> {
     }
 }
 
-impl<'a> Encode for HeapType<'a> {
+impl Encode for HeapType<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             HeapType::Abstract { shared, ty } => {
@@ -454,7 +454,7 @@ impl Encode for AbstractHeapType {
     }
 }
 
-impl<'a> Encode for RefType<'a> {
+impl Encode for RefType<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             // Binary abbreviations (i.e., short form), for when the ref is
@@ -490,7 +490,7 @@ impl<'a> Encode for RefType<'a> {
     }
 }
 
-impl<'a> Encode for StorageType<'a> {
+impl Encode for StorageType<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             StorageType::I8 => e.push(0x78),
@@ -555,7 +555,7 @@ impl Encode for Index<'_> {
     }
 }
 
-impl<'a> Encode for TableType<'a> {
+impl Encode for TableType<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.elem.encode(e);
 
@@ -603,7 +603,7 @@ impl Encode for MemoryType {
     }
 }
 
-impl<'a> Encode for GlobalType<'a> {
+impl Encode for GlobalType<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.ty.encode(e);
         let mut flags = 0;
@@ -1283,14 +1283,14 @@ impl Encode for Id<'_> {
     }
 }
 
-impl<'a> Encode for TryTable<'a> {
+impl Encode for TryTable<'_> {
     fn encode(&self, dst: &mut Vec<u8>) {
         self.block.encode(dst);
         self.catches.encode(dst);
     }
 }
 
-impl<'a> Encode for TryTableCatch<'a> {
+impl Encode for TryTableCatch<'_> {
     fn encode(&self, dst: &mut Vec<u8>) {
         let flag_byte: u8 = match self.kind {
             TryTableCatchKind::Catch(..) => 0,
@@ -1321,7 +1321,7 @@ impl Encode for I8x16Shuffle {
     }
 }
 
-impl<'a> Encode for SelectTypes<'a> {
+impl Encode for SelectTypes<'_> {
     fn encode(&self, dst: &mut Vec<u8>) {
         match &self.tys {
             Some(list) => {

--- a/libs/wast/src/core/expr.rs
+++ b/libs/wast/src/core/expr.rs
@@ -165,7 +165,7 @@ enum If<'a> {
 }
 
 impl<'a> ExpressionParser<'a> {
-    fn new(parser: Parser<'a>) -> ExpressionParser {
+    fn new(parser: Parser<'a>) -> ExpressionParser<'a> {
         ExpressionParser {
             raw_instrs: Vec::new(),
             stack: Vec::new(),

--- a/libs/wast/src/core/expr.rs
+++ b/libs/wast/src/core/expr.rs
@@ -1204,7 +1204,7 @@ const _: () = {
     assert!(size <= pointer * 10);
 };
 
-impl<'a> Instruction<'a> {
+impl Instruction<'_> {
     pub(crate) fn needs_data_count(&self) -> bool {
         matches!(
             self,

--- a/libs/wast/src/core/module.rs
+++ b/libs/wast/src/core/module.rs
@@ -157,7 +157,7 @@ pub enum ModuleField<'a> {
 }
 
 impl<'a> ModuleField<'a> {
-    pub(crate) fn parse_remaining(parser: Parser<'a>) -> Result<Vec<ModuleField>> {
+    pub(crate) fn parse_remaining(parser: Parser<'a>) -> Result<Vec<ModuleField<'a>>> {
         let mut fields = Vec::new();
         while !parser.is_empty() {
             fields.push(parser.parens(ModuleField::parse)?);

--- a/libs/wast/src/core/resolve/deinline_import_export.rs
+++ b/libs/wast/src/core/resolve/deinline_import_export.rs
@@ -51,7 +51,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                     // field here instead, switching this to a `Normal` memory.
                     MemoryKind::Inline { is64, ref data } => {
                         let len = data.iter().map(|l| l.len()).sum::<usize>() as u64;
-                        let pages = (len + default_page_size() - 1) / default_page_size();
+                        let pages = len.div_ceil(default_page_size());
                         let kind = MemoryKind::Normal(MemoryType {
                             limits: Limits {
                                 is64,

--- a/libs/wast/src/core/types.rs
+++ b/libs/wast/src/core/types.rs
@@ -47,7 +47,7 @@ impl<'a> Parse<'a> for ValType<'a> {
     }
 }
 
-impl<'a> Peek for ValType<'a> {
+impl Peek for ValType<'_> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         Ok(kw::i32::peek(cursor)?
             || kw::i64::peek(cursor)?
@@ -97,7 +97,7 @@ impl<'a> Parse<'a> for HeapType<'a> {
     }
 }
 
-impl<'a> Peek for HeapType<'a> {
+impl Peek for HeapType<'_> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         Ok(AbstractHeapType::peek(cursor)?
             || (LParen::peek(cursor)? && kw::shared::peek2(cursor)?)
@@ -460,7 +460,7 @@ impl<'a> Parse<'a> for RefType<'a> {
     }
 }
 
-impl<'a> Peek for RefType<'a> {
+impl Peek for RefType<'_> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         Ok(kw::funcref::peek(cursor)?
             || kw::externref::peek(cursor)?
@@ -723,7 +723,7 @@ impl<'a> Parse<'a> for FunctionType<'a> {
     }
 }
 
-impl<'a> Peek for FunctionType<'a> {
+impl Peek for FunctionType<'_> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         if let Some(next) = cursor.lparen()? {
             match next.keyword()? {
@@ -755,7 +755,7 @@ impl<'a> Parse<'a> for FunctionTypeNoNames<'a> {
     }
 }
 
-impl<'a> Peek for FunctionTypeNoNames<'a> {
+impl Peek for FunctionTypeNoNames<'_> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         FunctionType::peek(cursor)
     }
@@ -946,7 +946,7 @@ pub struct Type<'a> {
     pub final_type: Option<bool>,
 }
 
-impl<'a> Peek for Type<'a> {
+impl Peek for Type<'_> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         kw::r#type::peek(cursor)
     }

--- a/libs/wast/src/lexer.rs
+++ b/libs/wast/src/lexer.rs
@@ -1171,7 +1171,7 @@ impl Token {
     }
 }
 
-impl<'a> Integer<'a> {
+impl Integer<'_> {
     /// Returns the sign token for this integer.
     pub fn sign(&self) -> Option<SignToken> {
         self.sign

--- a/libs/wast/src/token.rs
+++ b/libs/wast/src/token.rs
@@ -95,7 +95,7 @@ impl<'a> Id<'a> {
     }
 }
 
-impl<'a> Hash for Id<'a> {
+impl Hash for Id<'_> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.name.hash(hasher);
         self.gen.hash(hasher);
@@ -108,7 +108,7 @@ impl<'a> PartialEq for Id<'a> {
     }
 }
 
-impl<'a> Eq for Id<'a> {}
+impl Eq for Id<'_> {}
 
 impl<'a> Parse<'a> for Id<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
@@ -255,7 +255,7 @@ impl<'a, K: Parse<'a>> Parse<'a> for ItemRef<'a, K> {
     }
 }
 
-impl<'a, K: Peek> Peek for ItemRef<'a, K> {
+impl<K: Peek> Peek for ItemRef<'_, K> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         match cursor.lparen()? {
             Some(remaining) => K::peek(remaining),

--- a/libs/wast/src/wast.rs
+++ b/libs/wast/src/wast.rs
@@ -226,7 +226,7 @@ pub enum WastExecute<'a> {
     },
 }
 
-impl<'a> WastExecute<'a> {
+impl WastExecute<'_> {
     /// Returns the first span for this execute statement.
     pub fn span(&self) -> Span {
         match self {

--- a/loader/build.rs
+++ b/loader/build.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 fn main() {
-    let workspace_root = Path::new(env!("CARGO_RUSTC_CURRENT_DIR"));
+    let workspace_root = PathBuf::from(env::var_os("__K23_CARGO_RUSTC_CURRENT_DIR").unwrap());
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
 
     println!("cargo::rerun-if-env-changed=KERNEL");

--- a/loader/riscv64imac-k23-none-loader.json
+++ b/loader/riscv64imac-k23-none-loader.json
@@ -8,11 +8,13 @@
   "features": "+m,+a,+c",
   "linker": "rust-lld",
   "linker-flavor": "gnu-lld",
+  "llvm-abiname": "lp64",
   "llvm-target": "riscv64",
   "max-atomic-width": 64,
   "panic-strategy": "abort",
   "relocation-model": "static",
   "supported-sanitizers": [
+    "shadow-call-stack",
     "kernel-address"
   ],
   "target-pointer-width": "64"

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -1,6 +1,6 @@
 use crate::kconfig;
 use crate::machine_info::MachineInfo;
-use core::arch::asm;
+use core::arch::{asm, naked_asm};
 use core::ops::Range;
 use core::ptr;
 use core::ptr::addr_of_mut;
@@ -24,7 +24,7 @@ pub fn machine_info() -> &'static MachineInfo<'static> {
 #[no_mangle]
 #[naked]
 unsafe extern "C" fn _start() -> ! {
-    asm!(
+    naked_asm!(
         ".option push",
         ".option norelax",
         "la		gp, __global_pointer$",
@@ -44,7 +44,6 @@ unsafe extern "C" fn _start() -> ! {
 
         fillstack = sym fillstack,
         start_rust = sym start,
-        options(noreturn)
     )
 }
 
@@ -98,7 +97,7 @@ fn zero_bss() {
 /// expects the bottom of `stack_size` in `t0` and the top of stack in `sp`
 #[naked]
 unsafe extern "C" fn fillstack() {
-    asm!(
+    naked_asm!(
         "li          t1, 0xACE0BACE",
         "sub         t0, sp, t0", // subtract stack_size from sp to get the bottom of stack
         "100:",
@@ -106,7 +105,6 @@ unsafe extern "C" fn fillstack() {
         "addi        t0, t0, 8",
         "bltu        t0, sp, 100b",
         "ret",
-        options(noreturn)
     )
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-08-15"
+channel = "nightly-2024-11-20"
 components = ["rustfmt", "clippy", "rust-src", "llvm-tools"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
This updates the Rust version from 1.82 to 1.84, making necessary changes for the build to still work correctly (including fixing a bit of UB in the loader yay!).

The reason for this is to A keep up to date with Rust nightly for trying out features and B that going forward we rely on strict-provenance to be enabled by default.