### PR TITLE
feat(loader): collect boot ticks

### DIFF
--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -32,7 +32,7 @@ impl Instant {
 
         Self::from_ticks(ticks)
     }
-    
+
     pub fn from_ticks(ticks: u64) -> Self {
         let timebase_freq =
             crate::HART_LOCAL_MACHINE_INFO.with(|minfo| minfo.timebase_frequency) as u64;

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -27,9 +27,13 @@ pub struct SystemTimeError(Duration);
 
 impl Instant {
     /// Returns an instant corresponding to "now".
-    pub fn now() -> Instant {
+    pub fn now() -> Self {
         let ticks = arch::time::read64();
 
+        Self::from_ticks(ticks)
+    }
+    
+    pub fn from_ticks(ticks: u64) -> Self {
         let timebase_freq =
             crate::HART_LOCAL_MACHINE_INFO.with(|minfo| minfo.timebase_frequency) as u64;
 
@@ -38,13 +42,13 @@ impl Instant {
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or zero duration if that instant is later than this one.
-    pub fn duration_since(&self, earlier: Instant) -> Duration {
+    pub fn duration_since(&self, earlier: Self) -> Duration {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
     /// Returns the amount of time elapsed from another instant to this one,
     /// or zero duration if that instant is later than this one.
-    pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
+    pub fn saturating_duration_since(&self, earlier: Self) -> Duration {
         self.checked_duration_since(earlier).unwrap_or_default()
     }
 
@@ -53,7 +57,7 @@ impl Instant {
     ///
     /// Due to [monotonicity bugs], even under correct logical ordering of the passed `Instant`s,
     /// this method can return `None`.
-    pub fn checked_duration_since(&self, earlier: Instant) -> Option<Duration> {
+    pub fn checked_duration_since(&self, earlier: Self) -> Option<Duration> {
         if *self >= earlier {
             let (secs, nanos) = if self.0.subsec_nanos() >= earlier.0.subsec_nanos() {
                 (
@@ -75,19 +79,19 @@ impl Instant {
 
     /// Returns the amount of time elapsed since this instant.
     pub fn elapsed(&self) -> Duration {
-        Instant::now() - *self
+        Self::now() - *self
     }
 
     /// Returns `Some(t)` where `t` is the time `self + duration` if `t` can be represented as
     /// `Instant` or `None` otherwise.
-    pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_add(duration).map(Instant)
+    pub fn checked_add(&self, duration: Duration) -> Option<Self> {
+        self.0.checked_add(duration).map(Self)
     }
 
     /// Returns `Some(t)` where `t` is the time `self - duration` if `t` can be represented as
     /// `Instant` or `None` otherwise.
-    pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
-        self.0.checked_sub(duration).map(Instant)
+    pub fn checked_sub(&self, duration: Duration) -> Option<Self> {
+        self.0.checked_sub(duration).map(Self)
     }
 }
 

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -58,6 +58,7 @@ pub struct BootInfo {
     ///
     /// This field can be used by the kernel to perform introspection of its own ELF file.
     pub kernel_elf: Range<PhysicalAddress>,
+    pub boot_ticks: u64
 }
 
 unsafe impl Send for BootInfo {}
@@ -79,6 +80,7 @@ impl BootInfo {
         stacks_region: Range<VirtualAddress>,
         tls_region: Option<Range<VirtualAddress>>,
         kernel_elf: Range<PhysicalAddress>,
+        boot_ticks: u64
     ) -> Self {
         Self {
             boot_hart,
@@ -94,6 +96,7 @@ impl BootInfo {
             stacks_region,
             tls_region,
             kernel_elf,
+            boot_ticks
         }
     }
 
@@ -152,7 +155,7 @@ impl fmt::Display for BootInfo {
         } else {
             writeln!(f, "{:<23} : None", "TLS TEMPLATE")?;
         }
-
+        writeln!(f, "{:<23} : {}", "BOOT TICKS", self.boot_ticks)?;
         for (idx, r) in self.memory_regions().iter().enumerate() {
             writeln!(
                 f,

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -58,7 +58,7 @@ pub struct BootInfo {
     ///
     /// This field can be used by the kernel to perform introspection of its own ELF file.
     pub kernel_elf: Range<PhysicalAddress>,
-    pub boot_ticks: u64
+    pub boot_ticks: u64,
 }
 
 unsafe impl Send for BootInfo {}
@@ -80,7 +80,7 @@ impl BootInfo {
         stacks_region: Range<VirtualAddress>,
         tls_region: Option<Range<VirtualAddress>>,
         kernel_elf: Range<PhysicalAddress>,
-        boot_ticks: u64
+        boot_ticks: u64,
     ) -> Self {
         Self {
             boot_hart,
@@ -96,7 +96,7 @@ impl BootInfo {
             stacks_region,
             tls_region,
             kernel_elf,
-            boot_ticks
+            boot_ticks,
         }
     }
 

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -187,7 +187,7 @@ fn start(hartid: usize, opaque: *const u8, boot_ticks: u64) -> ! {
                 fdt_phys,
                 self_regions.executable.start..self_regions.read_write.end,
                 kernel_phys,
-                boot_ticks
+                boot_ticks,
             )?;
 
             Ok((

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -15,7 +15,7 @@ pub fn init_boot_info(
     fdt_phys: Range<PhysicalAddress>,
     loader_phys: Range<PhysicalAddress>,
     kernel_phys: Range<PhysicalAddress>,
-    boot_ticks: u64
+    boot_ticks: u64,
 ) -> crate::Result<*mut BootInfo> {
     let frame = frame_alloc
         .allocate_contiguous_zeroed(
@@ -52,7 +52,7 @@ pub fn init_boot_info(
                 .as_ref()
                 .map(|tls| tls.total_region().clone()),
             kernel_phys,
-            boot_ticks
+            boot_ticks,
         ));
     }
 

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -15,6 +15,7 @@ pub fn init_boot_info(
     fdt_phys: Range<PhysicalAddress>,
     loader_phys: Range<PhysicalAddress>,
     kernel_phys: Range<PhysicalAddress>,
+    boot_ticks: u64
 ) -> crate::Result<*mut BootInfo> {
     let frame = frame_alloc
         .allocate_contiguous_zeroed(
@@ -51,6 +52,7 @@ pub fn init_boot_info(
                 .as_ref()
                 .map(|tls| tls.total_region().clone()),
             kernel_phys,
+            boot_ticks
         ));
     }
 


### PR DESCRIPTION
This collects the ticks value as early on system startup as possible (literally the first instruction in the loader) so we can accurately measure boot times.