### PR TITLE
fix(loader): prevent frame allocator from handing out loader memory

### DIFF
--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -294,14 +294,13 @@ pub unsafe fn sleep(duration: Duration) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::arch::asm;
     use core::time::Duration;
 
     #[ktest::test]
     fn instant() {
         let start = Instant::now();
 
-        sleep(Duration::from_secs(1));
+        unsafe { sleep(Duration::from_secs(1)); }
 
         let end = Instant::now();
         let elapsed = end.duration_since(start);

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -300,7 +300,9 @@ mod tests {
     fn instant() {
         let start = Instant::now();
 
-        unsafe { sleep(Duration::from_secs(1)); }
+        unsafe {
+            sleep(Duration::from_secs(1));
+        }
 
         let end = Instant::now();
         let elapsed = end.duration_since(start);

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -99,7 +99,8 @@ fn start(hartid: usize, opaque: *const u8) -> ! {
             let self_regions = SelfRegions::collect(&minfo);
             log::trace!("{self_regions:?}");
 
-            let mut frame_alloc = BootstrapAllocator::new(&minfo.memories);
+            let allocatable_memories = allocatable_memory_regions(&minfo, &self_regions);
+            let mut frame_alloc = BootstrapAllocator::new(&allocatable_memories);
 
             let mut page_alloc = if ENABLE_KASLR {
                 PageAllocator::new(ChaCha20Rng::from_seed(
@@ -385,6 +386,34 @@ pub fn allocate_and_copy(
     }
 
     Ok(base..base.add(layout.size()))
+}
+
+fn allocatable_memory_regions(
+    minfo: &MachineInfo,
+    self_regions: &SelfRegions,
+) -> ArrayVec<Range<PhysicalAddress>, 16> {
+    let mut out = ArrayVec::new();
+    let to_exclude = self_regions.executable.start..self_regions.read_write.end;
+
+    for mut region in minfo.memories.clone() {
+        if to_exclude.contains(&region.start) && to_exclude.contains(&region.end) {
+            // remove region
+            continue;
+        } else if region.contains(&to_exclude.start) && region.contains(&to_exclude.end) {
+            out.push(region.start..to_exclude.start);
+            out.push(to_exclude.end..region.end);
+        } else if to_exclude.contains(&region.start) {
+            region.start = to_exclude.end;
+            out.push(region);
+        } else if to_exclude.contains(&region.end) {
+            region.end = to_exclude.start;
+            out.push(region);
+        } else {
+            out.push(region);
+        }
+    }
+
+    out
 }
 
 pub unsafe fn handoff_to_kernel(


### PR DESCRIPTION
This brings back the behaviour of `BumpAllocator::lower_bound` of preventing the loader from overriding its own memory in a more maintainable way by building up a second array of available memory regions that are filtered to exclude the loader memory