### PR TITLE
feat(kernel): parse `timebase-frequency` into  hart local state

### DIFF
--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -7,7 +7,7 @@ use riscv::{interrupt, sie, sstatus};
 
 pub use setjmp_longjmp::{longjmp, setjmp, JumpBuf};
 
-pub fn finish_processor_init() {
+pub fn finish_hart_init() {
     unsafe {
         interrupt::enable();
         sie::set_stie();

--- a/kernel/src/vm.rs
+++ b/kernel/src/vm.rs
@@ -25,7 +25,7 @@ use wavltree::{Entry, Side};
 
 pub static KERNEL_ASPACE: OnceLock<Mutex<AddressSpace>> = OnceLock::new();
 
-pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) {
+pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) -> crate::Result<()> {
     KERNEL_ASPACE.get_or_try_init(|| -> crate::Result<_> {
         let mut frame_alloc = unsafe {
             let usable_regions = boot_info
@@ -43,12 +43,10 @@ pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) {
         let prng = ChaCha20Rng::from_seed(minfo.rng_seed.unwrap()[0..32].try_into().unwrap());
         let mut aspace = AddressSpace::new(arch, frame_alloc, prng);
 
-        // let kernel_heap_spot =
-        //     aspace.find_spot(Layout::from_size_align(3 * MIB, 4096).unwrap(), 27);
-        // log::trace!("kernel heap spot: {kernel_heap_spot:?}");
-
         Ok(Mutex::new(aspace))
-    });
+    })?;
+
+    Ok(())
 }
 
 pub struct AddressSpace {

--- a/libs/riscv/src/register/mod.rs
+++ b/libs/riscv/src/register/mod.rs
@@ -9,6 +9,7 @@ pub mod sie;
 pub mod sstatus;
 pub mod stval;
 pub mod stvec;
+pub mod time;
 
 macro_rules! csr_base_and_read {
     ($ty_name: ident, $csr_name: literal) => {

--- a/libs/riscv/src/register/time.rs
+++ b/libs/riscv/src/register/time.rs
@@ -1,0 +1,13 @@
+//! Time Register
+
+use super::csr_base_and_read;
+use core::fmt;
+use core::fmt::Formatter;
+
+csr_base_and_read!(Time, "0xC01");
+
+impl fmt::Debug for Time {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Time").field(&self.bits).finish()
+    }
+}

--- a/loader/src/machine_info.rs
+++ b/loader/src/machine_info.rs
@@ -84,10 +84,6 @@ impl fmt::Display for MachineInfo<'_> {
             writeln!(f, "MEMORY REGION {:<4}: {}..{}", idx, r.start, r.end)?;
         }
 
-        // for (idx, r) in self.0.memory_regions().iter().enumerate() {
-        //     writeln!(f, "MEMORY REGION {}: {:#>10x?}", idx, r.range.start.as_raw()..r.range.end.as_raw())?;
-        // }
-
         Ok(())
     }
 }
@@ -103,7 +99,7 @@ impl<'dt> MachineInfo<'dt> {
         let mut reservations = fdt.reserved_entries();
         let fdt_slice = fdt.as_slice();
 
-        let mut v = BootInfoVisitor::default();
+        let mut v = MachineInfoVisitor::default();
         fdt.visit(&mut v).unwrap();
 
         let mut info = MachineInfo {
@@ -190,14 +186,14 @@ fn compare_memory_regions(a: &Range<PhysicalAddress>, b: &Range<PhysicalAddress>
     visitors
 ---------------------------------------------------------------------------------------------------*/
 #[derive(Default)]
-struct BootInfoVisitor<'dt> {
+struct MachineInfoVisitor<'dt> {
     cpus: CpusVisitor,
     memories: RegsVisitor,
     reservations: ReservationsVisitor<'dt>,
     chosen_visitor: ChosenVisitor<'dt>,
 }
 
-impl<'dt> Visitor<'dt> for BootInfoVisitor<'dt> {
+impl<'dt> Visitor<'dt> for MachineInfoVisitor<'dt> {
     type Error = dtb_parser::Error;
     fn visit_subnode(&mut self, name: &'dt str, node: Node<'dt>) -> Result<(), Self::Error> {
         if name.is_empty() {

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -21,5 +21,5 @@ mod vm;
 pub use error::Error;
 pub type Result<T> = core::result::Result<T, Error>;
 
-pub const ENABLE_KASLR: bool = false;
+pub const ENABLE_KASLR: bool = true;
 pub const LOG_LEVEL: log::LevelFilter = log::LevelFilter::Trace;


### PR DESCRIPTION
This change restructures the kernels `MachineInfo` struct into a `MachineInfo` and a TLS `HartLocalMachineInfo`. The reason for doing so is that `HartLocalMachineInfo` now tracks the hart-local `timebase-frequency` property required for converting the Riscv logical realtime clock value into a wall-clock value.

It also introduces the necessary low-level `riscv::register::time` primitives to read the realtime clock register. 