### PR TITLE
Revert: `BuddyAllocator` usage in loader

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -29,5 +29,10 @@ pub const LOG_LEVEL: log::Level = log::Level::Trace;
 pub const STACK_SIZE_PAGES: u32 = 256;
 /// The size of the trap handler stack in pages
 pub const TRAP_STACK_SIZE_PAGES: usize = 16;
-/// The size of the kernel heap in pages
-pub const HEAP_SIZE_PAGES: u32 = 8192; // 32 MiB
+/// The initial size of the kernel heap in pages.
+/// 
+/// This initial size should be small enough so the loaders less sophisticated allocator can
+/// doesn't cause startup slowdown & inefficient mapping, but large enough so we can bootstrap
+/// our own virtual memory subsystem. At that point we are no longer reliant on this initial heap
+/// size and can dynamically grow the heap as needed.
+pub const HEAP_SIZE_PAGES: u32 = 16; // 32 MiB

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -30,7 +30,7 @@ pub const STACK_SIZE_PAGES: u32 = 256;
 /// The size of the trap handler stack in pages
 pub const TRAP_STACK_SIZE_PAGES: usize = 16;
 /// The initial size of the kernel heap in pages.
-/// 
+///
 /// This initial size should be small enough so the loaders less sophisticated allocator can
 /// doesn't cause startup slowdown & inefficient mapping, but large enough so we can bootstrap
 /// our own virtual memory subsystem. At that point we are no longer reliant on this initial heap

--- a/kernel/src/vm.rs
+++ b/kernel/src/vm.rs
@@ -38,6 +38,7 @@ pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) {
         };
 
         let arch = arch::vm::init(boot_info, &mut frame_alloc)?;
+        // log::trace!("\n{arch}");
 
         let prng = ChaCha20Rng::from_seed(minfo.rng_seed.unwrap()[0..32].try_into().unwrap());
         let mut aspace = AddressSpace::new(arch, frame_alloc, prng);

--- a/libs/pmm/src/address_space.rs
+++ b/libs/pmm/src/address_space.rs
@@ -182,7 +182,7 @@ impl AddressSpace {
                     // This PTE is an internal node pointing to another page table
                     pgtable = self.pgtable_ptr_from_phys(pte.get_address_and_flags().0);
                 } else {
-                    unreachable!("Invalid state: PTE can't be valid leaf (this means {virt:?} is already mapped) {pte:?}");
+                    unreachable!("Invalid state: PTE can't be valid leaf (this means {virt:?} is already mapped) {pte:?} {pte:p}");
                 }
             }
         }

--- a/libs/pmm/src/frame_alloc/bootstrap.rs
+++ b/libs/pmm/src/frame_alloc/bootstrap.rs
@@ -20,7 +20,7 @@ impl<'a> BootstrapAllocator<'a> {
             phys_offset: VirtualAddress::default(),
         }
     }
-    
+
     pub fn set_phys_offset(&mut self, phys_offset: VirtualAddress) {
         self.phys_offset = phys_offset;
     }

--- a/libs/pmm/src/frame_alloc/bootstrap.rs
+++ b/libs/pmm/src/frame_alloc/bootstrap.rs
@@ -1,0 +1,188 @@
+use crate::frame_alloc::{FrameAllocator, FrameUsage};
+use crate::{arch, PhysicalAddress, VirtualAddress};
+use core::alloc::Layout;
+use core::ops::Range;
+use core::{cmp, iter, ptr, slice};
+
+pub struct BootstrapAllocator<'a> {
+    regions: &'a [Range<PhysicalAddress>],
+    // offset from the top of memory regions
+    offset: usize,
+    phys_offset: VirtualAddress,
+}
+impl<'a> BootstrapAllocator<'a> {
+    /// Create a new frame allocator over a given set of physical memory regions.
+    #[must_use]
+    pub fn new(regions: &'a [Range<PhysicalAddress>]) -> Self {
+        Self {
+            regions,
+            offset: 0,
+            phys_offset: VirtualAddress::default(),
+        }
+    }
+    
+    pub fn set_phys_offset(&mut self, phys_offset: VirtualAddress) {
+        self.phys_offset = phys_offset;
+    }
+
+    #[must_use]
+    pub fn free_regions(&self) -> FreeRegions<'_> {
+        FreeRegions {
+            offset: self.offset,
+            inner: self.regions.iter().rev().cloned(),
+        }
+    }
+
+    #[must_use]
+    pub fn used_regions(&self) -> UsedRegions<'_> {
+        UsedRegions {
+            offset: self.offset,
+            inner: self.regions.iter().rev().cloned(),
+        }
+    }
+}
+
+impl FrameAllocator for BootstrapAllocator<'_> {
+    fn allocate_contiguous(&mut self, layout: Layout) -> Option<PhysicalAddress> {
+        let requested_size = layout.pad_to_align().size();
+        assert_eq!(
+            layout.align(),
+            arch::PAGE_SIZE,
+            "BootstrapAllocator only supports page-aligned allocations"
+        );
+        let mut offset = self.offset;
+
+        for region in self.regions.iter().rev() {
+            let region_size = region.end.sub_addr(region.start);
+
+            // only consider regions that we haven't already exhausted
+            if offset < region_size {
+                // Allocating a contiguous range has different requirements than "regular" allocation
+                // contiguous are rare and often happen in very critical paths where e.g. virtual
+                // memory is not available yet. So we rather waste some memory than outright crash.
+                if region_size - offset < requested_size {
+                    log::warn!("Skipped memory region {region:?} since it was fulfill request for {requested_size} bytes. Wasted {} bytes in the process...", region_size - offset);
+
+                    self.offset += region_size - offset;
+                    offset = 0;
+                    continue;
+                }
+
+                let frame = region.end.sub(offset + requested_size);
+                self.offset += requested_size;
+
+                return Some(frame);
+            }
+
+            offset -= region_size;
+        }
+
+        None
+    }
+
+    fn deallocate_contiguous(&mut self, _addr: PhysicalAddress, _layout: Layout) {
+        unimplemented!("Bootstrap allocator can't free");
+    }
+
+    fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<PhysicalAddress> {
+        let requested_size = layout.pad_to_align().size();
+        let addr = self.allocate_contiguous(layout)?;
+        unsafe {
+            ptr::write_bytes(
+                self.phys_offset.add(addr.as_raw()).as_raw() as *mut u8,
+                0,
+                requested_size,
+            )
+        }
+        Some(addr)
+    }
+
+    fn allocate_partial(&mut self, layout: Layout) -> Option<(PhysicalAddress, usize)> {
+        let requested_size = layout.pad_to_align().size();
+        assert_eq!(
+            layout.align(),
+            arch::PAGE_SIZE,
+            "BootstrapAllocator only supports page-aligned allocations"
+        );
+        let mut offset = self.offset;
+
+        for region in self.regions.iter().rev() {
+            let region_size = region.end.sub_addr(region.start);
+
+            // only consider regions that we haven't already exhausted
+            if offset < region_size {
+                let alloc_size = cmp::min(requested_size, region_size - offset);
+
+                let frame = region.end.sub(offset + alloc_size);
+                self.offset += alloc_size;
+
+                return Some((frame, alloc_size));
+            }
+
+            offset -= region_size;
+        }
+
+        None
+    }
+
+    fn frame_usage(&self) -> FrameUsage {
+        let mut total = 0;
+        for region in self.regions {
+            let region_size = region.end.0 - region.start.0;
+            total += region_size >> arch::PAGE_SHIFT;
+        }
+        let used = self.offset >> arch::PAGE_SHIFT;
+        FrameUsage { used, total }
+    }
+}
+
+pub struct FreeRegions<'a> {
+    offset: usize,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<PhysicalAddress>>>>,
+}
+
+impl Iterator for FreeRegions<'_> {
+    type Item = Range<PhysicalAddress>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut region = self.inner.next()?;
+            let region_size = region.end.as_raw() - region.start.as_raw();
+            // keep advancing past already fully used memory regions
+            if self.offset >= region_size {
+                self.offset -= region_size;
+                continue;
+            } else if self.offset > 0 {
+                region.end = region.end.sub(self.offset);
+                self.offset = 0;
+            }
+
+            return Some(region);
+        }
+    }
+}
+
+pub struct UsedRegions<'a> {
+    offset: usize,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<PhysicalAddress>>>>,
+}
+
+impl Iterator for UsedRegions<'_> {
+    type Item = Range<PhysicalAddress>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut region = self.inner.next()?;
+        let region_size = region.end.as_raw() - region.start.as_raw();
+
+        if self.offset >= region_size {
+            Some(region)
+        } else if self.offset > 0 {
+            region.start = region.end.sub(self.offset);
+            self.offset = 0;
+
+            Some(region)
+        } else {
+            None
+        }
+    }
+}

--- a/libs/pmm/src/frame_alloc/buddy.rs
+++ b/libs/pmm/src/frame_alloc/buddy.rs
@@ -12,7 +12,7 @@ const DEFAULT_MAX_ORDER: usize = 11;
 
 pub struct BuddyAllocator<const MAX_ORDER: usize = DEFAULT_MAX_ORDER> {
     free_lists: [linked_list::List<FreeArea>; MAX_ORDER],
-    pub phys_offset: VirtualAddress,
+    phys_offset: VirtualAddress,
     max_order: usize,
     used: usize,
     total: usize,

--- a/libs/pmm/src/frame_alloc/mod.rs
+++ b/libs/pmm/src/frame_alloc/mod.rs
@@ -1,12 +1,12 @@
-mod buddy;
 mod bootstrap;
+mod buddy;
 
 use crate::{PhysicalAddress, VirtualAddress};
 use core::alloc::Layout;
 use core::ptr;
 
-pub use buddy::BuddyAllocator;
 pub use bootstrap::BootstrapAllocator;
+pub use buddy::BuddyAllocator;
 
 #[derive(Debug)]
 pub struct FrameUsage {

--- a/libs/pmm/src/frame_alloc/mod.rs
+++ b/libs/pmm/src/frame_alloc/mod.rs
@@ -1,10 +1,12 @@
 mod buddy;
+mod bootstrap;
 
 use crate::{PhysicalAddress, VirtualAddress};
 use core::alloc::Layout;
 use core::ptr;
 
 pub use buddy::BuddyAllocator;
+pub use bootstrap::BootstrapAllocator;
 
 #[derive(Debug)]
 pub struct FrameUsage {

--- a/loader/src/machine_info.rs
+++ b/loader/src/machine_info.rs
@@ -155,7 +155,7 @@ impl<'dt> MachineInfo<'dt> {
                 exclude_region(region);
             }
         }
-        
+
         // remove memory regions that are left as zero-sized from the previous step
         info.memories
             .retain(|region| region.end.as_raw() - region.start.as_raw() > 0);

--- a/loader/src/machine_info.rs
+++ b/loader/src/machine_info.rs
@@ -155,14 +155,7 @@ impl<'dt> MachineInfo<'dt> {
                 exclude_region(region);
             }
         }
-
-        // exclude the FDT blob from the available memory regions so that we don't accidentally
-        // override it
-        exclude_region({
-            let range = fdt_slice.as_ptr_range();
-            PhysicalAddress::new(range.start as usize)..PhysicalAddress::new(range.end as usize)
-        });
-
+        
         // remove memory regions that are left as zero-sized from the previous step
         info.memories
             .retain(|region| region.end.as_raw() - region.start.as_raw() > 0);

--- a/loader/src/vm.rs
+++ b/loader/src/vm.rs
@@ -576,11 +576,8 @@ fn map_kernel_heap(
     heap_size_pages: usize,
     flush: &mut Flush,
 ) -> crate::Result<Range<VirtualAddress>> {
-    let layout = Layout::from_size_align(
-        heap_size_pages * arch::PAGE_SIZE,
-        arch::PAGE_SIZE
-    )
-    .unwrap();
+    let layout =
+        Layout::from_size_align(heap_size_pages * arch::PAGE_SIZE, arch::PAGE_SIZE).unwrap();
 
     // Since the kernel heap region is likely quite large and should only be exposed through Rusts
     // allocator APIs, we don't zero it here. Instead, it should be zeroed on demand by the allocator.

--- a/loader/src/vm.rs
+++ b/loader/src/vm.rs
@@ -578,7 +578,7 @@ fn map_kernel_heap(
 ) -> crate::Result<Range<VirtualAddress>> {
     let layout = Layout::from_size_align(
         heap_size_pages * arch::PAGE_SIZE,
-        pmm::arch::page_size_for_level(1),
+        arch::PAGE_SIZE
     )
     .unwrap();
 


### PR DESCRIPTION
This PR partially reverts usage of the new `BuddyAllocator` in the loader, it's tendency to scatter allocations across the managed range - while a benefit in normal operation - turns out to be a downside in the loader where we need to collect up free and used regions to pass them to the kernel. The `BuddyAllocator` produced hundreds of regions even for small physmem sizes (3G of physmem resulted in ~1024 regions), which drastically limited max physmem size we were able to deal with.

This change reintroduces the `BumpAllocator` as `BootstrapAllocator` and while it produces less efficient mappings for the kernel heap, I think in practice that is acceptable. The overhead turns out to not be *that* significant and we can always deal with it later.