### PR TITLE
refactor: replace broken `cursor`/`cursor_mut` with `root`/`root_mut` methods

### DIFF
--- a/libs/wavltree/src/lib.rs
+++ b/libs/wavltree/src/lib.rs
@@ -492,20 +492,20 @@ where
         }
     }
 
-    /// Returns a cursor over the entire tree.
+    /// Returns a cursor to the root of the tree.
     #[inline]
-    pub fn cursor(&self) -> Cursor<'_, T> {
+    pub fn root(&self) -> Cursor<'_, T> {
         Cursor {
-            current: None,
+            current: self.root,
             _tree: self,
         }
     }
 
-    /// Returns a mutable cursor over the entire tree.
+    /// Returns a mutable cursor to the root of the tree.
     #[inline]
-    pub fn cursor_mut(&mut self) -> CursorMut<'_, T> {
+    pub fn root_mut(&mut self) -> CursorMut<'_, T> {
         CursorMut {
-            current: None,
+            current: self.root,
             _tree: self,
         }
     }


### PR DESCRIPTION
The  `cursor`/`cursor_mut` where ambiguously named and broken anyway, so this change "replaces" them with `root` and `root_mut` methods that still return a cursor over the whole tree, but make it clear where they start (in the middle)