### PR TITLE
fix(kernel): prevent `setjmp`/`longjmp` miscompilations through `call_with_setjmp`

### DIFF
--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 pub use pmm::arch::*;
 
 cfg_if::cfg_if! {

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -6,7 +6,7 @@ use core::arch::asm;
 use riscv::sstatus::FS;
 use riscv::{interrupt, sie, sstatus};
 
-pub use setjmp_longjmp::{longjmp, setjmp, JumpBuf};
+pub use setjmp_longjmp::{call_with_setjmp, longjmp, setjmp, JmpBuf, JmpBufStruct};
 
 pub fn finish_hart_init() {
     unsafe {

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -360,7 +360,7 @@ mod tests {
     #[ktest::test]
     fn _call_with_setjmp() {
         unsafe {
-            let ret = call_with_setjmp(|env| {
+            let ret = call_with_setjmp(|_env| {
                 log::trace!("called 1!");
 
                 1234
@@ -371,8 +371,6 @@ mod tests {
                 log::trace!("called 2!");
 
                 longjmp(env, 4321);
-
-                1234
             });
             assert_eq!(ret, 4321);
         }

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -392,7 +392,6 @@ mod tests {
         static mut C: u32 = 0;
 
         unsafe {
-            // let mut c = 0;
             let mut buf = JmpBufStruct::new();
 
             let r = setjmp(ptr::from_mut(&mut buf));

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -36,31 +36,43 @@
 //! result. In a nested calls scenario (e.g. host->wasm->host->wasm) it is therefore up to each host function
 //! to propagate the trap and each host function therefore gets to clean up all its resources.
 
-use core::arch::naked_asm;
+use alloc::boxed::Box;
+use core::any::Any;
+use core::arch::{asm, naked_asm};
+use core::marker::{PhantomData, PhantomPinned};
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::panic::UnwindSafe;
 use core::ptr;
+use core::ptr::addr_of_mut;
 
 /// A store for the register state used by `setjmp` and `longjmp`.
 ///
 /// In essence this marks a "checkpoint" in the program's execution that can be returned to later.
 #[repr(C)]
 #[derive(Clone, Debug, Default)]
-pub struct JumpBuf {
+pub struct JmpBufStruct {
     pc: usize,
     s: [usize; 12],
     sp: usize,
     fs: [usize; 12],
+    _neither_send_nor_sync: PhantomData<*const u8>,
+    _not_unpin: PhantomPinned,
 }
 
-impl JumpBuf {
+impl JmpBufStruct {
     pub const fn new() -> Self {
         Self {
             pc: 0,
             sp: 0,
             s: [0; 12],
             fs: [0; 12],
+            _neither_send_nor_sync: PhantomData,
+            _not_unpin: PhantomPinned,
         }
     }
 }
+
+pub type JmpBuf = *const JmpBufStruct;
 
 /// Helper macro for constructing the inline assembly, used below.
 macro_rules! define_op {
@@ -142,8 +154,9 @@ cfg_if::cfg_if! {
 ///
 /// Due to the weird multi-return nature of `setjmp` it is very easy to make mistakes, this
 /// function be used with extreme care.
+#[no_mangle]
 #[naked]
-pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
+pub unsafe extern "C" fn setjmp(env: JmpBuf) -> isize {
     cfg_if::cfg_if! {
         if #[cfg(target_feature = "d")] {
             naked_asm! {
@@ -212,7 +225,7 @@ pub unsafe extern "C" fn setjmp(buf: *mut JumpBuf) -> isize {
 /// Additionally, the whole point of this function is to continue execution at a wildly different
 /// address, so this might cause confusing and hard-to-debug behavior.
 #[naked]
-pub unsafe extern "C" fn longjmp(buf: *mut JumpBuf, val: isize) -> ! {
+pub unsafe extern "C" fn longjmp(env: JmpBuf, val: isize) -> ! {
     cfg_if::cfg_if! {
         if #[cfg(target_feature = "d")] {
             naked_asm! {
@@ -271,6 +284,69 @@ pub unsafe extern "C" fn longjmp(buf: *mut JumpBuf, val: isize) -> ! {
     }
 }
 
+/// Invokes a closure, setting up the environment for contained code to safely use `longjmp`.
+///
+/// # Reason
+///
+/// TODO
+///
+/// # Safety
+///
+/// TODO
+#[inline(never)]
+pub fn call_with_setjmp<F>(f: F) -> isize
+where
+    F: for<'a> FnOnce(&'a JmpBufStruct) -> isize,
+{
+    let mut f = MaybeUninit::new(f);
+
+    extern "C" fn do_call<F>(env: JmpBuf, closure_env_ptr: *mut F) -> isize
+    where
+        F: for<'a> FnOnce(&'a JmpBufStruct) -> isize,
+    {
+        // Dereference `closure_env_ptr` with .read() to acquire ownership of
+        // the FnOnce object, then call it. (See also the forget note below.)
+        //
+        // Note that `closure_env_ptr` is not a raw function pointer, it's a
+        // pointer to a FnOnce; the code we call comes from the generic `F`.
+        unsafe { (closure_env_ptr.read())(&*env) }
+    }
+
+    unsafe {
+        let mut jbuf = MaybeUninit::<JmpBufStruct>::zeroed().assume_init();
+        let ret: isize;
+        let env_ptr = addr_of_mut!(jbuf);
+        let closure_ptr = addr_of_mut!(f);
+
+        // The callback is now effectively owned by `closure_env_ptr` (i.e., the
+        // `closure_env_ptr.read()` call in `call_from_c_to_rust` will take a
+        // direct bitwise copy of its state, and pass that ownership into the
+        // FnOnce::call_once invocation.)
+        //
+        // Therefore, we need to forget about our own ownership of the callback now.
+        #[allow(clippy::forget_non_drop)]
+        core::mem::forget(f);
+
+        asm! {
+            "call {setjmp}",        // fills in jbuf; future longjmp calls go here.
+            "bnez a0, 1f",          // if return value non-zero, skip the callback invocation
+            "mv a0, {env_ptr}",     // move saved jmp buf into do_call's first arg position
+            "mv a1, {closure_ptr}", // move saved closure env into do_call's second arg position
+            "call {do_call}",       // invoke the do_call and through it the callback
+            "1:",                   // at this point, a0 carries the return value (from either outcome)
+
+            in("a0") env_ptr,
+            setjmp = sym setjmp,
+            do_call = sym do_call::<F>,
+            env_ptr = in(reg) env_ptr,
+            closure_ptr = in(reg) closure_ptr,
+            lateout("a0") ret,
+            clobber_abi("C")
+        }
+        ret
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,24 +354,56 @@ mod tests {
     use core::ptr::addr_of_mut;
 
     #[ktest::test]
-    fn setjmp_longjmp_simple() {
+    fn _call_with_setjmp() {
         unsafe {
-            let mut c = 0;
-            let mut buf = JumpBuf::new();
+            let ret = call_with_setjmp(|env| {
+                log::trace!("called 1!");
+
+                1234
+            });
+            assert_eq!(ret, 1234);
+
+            let ret = call_with_setjmp(|env| {
+                log::trace!("called 2!");
+
+                longjmp(env, 4321);
+
+                1234
+            });
+            assert_eq!(ret, 4321);
+        }
+    }
+
+    #[ktest::test]
+    #[allow(static_mut_refs)]
+    fn setjmp_longjmp_simple() {
+        // The LLVM optimizer doesn't understand the "setjmp returns twice" behaviour and would
+        // turn the `C += 1` into a constant store instruction instead of a load-add-store sequence.
+        // To force this, we use a static variable here, but forcing the location of the variable
+        // into a different (longer-lived) stack frame would also work.
+        //
+        // Note that this only exists to test the behaviour of setjmp/longjmp, in real code you
+        // should use `call_with_setjmp` as it limits much of the footguns.
+
+        static mut C: u32 = 0;
+
+        unsafe {
+            // let mut c = 0;
+            let mut buf = JmpBufStruct::new();
 
             let r = setjmp(ptr::from_mut(&mut buf));
-            c += 1;
+            C += 1;
             if r == 0 {
-                assert_eq!(c, 1);
+                assert_eq!(C, 1);
                 longjmp(ptr::from_mut(&mut buf), 1234567);
             }
-            assert_eq!(c, 2);
+            assert_eq!(C, 2);
             assert_eq!(r, 1234567);
         }
     }
 
-    static mut BUFFER_A: JumpBuf = JumpBuf::new();
-    static mut BUFFER_B: JumpBuf = JumpBuf::new();
+    static mut BUFFER_A: JmpBufStruct = JmpBufStruct::new();
+    static mut BUFFER_B: JmpBufStruct = JmpBufStruct::new();
 
     #[ktest::test]
     fn setjmp_longjmp_complex() {

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -36,13 +36,9 @@
 //! result. In a nested calls scenario (e.g. host->wasm->host->wasm) it is therefore up to each host function
 //! to propagate the trap and each host function therefore gets to clean up all its resources.
 
-use alloc::boxed::Box;
-use core::any::Any;
 use core::arch::{asm, naked_asm};
 use core::marker::{PhantomData, PhantomPinned};
-use core::mem::{ManuallyDrop, MaybeUninit};
-use core::panic::UnwindSafe;
-use core::ptr;
+use core::mem::MaybeUninit;
 use core::ptr::addr_of_mut;
 
 /// A store for the register state used by `setjmp` and `longjmp`.

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -1,4 +1,3 @@
-use crate::time::Instant;
 use crate::{arch, TRAP_STACK_SIZE_PAGES};
 use core::arch::{asm, naked_asm};
 use riscv::scause::{Exception, Interrupt, Trap};
@@ -223,22 +222,22 @@ fn default_trap_handler(
             let tval = stval::read();
 
             log::error!("KERNEL LOAD PAGE FAULT: epc {epc:#x?} tval {tval:#x?}");
-            unsafe { sepc::write(trap_panic_trampoline as usize) }
+            sepc::write(trap_panic_trampoline as usize)
         }
         Trap::Exception(Exception::StorePageFault) => {
             let epc = sepc::read();
             let tval = stval::read();
 
             log::error!("KERNEL STORE PAGE FAULT: epc {epc:#x?} tval {tval:#x?}");
-            unsafe { sepc::write(trap_panic_trampoline as usize) }
+            sepc::write(trap_panic_trampoline as usize)
         }
         Trap::Interrupt(Interrupt::SupervisorTimer) => {
             // just clear the timer interrupt when it happens for now, this is required to make the
             // tests in the `time` module work
-            riscv::sbi::time::set_timer(u64::MAX);
+            riscv::sbi::time::set_timer(u64::MAX).unwrap();
         }
         _ => {
-            unsafe { sepc::write(trap_panic_trampoline as usize) }
+            sepc::write(trap_panic_trampoline as usize)
             // panic!("trap_handler cause {cause:?}, a1 {a1:#x} a2 {a2:#x} a3 {a3:#x} a4 {a4:#x} a5 {a5:#x} a6 {a6:#x} a7 {a7:#x}");
         }
     }

--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -1,4 +1,3 @@
-use crate::arch;
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
 use loader_api::BootInfo;
@@ -9,7 +8,7 @@ const KERNEL_ASID: usize = 0;
 
 pub fn init(
     boot_info: &BootInfo,
-    frame_alloc: &mut BuddyAllocator,
+    _frame_alloc: &mut BuddyAllocator,
 ) -> crate::Result<pmm::AddressSpace> {
     let (mut arch, mut flush) =
         pmm::AddressSpace::from_active(KERNEL_ASID, boot_info.physical_memory_map.start);
@@ -39,17 +38,17 @@ fn unmap_loader(boot_info: &BootInfo, arch: &mut pmm::AddressSpace, flush: &mut 
 
 struct IgnoreAlloc;
 impl FrameAllocator for IgnoreAlloc {
-    fn allocate_contiguous(&mut self, layout: Layout) -> Option<PhysicalAddress> {
+    fn allocate_contiguous(&mut self, _layout: Layout) -> Option<PhysicalAddress> {
         unimplemented!()
     }
 
-    fn deallocate_contiguous(&mut self, addr: PhysicalAddress, layout: Layout) {}
+    fn deallocate_contiguous(&mut self, _addr: PhysicalAddress, _layout: Layout) {}
 
-    fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<PhysicalAddress> {
+    fn allocate_contiguous_zeroed(&mut self, _layout: Layout) -> Option<PhysicalAddress> {
         unimplemented!()
     }
 
-    fn allocate_partial(&mut self, layout: Layout) -> Option<(PhysicalAddress, usize)> {
+    fn allocate_partial(&mut self, _layout: Layout) -> Option<(PhysicalAddress, usize)> {
         unimplemented!()
     }
 


### PR DESCRIPTION
This PR adds a *safer* wrapper for `setjmp` called `call_with_setjmp` that helps to prevent LLVM miscompilations such as happened [here](https://github.com/JonasKruckenberg/k23/actions/runs/12529118111/job/34944386599#step:6:666) where LLVM emitted a store immediate 1 instead of a load-add-store sequence for this code snippet:
```rust
let mut c = 0;
let mut buf = JumpBuf::new();

let r = setjmp(ptr::from_mut(&mut buf));
c += 1; // on opt-lvl >=1 this becomes a store immediate 1 instead of a load-add-store
        // because LLVM rightly assumes that this point will only be reached once per frame
if r == 0 {
    assert_eq!(c, 1);
    longjmp(ptr::from_mut(&mut buf), 1234567);
}
assert_eq!(c, 2);
assert_eq!(r, 1234567);
```
(see on godbolt [here](https://godbolt.org/z/Wxbo1qPE5))

If you force `c` into a different stack frame or into a static things are fine btw if you were curious (see the `setjmp_longjmp_simple` test for more).

The proper solution though - documented [here](https://rust-lang.zulipchat.com/#narrow/stream/210922-project-ffi-unwind/topic/cost.20of.20supporting.20longjmp.20without.20annotations/near/301840755) and adapted into a crate https://github.com/pnkfelix/cee-scape - is to use inline assembly and mark all registers as clobbered along with preventing accidental misuse of the `JmpBuf` in invalid contexts.

