### PR TITLE
fix(mmu/riscv64): assert correct ASID when loading pgtables

### DIFF
--- a/libs/mmu/src/arch/riscv64.rs
+++ b/libs/mmu/src/arch/riscv64.rs
@@ -78,8 +78,9 @@ pub fn invalidate_range(asid: usize, address_range: Range<VirtualAddress>) -> cr
 }
 
 /// Return a pointer to the currently active page table.
-pub fn get_active_pgtable(_asid: usize) -> PhysicalAddress {
+pub fn get_active_pgtable(asid: usize) -> PhysicalAddress {
     let satp = satp::read();
+    assert_eq!(satp.asid(), asid);
     PhysicalAddress(satp.ppn() << 12)
 }
 


### PR DESCRIPTION
This change actually makes use of the `asid` param passed to `get_active_pgtable`. It asserts that the currently active ASID matches the passed ASID as a sanity check.