### PR TITLE
fix: allocate and copy kernel ELF

### DIFF
--- a/libs/pmm/src/frame_alloc/buddy.rs
+++ b/libs/pmm/src/frame_alloc/buddy.rs
@@ -81,7 +81,8 @@ impl<const MAX_ORDER: usize> BuddyAllocator<MAX_ORDER> {
     ///
     /// # Safety
     ///
-    /// The range must be valid physical memory and not already "owned" by other parts of the system.
+    /// The range must be valid physical memory and not already managed by other parts of the system
+    /// or the allocator itself.
     pub unsafe fn add_range(&mut self, range: Range<PhysicalAddress>) {
         let aligned = range.align_in(arch::PAGE_SIZE);
         let mut remaining_bytes = aligned.size();

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -1,4 +1,3 @@
-use crate::kernel::Kernel;
 use crate::vm::KernelAddressSpace;
 use core::alloc::Layout;
 use core::ops::Range;
@@ -9,11 +8,11 @@ use pmm::{arch, Error, PhysicalAddress, VirtualAddress};
 pub fn init_boot_info(
     mut frame_alloc: BootstrapAllocator,
     boot_hart: usize,
-    kernel: &Kernel,
     kernel_aspace: &KernelAddressSpace,
     physical_memory_offset: VirtualAddress,
     fdt_phys: Range<PhysicalAddress>,
     loader_phys: Range<PhysicalAddress>,
+    kernel_phys: Range<PhysicalAddress>,
 ) -> crate::Result<*mut BootInfo> {
     let frame = frame_alloc
         .allocate_contiguous_zeroed(
@@ -42,11 +41,7 @@ pub fn init_boot_info(
                     ..VirtualAddress::new(loader_phys.end.as_raw())
             },
             kernel_aspace.heap_virt.clone(),
-            {
-                let r = kernel.elf_file.input.as_ptr_range();
-
-                PhysicalAddress::new(r.start as usize)..PhysicalAddress::new(r.end as usize)
-            },
+            kernel_phys,
         ));
     }
 

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -5,13 +5,13 @@ use loader_api::LoaderConfig;
 use xmas_elf::program::{ProgramHeader, Type};
 
 /// The inlined kernel
-static KERNEL_BYTES: KernelBytes = KernelBytes(*include_bytes!(env!("KERNEL")));
+pub static INLINED_KERNEL_BYTES: KernelBytes = KernelBytes(*include_bytes!(env!("KERNEL")));
 /// Wrapper type for the inlined bytes to ensure proper alignment
 #[repr(C, align(4096))]
 pub struct KernelBytes(pub [u8; include_bytes!(env!("KERNEL")).len()]);
 
-pub fn parse_inlined_kernel() -> crate::Result<Kernel<'static>> {
-    let elf_file = xmas_elf::ElfFile::new(&KERNEL_BYTES.0).map_err(Error::Elf)?;
+pub fn parse_kernel(bytes: &'static [u8]) -> crate::Result<Kernel<'static>> {
+    let elf_file = xmas_elf::ElfFile::new(bytes).map_err(Error::Elf)?;
 
     let loader_config = unsafe {
         let section = elf_file

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -7,6 +7,7 @@
 )]
 #![feature(generic_const_exprs)]
 #![feature(maybe_uninit_slice)]
+#![feature(slice_from_ptr_range)]
 
 mod arch;
 mod boot_info;


### PR DESCRIPTION
This change actually allocates and copies the kernel ELF into a freshly allocated physical memory region so it gets properly accounted for in later physical memory allocators