### PR TITLE
fix(pmm): Detect already managed areas in `BuddyAlloc` through canary value

### DIFF
--- a/libs/pmm/src/frame_alloc/buddy.rs
+++ b/libs/pmm/src/frame_alloc/buddy.rs
@@ -281,13 +281,16 @@ impl FreeArea {
         phys_offset: VirtualAddress,
     ) -> Pin<Unique<Self>> {
         let ptr = &mut *(phys_offset.add(addr.as_raw()).as_raw() as *mut MaybeUninit<Self>);
-        
+
         let this = if *ptr.as_ptr().cast::<u32>() == FREE_AREA_MAGIC {
             ptr.assume_init_mut()
-        } else { 
-            ptr.write(FreeArea { _magic: FREE_AREA_MAGIC, links: Default::default() })
+        } else {
+            ptr.write(FreeArea {
+                _magic: FREE_AREA_MAGIC,
+                links: Default::default(),
+            })
         };
-        
+
         Unique::from(this).into_pin()
     }
 


### PR DESCRIPTION
This change adds a canary value field to the `FreeArea` buddy allocator entry that is used to detect already initialized free areas and panic if areas are already managed by an allocator