### PR TITLE
reafctor: report the full physmem map region not just the start address

### DIFF
--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -12,7 +12,7 @@ pub fn init(
     frame_alloc: &mut BuddyAllocator,
 ) -> crate::Result<pmm::AddressSpace> {
     let (mut arch, mut flush) =
-        pmm::AddressSpace::from_active(KERNEL_ASID, boot_info.physical_memory_offset);
+        pmm::AddressSpace::from_active(KERNEL_ASID, boot_info.physical_memory_map.start);
 
     unmap_loader(boot_info, &mut arch, &mut flush);
 

--- a/kernel/src/start.rs
+++ b/kernel/src/start.rs
@@ -27,7 +27,8 @@ fn start(hartid: usize, boot_info: &'static loader_api::BootInfo) -> ! {
                 .expect("no FDT region");
 
             boot_info
-                .physical_memory_offset
+                .physical_memory_map
+                .start
                 .add(fdt.range.start.as_raw())
                 .as_raw() as *const u8
         };

--- a/libs/ktest/src/run.rs
+++ b/libs/ktest/src/run.rs
@@ -29,7 +29,8 @@ extern "Rust" fn kmain(_hartid: usize, boot_info: &'static loader_api::BootInfo)
     let machine_info = unsafe {
         MachineInfo::from_dtb(
             boot_info
-                .physical_memory_offset
+                .physical_memory_map
+                .start
                 .add(fdt.range.start.as_raw())
                 .as_raw() as *const u8,
         )

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -32,7 +32,7 @@ pub struct BootInfo {
     /// frames that are also mapped at other virtual addresses can easily break memory safety and
     /// cause undefined behavior. Only frames reported as `USABLE` by the memory map in the `BootInfo`
     /// can be safely accessed.
-    pub physical_memory_offset: VirtualAddress,
+    pub physical_memory_map: Range<VirtualAddress>,
     /// Virtual memory region occupied by the loader.
     ///
     /// This region is identity-mapped contains the loader executable.
@@ -63,7 +63,7 @@ impl BootInfo {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         boot_hart: usize,
-        physical_memory_offset: VirtualAddress,
+        physical_memory_map: Range<VirtualAddress>,
         kernel_virt: Range<VirtualAddress>,
         memory_regions: *const MemoryRegion,
         memory_regions_len: usize,
@@ -74,7 +74,7 @@ impl BootInfo {
     ) -> Self {
         Self {
             boot_hart,
-            physical_memory_offset,
+            physical_memory_map,
             memory_regions,
             memory_regions_len,
             tls_template,
@@ -95,8 +95,8 @@ impl fmt::Display for BootInfo {
         writeln!(f, "{:<23} : {}", "BOOT HART", self.boot_hart)?;
         writeln!(
             f,
-            "{:<23} : {}",
-            "PHYSICAL MEMORY OFFSET", self.physical_memory_offset
+            "{:<23} : {}..{}",
+            "PHYSICAL MEMORY OFFSET", self.physical_memory_map.start, self.physical_memory_map.end
         )?;
         writeln!(
             f,

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -177,7 +177,7 @@ fn start(hartid: usize, opaque: *const u8) -> ! {
                 frame_alloc,
                 hartid,
                 &kernel_aspace,
-                physmap.start,
+                physmap,
                 fdt_phys,
                 self_regions.executable.start..self_regions.read_write.end,
                 kernel_phys,

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -9,7 +9,7 @@ pub fn init_boot_info(
     mut frame_alloc: BootstrapAllocator,
     boot_hart: usize,
     kernel_aspace: &KernelAddressSpace,
-    physical_memory_offset: VirtualAddress,
+    physical_memory_map: Range<VirtualAddress>,
     fdt_phys: Range<PhysicalAddress>,
     loader_phys: Range<PhysicalAddress>,
     kernel_phys: Range<PhysicalAddress>,
@@ -19,7 +19,7 @@ pub fn init_boot_info(
             Layout::from_size_align(arch::PAGE_SIZE, arch::PAGE_SIZE).unwrap(),
         )
         .ok_or(Error::OutOfMemory)?;
-    let page = physical_memory_offset.add(frame.as_raw());
+    let page = physical_memory_map.start.add(frame.as_raw());
 
     let (memory_regions, memory_regions_len) =
         init_boot_info_memory_regions(page, frame_alloc, fdt_phys);
@@ -28,7 +28,7 @@ pub fn init_boot_info(
     unsafe {
         boot_info.write(BootInfo::new(
             boot_hart,
-            physical_memory_offset,
+            physical_memory_map,
             kernel_aspace.kernel_virt.clone(),
             memory_regions,
             memory_regions_len,


### PR DESCRIPTION
This PR reports the full `physmap` region through the `BootInfo` structure instead of just the start address, since recreating it from the FDT would be much more expensive.