### PR TITLE
refactor(kernel): remove `onlyerror`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,7 +343,6 @@ dependencies = [
  "loader-api",
  "log",
  "mmu",
- "onlyerror",
  "panic-unwind",
  "pin-project-lite",
  "rand 0.8.5",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -31,7 +31,6 @@ cfg-if.workspace = true
 pin-project-lite.workspace = true
 rand_chacha.workspace = true
 rand.workspace = true
-onlyerror.workspace = true
 bitflags.workspace = true
 xmas-elf.workspace = true
 static_assertions.workspace = true

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -1,9 +1,70 @@
-#[derive(Debug, onlyerror::Error)]
+use core::fmt::{Display, Formatter};
+
+#[derive(Debug)]
 pub enum Error {
     /// Failed to set up mappings
-    Mmu(#[from] mmu::Error),
+    Mmu(mmu::Error),
     /// Failed to parse device tree blob
-    Dtb(#[from] dtb_parser::Error),
-    /// Access to a resource was denied
+    Dtb(dtb_parser::Error),
+    /// The caller did not have permission to perform the specified operation.
     AccessDenied,
+    /// An argument is invalid.
+    InvalidArgument,
+    /// An object with the specified identifier or at the specified place already exists.
+    ///
+    /// Example: creating a mapping for an address range that is already mapped.
+    AlreadyExists,
+    /// The system was not able to allocate some resource needed for the operation.
+    NoResources,
+}
+
+impl From<mmu::Error> for Error {
+    fn from(err: mmu::Error) -> Self {
+        Self::Mmu(err)
+    }
+}
+
+impl From<dtb_parser::Error> for Error {
+    fn from(err: dtb_parser::Error) -> Self {
+        Self::Dtb(err)
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Error::Mmu(_) => f.write_str("Failed to set up mappings"),
+            Error::Dtb(_) => f.write_str("Failed to parse device tree blob"),
+            Error::AccessDenied => {
+                f.write_str("The caller did not have permission to perform the specified operation")
+            }
+            Error::InvalidArgument => f.write_str("An argument is invalid"),
+            Error::AlreadyExists => f.write_str(
+                "An object with the specified identifier or at the specified place already exists",
+            ),
+            Error::NoResources => f.write_str(
+                "The system was not able to allocate some resource needed for the operation",
+            ),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $error:expr, $msg:expr) => {
+        if !$cond {
+            log::error!($msg);
+            return Err($error);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! bail {
+    ($error:expr, $msg:expr) => {
+        log::error!($msg);
+        return Err($error);
+    };
 }


### PR DESCRIPTION
`onlyerror` specifically in the kernel crate has caused weird infinite name resolution times for RustRover :/ it doesn't do that much anyways so just remove it from the kernel.