### PR TITLE
chore: QEMU reenable SMP & NUMA

### DIFF
--- a/justfile
+++ b/justfile
@@ -154,13 +154,18 @@ _run_riscv64 binary *args: (_build_bootimg binary)
         {{_loader_artifact}} \
         -machine virt \
         -cpu rv64 \
-        -smp 1 \
         -m 128M \
         -d guest_errors,int \
         -display none \
         -serial stdio \
         -semihosting-config \
         enable=on,target=native \
+        -smp cpus=8 \
+        -object memory-backend-ram,size=64M,id=m0 \
+        -object memory-backend-ram,size=64M,id=m1 \
+        -numa node,cpus=0-3,nodeid=0,memdev=m0 \
+        -numa node,cpus=4-7,nodeid=1,memdev=m1 \
+        -numa dist,src=0,dst=1,val=20 \
         {{args}}
 
 _build_bootimg $KERNEL:


### PR DESCRIPTION
This change reenables SMP in QEMU. The kernel should be fully SMP ready and future development should have SMP enabled to make sure support doesn't regress.

This change also sets up a basic NUMA topology, where 8 cpus are equally grouped into 2 nodes and memory is also equally divided between the two nodes.