### PR TITLE
chore: vendor `addr2line` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,10 +5,11 @@ version = 4
 [[package]]
 name = "addr2line"
 version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
+ "fallible-iterator",
  "gimli",
+ "smallvec",
+ "sync",
 ]
 
 [[package]]
@@ -67,9 +68,7 @@ name = "backtrace"
 version = "0.1.0"
 dependencies = [
  "addr2line",
- "cfg-if",
  "gimli",
- "log",
  "rustc-demangle",
  "unwind2",
  "xmas-elf",
@@ -246,6 +245,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "getrandom"
@@ -689,6 +694,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ large_stack_arrays = "deny"
 recursive_format_impl = "deny"
 
 [workspace.dependencies]
+addr2line = { path = "libs/addr2line" }
 backtrace = { path = "libs/backtrace" }
 dtb-parser = { path = "libs/dtb-parser" }
 leb128 = { path = "libs/leb128" }
@@ -41,7 +42,9 @@ rand_chacha = { version = "0.3.1", default-features = false }
 arrayvec = { version = "0.7.4", default-features = false }
 gimli = { version = "0.31.0", default-features = false, features = ["read"] }
 talc = { version = "4.4.2", default-features = false, features = ["lock_api", "counters"] }
-pin-project-lite = "0.2.15"
+smallvec = { version = "1", default-features = false }
+rustc-demangle = "0.1"
+fallible-iterator = { version = "0.3.0", default-features = false }
 
 # wast dependencies
 bumpalo = "3.14.0"
@@ -53,3 +56,6 @@ hashbrown = { version = "0.14.5", default-features = false, features = [
     "inline-more",
     "nightly",
 ] }
+
+[profile.release]
+debug = "limited" # The kernel should be able to print stack traces of itself even in release mode

--- a/libs/addr2line/CHANGELOG.md
+++ b/libs/addr2line/CHANGELOG.md
@@ -1,0 +1,444 @@
+# `addr2line` Change Log
+
+--------------------------------------------------------------------------------
+
+## 0.24.2 (2024/10/04)
+
+### Changed
+
+* Enabled caching of DWARF abbreviations.
+  [#318](https://github.com/gimli-rs/addr2line/pull/318)
+
+* Changed the `addr2line` binary to prefer symbol names over DWARF names.
+  [#332](https://github.com/gimli-rs/addr2line/pull/332)
+
+* Updated `gimli` dependency.
+
+### Added
+
+* Added `Context::from_arc_dwarf`.
+  [#327](https://github.com/gimli-rs/addr2line/pull/327)
+
+* Added benchmark comparison.
+  [#315](https://github.com/gimli-rs/addr2line/pull/315)
+  [#321](https://github.com/gimli-rs/addr2line/pull/321)
+  [#322](https://github.com/gimli-rs/addr2line/pull/322)
+  [#325](https://github.com/gimli-rs/addr2line/pull/325)
+
+* Added more tests.
+  [#328](https://github.com/gimli-rs/addr2line/pull/328)
+  [#330](https://github.com/gimli-rs/addr2line/pull/330)
+  [#331](https://github.com/gimli-rs/addr2line/pull/331)
+  [#333](https://github.com/gimli-rs/addr2line/pull/333)
+
+--------------------------------------------------------------------------------
+
+## 0.24.1 (2024/07/26)
+
+### Changed
+
+* Fixed parsing of partial units, which are found in supplementary object files.
+  [#313](https://github.com/gimli-rs/addr2line/pull/313)
+
+--------------------------------------------------------------------------------
+
+## 0.24.0 (2024/07/16)
+
+### Breaking changes
+
+* Updated `gimli` dependency.
+
+### Changed
+
+* Changed the order of ranges returned by `Context::find_location_range`, and
+  fixed handling in rare situations.
+  [#303](https://github.com/gimli-rs/addr2line/pull/303)
+  [#304](https://github.com/gimli-rs/addr2line/pull/304)
+  [#306](https://github.com/gimli-rs/addr2line/pull/306)
+
+* Improved the performance of `Context::find_location`.
+  [#305](https://github.com/gimli-rs/addr2line/pull/305)
+
+### Added
+
+* Added `LoaderReader`.
+  [#307](https://github.com/gimli-rs/addr2line/pull/307)
+
+* Added `--all` option to `addr2line`.
+  [#307](https://github.com/gimli-rs/addr2line/pull/307)
+
+--------------------------------------------------------------------------------
+
+## 0.23.0 (2024/05/26)
+
+### Breaking changes
+
+* Updated `gimli` dependency.
+
+* Deleted `Context::new`, `Context::new_with_sup`, and `builtin_split_dwarf_loader`.
+  Use `Context::from_dwarf` or `Loader::new` instead.
+  This removes `object` from the public API.
+  [#296](https://github.com/gimli-rs/addr2line/pull/296)
+
+### Changed
+
+* Fixed handling of column 0 in the line table.
+  [#290](https://github.com/gimli-rs/addr2line/pull/290)
+
+* Moved `addr2line` from `examples` to `bin`. Requires the `bin` feature.
+  [#291](https://github.com/gimli-rs/addr2line/pull/291)
+
+* Split up `lib.rs` into smaller modules.
+  [#292](https://github.com/gimli-rs/addr2line/pull/292)
+
+### Added
+
+* Added `Loader`. Requires the `loader` feature.
+  [#296](https://github.com/gimli-rs/addr2line/pull/296)
+  [#297](https://github.com/gimli-rs/addr2line/pull/297)
+
+* Added unpacked Mach-O support to `Loader`.
+  [#298](https://github.com/gimli-rs/addr2line/pull/298)
+
+--------------------------------------------------------------------------------
+
+## 0.22.0 (2024/04/11)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+--------------------------------------------------------------------------------
+
+## 0.21.0 (2023/08/12)
+
+### Breaking changes
+
+* Updated `gimli`, `object`, and `fallible-iterator` dependencies.
+
+### Changed
+
+* The minimum supported rust version is 1.65.0.
+
+* Store boxed slices instead of `Vec` objects in `Context`.
+  [#278](https://github.com/gimli-rs/addr2line/pull/278)
+
+--------------------------------------------------------------------------------
+
+## 0.20.0 (2023/04/15)
+
+### Breaking changes
+
+* The minimum supported rust version is 1.58.0.
+
+* Changed `Context::find_frames` to return `LookupResult`.
+  Use `LookupResult::skip_all_loads` to obtain the result without loading split DWARF.
+  [#260](https://github.com/gimli-rs/addr2line/pull/260)
+
+* Replaced `Context::find_dwarf_unit` with `Context::find_dwarf_and_unit`.
+  [#260](https://github.com/gimli-rs/addr2line/pull/260)
+
+* Updated `object` dependency.
+
+### Changed
+
+* Fix handling of file index 0 for DWARF 5.
+  [#264](https://github.com/gimli-rs/addr2line/pull/264)
+
+### Added
+
+* Added types and methods to support loading split DWARF:
+  `LookupResult`, `SplitDwarfLoad`, `SplitDwarfLoader`, `Context::preload_units`.
+  [#260](https://github.com/gimli-rs/addr2line/pull/260)
+  [#262](https://github.com/gimli-rs/addr2line/pull/262)
+  [#263](https://github.com/gimli-rs/addr2line/pull/263)
+
+--------------------------------------------------------------------------------
+
+## 0.19.0 (2022/11/24)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+--------------------------------------------------------------------------------
+
+## 0.18.0 (2022/07/16)
+
+### Breaking changes
+
+* Updated `object` dependency.
+
+### Changed
+
+* Fixed handling of relative path for `DW_AT_comp_dir`.
+  [#239](https://github.com/gimli-rs/addr2line/pull/239)
+
+* Fixed handling of `DW_FORM_addrx` for DWARF 5 support.
+  [#243](https://github.com/gimli-rs/addr2line/pull/243)
+
+* Fixed handling of units that are missing range information.
+  [#249](https://github.com/gimli-rs/addr2line/pull/249)
+
+--------------------------------------------------------------------------------
+
+## 0.17.0 (2021/10/24)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+### Changed
+
+* Use `skip_attributes` to improve performance.
+  [#236](https://github.com/gimli-rs/addr2line/pull/236)
+
+--------------------------------------------------------------------------------
+
+## 0.16.0 (2021/07/26)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+--------------------------------------------------------------------------------
+
+## 0.15.2 (2021/06/04)
+
+### Fixed
+
+* Allow `Context` to be `Send`.
+  [#219](https://github.com/gimli-rs/addr2line/pull/219)
+
+--------------------------------------------------------------------------------
+
+## 0.15.1 (2021/05/02)
+
+### Fixed
+
+* Don't ignore aranges with address 0.
+  [#217](https://github.com/gimli-rs/addr2line/pull/217)
+
+--------------------------------------------------------------------------------
+
+## 0.15.0 (2021/05/02)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+  [#215](https://github.com/gimli-rs/addr2line/pull/215)
+
+* Added `debug_aranges` parameter to `Context::from_sections`.
+  [#200](https://github.com/gimli-rs/addr2line/pull/200)
+
+### Added
+
+* Added `.debug_aranges` support.
+  [#200](https://github.com/gimli-rs/addr2line/pull/200)
+
+* Added supplementary object file support.
+  [#208](https://github.com/gimli-rs/addr2line/pull/208)
+
+### Fixed
+
+* Fixed handling of Windows paths in locations.
+  [#209](https://github.com/gimli-rs/addr2line/pull/209)
+
+* examples/addr2line: Flush stdout after each response.
+  [#210](https://github.com/gimli-rs/addr2line/pull/210)
+
+* examples/addr2line: Avoid copying every section.
+  [#213](https://github.com/gimli-rs/addr2line/pull/213)
+
+--------------------------------------------------------------------------------
+
+## 0.14.1 (2020/12/31)
+
+### Fixed
+
+* Fix location lookup for skeleton units.
+  [#201](https://github.com/gimli-rs/addr2line/pull/201)
+
+### Added
+
+* Added `Context::find_location_range`.
+  [#196](https://github.com/gimli-rs/addr2line/pull/196)
+  [#199](https://github.com/gimli-rs/addr2line/pull/199)
+
+--------------------------------------------------------------------------------
+
+## 0.14.0 (2020/10/27)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+### Fixed
+
+* Handle units that only have line information.
+  [#188](https://github.com/gimli-rs/addr2line/pull/188)
+
+* Handle DWARF units with version <= 4 and no `DW_AT_name`.
+  [#191](https://github.com/gimli-rs/addr2line/pull/191)
+
+* Fix handling of `DW_FORM_ref_addr`.
+  [#193](https://github.com/gimli-rs/addr2line/pull/193)
+
+--------------------------------------------------------------------------------
+
+## 0.13.0 (2020/07/07)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+* Added `rustc-dep-of-std` feature.
+  [#166](https://github.com/gimli-rs/addr2line/pull/166)
+
+### Changed
+
+* Improve performance by parsing function contents lazily.
+  [#178](https://github.com/gimli-rs/addr2line/pull/178)
+
+* Don't skip `.debug_info` and `.debug_line` entries with a zero address.
+  [#182](https://github.com/gimli-rs/addr2line/pull/182)
+
+--------------------------------------------------------------------------------
+
+## 0.12.2 (2020/06/21)
+
+### Fixed
+
+* Avoid linear search for `DW_FORM_ref_addr`.
+  [#175](https://github.com/gimli-rs/addr2line/pull/175)
+
+--------------------------------------------------------------------------------
+
+## 0.12.1 (2020/05/19)
+
+### Fixed
+
+* Handle units with overlapping address ranges.
+  [#163](https://github.com/gimli-rs/addr2line/pull/163)
+
+* Don't assert for functions with overlapping address ranges.
+  [#168](https://github.com/gimli-rs/addr2line/pull/168)
+
+--------------------------------------------------------------------------------
+
+## 0.12.0 (2020/05/12)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+* Added more optional features: `smallvec` and `fallible-iterator`.
+  [#160](https://github.com/gimli-rs/addr2line/pull/160)
+
+### Added
+
+*  Added `Context::dwarf` and `Context::find_dwarf_unit`.
+  [#159](https://github.com/gimli-rs/addr2line/pull/159)
+
+### Changed
+
+* Removed `lazycell` dependency.
+  [#160](https://github.com/gimli-rs/addr2line/pull/160)
+
+--------------------------------------------------------------------------------
+
+## 0.11.0 (2020/01/11)
+
+### Breaking changes
+
+* Updated `gimli` and `object` dependencies.
+
+* [#130](https://github.com/gimli-rs/addr2line/pull/130)
+  Changed `Location::file` from `Option<String>` to `Option<&str>`.
+  This required adding lifetime parameters to `Location` and other structs that
+  contain it.
+
+* [#152](https://github.com/gimli-rs/addr2line/pull/152)
+  Changed `Location::line` and `Location::column` from `Option<u64>`to `Option<u32>`.
+
+* [#156](https://github.com/gimli-rs/addr2line/pull/156)
+  Deleted `alloc` feature, and fixed `no-std` builds with stable rust.
+  Removed default `Reader` parameter for `Context`, and added `ObjectContext` instead.
+
+### Added
+
+* [#134](https://github.com/gimli-rs/addr2line/pull/134)
+  Added `Context::from_dwarf`.
+
+### Changed
+
+* [#133](https://github.com/gimli-rs/addr2line/pull/133)
+  Fixed handling of units that can't be parsed.
+
+* [#155](https://github.com/gimli-rs/addr2line/pull/155)
+  Fixed `addr2line` output to match binutils.
+
+* [#130](https://github.com/gimli-rs/addr2line/pull/130)
+  Improved `.debug_line` parsing performance.
+
+* [#148](https://github.com/gimli-rs/addr2line/pull/148)
+  [#150](https://github.com/gimli-rs/addr2line/pull/150)
+  [#151](https://github.com/gimli-rs/addr2line/pull/151)
+  [#152](https://github.com/gimli-rs/addr2line/pull/152)
+  Improved `.debug_info` parsing performance.
+
+* [#137](https://github.com/gimli-rs/addr2line/pull/137)
+  [#138](https://github.com/gimli-rs/addr2line/pull/138)
+  [#139](https://github.com/gimli-rs/addr2line/pull/139)
+  [#140](https://github.com/gimli-rs/addr2line/pull/140)
+  [#146](https://github.com/gimli-rs/addr2line/pull/146)
+  Improved benchmarks.
+
+--------------------------------------------------------------------------------
+
+## 0.10.0 (2019/07/07)
+
+### Breaking changes
+
+* [#127](https://github.com/gimli-rs/addr2line/pull/127)
+  Update `gimli`.
+
+--------------------------------------------------------------------------------
+
+## 0.9.0 (2019/05/02)
+
+### Breaking changes
+
+* [#121](https://github.com/gimli-rs/addr2line/pull/121)
+  Update `gimli`, `object`, and `fallible-iterator` dependencies.
+
+### Added
+
+* [#121](https://github.com/gimli-rs/addr2line/pull/121)
+  Reexport `gimli`, `object`, and `fallible-iterator`.
+
+--------------------------------------------------------------------------------
+
+## 0.8.0 (2019/02/06)
+
+### Breaking changes
+
+* [#107](https://github.com/gimli-rs/addr2line/pull/107)
+  Update `object` dependency to 0.11. This is part of the public API.
+
+### Added
+
+* [#101](https://github.com/gimli-rs/addr2line/pull/101)
+  Add `object` feature (enabled by default). Disable this feature to remove
+  the `object` dependency and `Context::new` API.
+
+* [#102](https://github.com/gimli-rs/addr2line/pull/102)
+  Add `std` (enabled by default) and `alloc` features.
+
+### Changed
+
+* [#108](https://github.com/gimli-rs/addr2line/issues/108)
+  `demangle` no longer outputs the hash for rust symbols.
+
+* [#109](https://github.com/gimli-rs/addr2line/issues/109)
+  Set default `R` for `Context<R>`.

--- a/libs/addr2line/Cargo.toml
+++ b/libs/addr2line/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "addr2line"
+version = "0.24.2"
+description = "A cross-platform symbolication library written in Rust, using `gimli`"
+edition.workspace = true
+authors.workspace = true
+license = "Apache-2.0 OR MIT"
+
+[dependencies]
+sync.workspace = true
+gimli = { workspace = true, default-features = false, features = ["read"] }
+smallvec.workspace = true
+fallible-iterator.workspace = true

--- a/libs/addr2line/LICENSE-APACHE
+++ b/libs/addr2line/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/libs/addr2line/LICENSE-MIT
+++ b/libs/addr2line/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2016-2018 The gimli Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/libs/addr2line/README.md
+++ b/libs/addr2line/README.md
@@ -1,0 +1,50 @@
+# addr2line
+
+[![](https://img.shields.io/crates/v/addr2line.svg)](https://crates.io/crates/addr2line)
+[![](https://img.shields.io/docsrs/addr2line.svg)](https://docs.rs/addr2line)
+[![Coverage Status](https://coveralls.io/repos/github/gimli-rs/addr2line/badge.svg?branch=master)](https://coveralls.io/github/gimli-rs/addr2line?branch=master)
+
+`addr2line` provides a cross-platform library for retrieving per-address debug information
+from files with DWARF debug information. Given an address, it can return the file name,
+line number, and function name associated with that address, as well as the inline call
+stack leading to that address.
+
+The crate has a CLI wrapper around the library which provides some of
+the functionality of the `addr2line` command line tool distributed with
+[GNU binutils](https://sourceware.org/binutils/docs/binutils/addr2line.html).
+
+# Quickstart
+ - Add the [`addr2line` crate](https://crates.io/crates/addr2line) to your `Cargo.toml`.
+ - Call [`addr2line::Loader::new`](https://docs.rs/addr2line/*/addr2line/struct.Loader.html#method.new) with the file path.
+ - Use [`addr2line::Loader::find_location`](https://docs.rs/addr2line/*/addr2line/struct.Loader.html#method.find_location)
+   or [`addr2line::Loader::find_frames`](https://docs.rs/addr2line/*/addr2line/struct.Loader.html#method.find_frames)
+   to look up debug information for an address.
+
+If you want to provide your own file loading and memory management, use
+[`addr2line::Context`](https://docs.rs/addr2line/*/addr2line/struct.Context.html)
+instead of `addr2line::Loader`.
+
+# Performance
+
+`addr2line` optimizes for speed over memory by caching parsed information.
+The DWARF information is parsed lazily where possible.
+
+The library aims to perform similarly to equivalent existing tools such
+as `addr2line` from binutils, `eu-addr2line` from elfutils, and
+`llvm-addr2line` from the llvm project. Current benchmarks show a performance
+improvement in all cases:
+
+![addr2line runtime](benchmark-time.svg)
+
+## License
+
+Licensed under either of
+
+  * Apache License, Version 2.0 ([`LICENSE-APACHE`](./LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+  * MIT license ([`LICENSE-MIT`](./LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/libs/addr2line/src/frame.rs
+++ b/libs/addr2line/src/frame.rs
@@ -1,0 +1,164 @@
+use crate::{maybe_small, Error, Function, InlinedFunction, ResUnit};
+use core::iter;
+
+/// A source location.
+pub struct Location<'a> {
+    /// The file name.
+    pub file: Option<&'a str>,
+    /// The line number.
+    pub line: Option<u32>,
+    /// The column number.
+    ///
+    /// A value of `Some(0)` indicates the left edge.
+    pub column: Option<u32>,
+}
+
+/// A function frame.
+pub struct Frame<'ctx, R: gimli::Reader> {
+    /// The DWARF unit offset corresponding to the DIE of the function.
+    pub dw_die_offset: Option<gimli::UnitOffset<R::Offset>>,
+    /// The name of the function.
+    pub function: Option<FunctionName<R>>,
+    /// The source location corresponding to this frame.
+    pub location: Option<Location<'ctx>>,
+}
+
+/// An iterator over function frames.
+pub struct FrameIter<'ctx, R>(FrameIterState<'ctx, R>)
+where
+    R: gimli::Reader;
+
+enum FrameIterState<'ctx, R>
+where
+    R: gimli::Reader,
+{
+    Empty,
+    Location(Option<Location<'ctx>>),
+    Frames(FrameIterFrames<'ctx, R>),
+}
+
+struct FrameIterFrames<'ctx, R>
+where
+    R: gimli::Reader,
+{
+    unit: &'ctx ResUnit<R>,
+    sections: &'ctx gimli::Dwarf<R>,
+    function: &'ctx Function<R>,
+    inlined_functions: iter::Rev<maybe_small::IntoIter<&'ctx InlinedFunction<R>>>,
+    next: Option<Location<'ctx>>,
+}
+
+impl<'ctx, R> FrameIter<'ctx, R>
+where
+    R: gimli::Reader + 'ctx,
+{
+    pub(crate) fn new_empty() -> Self {
+        FrameIter(FrameIterState::Empty)
+    }
+
+    pub(crate) fn new_location(location: Location<'ctx>) -> Self {
+        FrameIter(FrameIterState::Location(Some(location)))
+    }
+
+    pub(crate) fn new_frames(
+        unit: &'ctx ResUnit<R>,
+        sections: &'ctx gimli::Dwarf<R>,
+        function: &'ctx Function<R>,
+        inlined_functions: maybe_small::Vec<&'ctx InlinedFunction<R>>,
+        location: Option<Location<'ctx>>,
+    ) -> Self {
+        FrameIter(FrameIterState::Frames(FrameIterFrames {
+            unit,
+            sections,
+            function,
+            inlined_functions: inlined_functions.into_iter().rev(),
+            next: location,
+        }))
+    }
+
+    /// Advances the iterator and returns the next frame.
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Result<Option<Frame<'ctx, R>>, Error> {
+        let frames = match &mut self.0 {
+            FrameIterState::Empty => return Ok(None),
+            FrameIterState::Location(location) => {
+                // We can't move out of a mutable reference, so use `take` instead.
+                let location = location.take();
+                self.0 = FrameIterState::Empty;
+                return Ok(Some(Frame {
+                    dw_die_offset: None,
+                    function: None,
+                    location,
+                }));
+            }
+            FrameIterState::Frames(frames) => frames,
+        };
+
+        let loc = frames.next.take();
+        let func = match frames.inlined_functions.next() {
+            Some(func) => func,
+            None => {
+                let frame = Frame {
+                    dw_die_offset: Some(frames.function.dw_die_offset),
+                    function: frames.function.name.clone().map(|name| FunctionName {
+                        name,
+                        language: frames.unit.lang,
+                    }),
+                    location: loc,
+                };
+                self.0 = FrameIterState::Empty;
+                return Ok(Some(frame));
+            }
+        };
+
+        let mut next = Location {
+            file: None,
+            line: if func.call_line != 0 {
+                Some(func.call_line)
+            } else {
+                None
+            },
+            column: if func.call_column != 0 {
+                Some(func.call_column)
+            } else {
+                None
+            },
+        };
+        if let Some(call_file) = func.call_file {
+            if let Some(lines) = frames.unit.parse_lines(frames.sections)? {
+                next.file = lines.file(call_file);
+            }
+        }
+        frames.next = Some(next);
+
+        Ok(Some(Frame {
+            dw_die_offset: Some(func.dw_die_offset),
+            function: func.name.clone().map(|name| FunctionName {
+                name,
+                language: frames.unit.lang,
+            }),
+            location: loc,
+        }))
+    }
+}
+
+impl<'ctx, R> fallible_iterator::FallibleIterator for FrameIter<'ctx, R>
+where
+    R: gimli::Reader + 'ctx,
+{
+    type Item = Frame<'ctx, R>;
+    type Error = Error;
+
+    #[inline]
+    fn next(&mut self) -> Result<Option<Frame<'ctx, R>>, Error> {
+        self.next()
+    }
+}
+
+/// A function name.
+pub struct FunctionName<R: gimli::Reader> {
+    /// The name of the function.
+    pub name: R,
+    /// The language of the compilation unit containing this function.
+    pub language: Option<gimli::DwLang>,
+}

--- a/libs/addr2line/src/function.rs
+++ b/libs/addr2line/src/function.rs
@@ -1,0 +1,552 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+
+// use crate::lazy::LazyResult;
+use crate::{maybe_small, LazyResult};
+use crate::{Context, DebugFile, Error, RangeAttributes};
+
+pub(crate) struct LazyFunctions<R: gimli::Reader>(LazyResult<Functions<R>>);
+
+impl<R: gimli::Reader> LazyFunctions<R> {
+    pub(crate) fn new() -> Self {
+        LazyFunctions(LazyResult::new())
+    }
+
+    pub(crate) fn borrow(&self, unit: gimli::UnitRef<R>) -> Result<&Functions<R>, Error> {
+        self.0
+            .get_or_init(|| Functions::parse(unit))
+            .as_ref()
+            .map_err(Error::clone)
+    }
+}
+
+pub(crate) struct Functions<R: gimli::Reader> {
+    /// List of all `DW_TAG_subprogram` details in the unit.
+    pub(crate) functions: Box<[LazyFunction<R>]>,
+    /// List of `DW_TAG_subprogram` address ranges in the unit.
+    pub(crate) addresses: Box<[FunctionAddress]>,
+}
+
+/// A single address range for a function.
+///
+/// It is possible for a function to have multiple address ranges; this
+/// is handled by having multiple `FunctionAddress` entries with the same
+/// `function` field.
+pub(crate) struct FunctionAddress {
+    range: gimli::Range,
+    /// An index into `Functions::functions`.
+    pub(crate) function: usize,
+}
+
+pub(crate) struct LazyFunction<R: gimli::Reader> {
+    dw_die_offset: gimli::UnitOffset<R::Offset>,
+    lazy: LazyResult<Function<R>>,
+}
+
+impl<R: gimli::Reader> LazyFunction<R> {
+    fn new(dw_die_offset: gimli::UnitOffset<R::Offset>) -> Self {
+        LazyFunction {
+            dw_die_offset,
+            lazy: LazyResult::new(),
+        }
+    }
+
+    pub(crate) fn borrow(
+        &self,
+        file: DebugFile,
+        unit: gimli::UnitRef<R>,
+        ctx: &Context<R>,
+    ) -> Result<&Function<R>, Error> {
+        self.lazy
+            .get_or_init(|| Function::parse(self.dw_die_offset, file, unit, ctx))
+            .as_ref()
+            .map_err(Error::clone)
+    }
+}
+
+pub(crate) struct Function<R: gimli::Reader> {
+    pub(crate) dw_die_offset: gimli::UnitOffset<R::Offset>,
+    pub(crate) name: Option<R>,
+    /// List of all `DW_TAG_inlined_subroutine` details in this function.
+    inlined_functions: Box<[InlinedFunction<R>]>,
+    /// List of `DW_TAG_inlined_subroutine` address ranges in this function.
+    inlined_addresses: Box<[InlinedFunctionAddress]>,
+}
+
+pub(crate) struct InlinedFunctionAddress {
+    range: gimli::Range,
+    call_depth: usize,
+    /// An index into `Function::inlined_functions`.
+    function: usize,
+}
+
+pub(crate) struct InlinedFunction<R: gimli::Reader> {
+    pub(crate) dw_die_offset: gimli::UnitOffset<R::Offset>,
+    pub(crate) name: Option<R>,
+    pub(crate) call_file: Option<u64>,
+    pub(crate) call_line: u32,
+    pub(crate) call_column: u32,
+}
+
+impl<R: gimli::Reader> Functions<R> {
+    fn parse(unit: gimli::UnitRef<R>) -> Result<Functions<R>, Error> {
+        let mut functions = Vec::new();
+        let mut addresses = Vec::new();
+        let mut entries = unit.entries_raw(None)?;
+        while !entries.is_empty() {
+            let dw_die_offset = entries.next_offset();
+            if let Some(abbrev) = entries.read_abbreviation()? {
+                if abbrev.tag() == gimli::DW_TAG_subprogram {
+                    let mut ranges = RangeAttributes::default();
+                    for spec in abbrev.attributes() {
+                        match entries.read_attribute(*spec) {
+                            Ok(ref attr) => {
+                                match attr.name() {
+                                    gimli::DW_AT_low_pc => match attr.value() {
+                                        gimli::AttributeValue::Addr(val) => {
+                                            ranges.low_pc = Some(val)
+                                        }
+                                        gimli::AttributeValue::DebugAddrIndex(index) => {
+                                            ranges.low_pc = Some(unit.address(index)?);
+                                        }
+                                        _ => {}
+                                    },
+                                    gimli::DW_AT_high_pc => match attr.value() {
+                                        gimli::AttributeValue::Addr(val) => {
+                                            ranges.high_pc = Some(val)
+                                        }
+                                        gimli::AttributeValue::DebugAddrIndex(index) => {
+                                            ranges.high_pc = Some(unit.address(index)?);
+                                        }
+                                        gimli::AttributeValue::Udata(val) => {
+                                            ranges.size = Some(val)
+                                        }
+                                        _ => {}
+                                    },
+                                    gimli::DW_AT_ranges => {
+                                        ranges.ranges_offset =
+                                            unit.attr_ranges_offset(attr.value())?;
+                                    }
+                                    _ => {}
+                                };
+                            }
+                            Err(e) => return Err(e),
+                        }
+                    }
+
+                    let function_index = functions.len();
+                    let has_address = ranges.for_each_range(unit, |range| {
+                        addresses.push(FunctionAddress {
+                            range,
+                            function: function_index,
+                        });
+                    })?;
+                    if has_address {
+                        functions.push(LazyFunction::new(dw_die_offset));
+                    }
+                } else {
+                    entries.skip_attributes(abbrev.attributes())?;
+                }
+            }
+        }
+
+        // The binary search requires the addresses to be sorted.
+        //
+        // It also requires them to be non-overlapping.  In practice, overlapping
+        // function ranges are unlikely, so we don't try to handle that yet.
+        //
+        // It's possible for multiple functions to have the same address range if the
+        // compiler can detect and remove functions with identical code.  In that case
+        // we'll nondeterministically return one of them.
+        addresses.sort_by_key(|x| x.range.begin);
+
+        Ok(Functions {
+            functions: functions.into_boxed_slice(),
+            addresses: addresses.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn find_address(&self, probe: u64) -> Option<usize> {
+        self.addresses
+            .binary_search_by(|address| {
+                if probe < address.range.begin {
+                    Ordering::Greater
+                } else if probe >= address.range.end {
+                    Ordering::Less
+                } else {
+                    Ordering::Equal
+                }
+            })
+            .ok()
+    }
+}
+
+impl<R: gimli::Reader> Function<R> {
+    fn parse(
+        dw_die_offset: gimli::UnitOffset<R::Offset>,
+        file: DebugFile,
+        unit: gimli::UnitRef<R>,
+        ctx: &Context<R>,
+    ) -> Result<Self, Error> {
+        let mut entries = unit.entries_raw(Some(dw_die_offset))?;
+        let depth = entries.next_depth();
+        let abbrev = entries.read_abbreviation()?.unwrap();
+        debug_assert_eq!(abbrev.tag(), gimli::DW_TAG_subprogram);
+
+        let mut name = None;
+        for spec in abbrev.attributes() {
+            match entries.read_attribute(*spec) {
+                Ok(ref attr) => {
+                    match attr.name() {
+                        gimli::DW_AT_linkage_name | gimli::DW_AT_MIPS_linkage_name => {
+                            if let Ok(val) = unit.attr_string(attr.value()) {
+                                name = Some(val);
+                            }
+                        }
+                        gimli::DW_AT_name => {
+                            if name.is_none() {
+                                name = unit.attr_string(attr.value()).ok();
+                            }
+                        }
+                        gimli::DW_AT_abstract_origin | gimli::DW_AT_specification => {
+                            if name.is_none() {
+                                name = name_attr(attr.value(), file, unit, ctx, 16)?;
+                            }
+                        }
+                        _ => {}
+                    };
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        let mut state = InlinedState {
+            entries,
+            functions: Vec::new(),
+            addresses: Vec::new(),
+            file,
+            unit,
+            ctx,
+        };
+        Function::parse_children(&mut state, depth, 0)?;
+
+        // Sort ranges in "breadth-first traversal order", i.e. first by call_depth
+        // and then by range.begin. This allows finding the range containing an
+        // address at a certain depth using binary search.
+        // Note: Using DFS order, i.e. ordering by range.begin first and then by
+        // call_depth, would not work! Consider the two examples
+        // "[0..10 at depth 0], [0..2 at depth 1], [6..8 at depth 1]"  and
+        // "[0..5 at depth 0], [0..2 at depth 1], [5..10 at depth 0], [6..8 at depth 1]".
+        // In this example, if you want to look up address 7 at depth 0, and you
+        // encounter [0..2 at depth 1], are you before or after the target range?
+        // You don't know.
+        state.addresses.sort_by(|r1, r2| {
+            if r1.call_depth < r2.call_depth {
+                Ordering::Less
+            } else if r1.call_depth > r2.call_depth {
+                Ordering::Greater
+            } else if r1.range.begin < r2.range.begin {
+                Ordering::Less
+            } else if r1.range.begin > r2.range.begin {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            }
+        });
+
+        Ok(Function {
+            dw_die_offset,
+            name,
+            inlined_functions: state.functions.into_boxed_slice(),
+            inlined_addresses: state.addresses.into_boxed_slice(),
+        })
+    }
+
+    fn parse_children(
+        state: &mut InlinedState<R>,
+        depth: isize,
+        inlined_depth: usize,
+    ) -> Result<(), Error> {
+        loop {
+            let dw_die_offset = state.entries.next_offset();
+            let next_depth = state.entries.next_depth();
+            if next_depth <= depth {
+                return Ok(());
+            }
+            if let Some(abbrev) = state.entries.read_abbreviation()? {
+                match abbrev.tag() {
+                    gimli::DW_TAG_subprogram => {
+                        Function::skip(&mut state.entries, abbrev, next_depth)?;
+                    }
+                    gimli::DW_TAG_inlined_subroutine => {
+                        InlinedFunction::parse(
+                            state,
+                            dw_die_offset,
+                            abbrev,
+                            next_depth,
+                            inlined_depth,
+                        )?;
+                    }
+                    _ => {
+                        state.entries.skip_attributes(abbrev.attributes())?;
+                    }
+                }
+            }
+        }
+    }
+
+    fn skip(
+        entries: &mut gimli::EntriesRaw<'_, '_, R>,
+        abbrev: &gimli::Abbreviation,
+        depth: isize,
+    ) -> Result<(), Error> {
+        // TODO: use DW_AT_sibling
+        entries.skip_attributes(abbrev.attributes())?;
+        while entries.next_depth() > depth {
+            if let Some(abbrev) = entries.read_abbreviation()? {
+                entries.skip_attributes(abbrev.attributes())?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Build the list of inlined functions that contain `probe`.
+    pub(crate) fn find_inlined_functions(
+        &self,
+        probe: u64,
+    ) -> maybe_small::Vec<&InlinedFunction<R>> {
+        // `inlined_functions` is ordered from outside to inside.
+        let mut inlined_functions = maybe_small::Vec::new();
+        let mut inlined_addresses = &self.inlined_addresses[..];
+        loop {
+            let current_depth = inlined_functions.len();
+            // Look up (probe, current_depth) in inline_ranges.
+            // `inlined_addresses` is sorted in "breadth-first traversal order", i.e.
+            // by `call_depth` first, and then by `range.begin`. See the comment at
+            // the sort call for more information about why.
+            let search = inlined_addresses.binary_search_by(|range| {
+                if range.call_depth > current_depth {
+                    Ordering::Greater
+                } else if range.call_depth < current_depth {
+                    Ordering::Less
+                } else if range.range.begin > probe {
+                    Ordering::Greater
+                } else if range.range.end <= probe {
+                    Ordering::Less
+                } else {
+                    Ordering::Equal
+                }
+            });
+            if let Ok(index) = search {
+                let function_index = inlined_addresses[index].function;
+                inlined_functions.push(&self.inlined_functions[function_index]);
+                inlined_addresses = &inlined_addresses[index + 1..];
+            } else {
+                break;
+            }
+        }
+        inlined_functions
+    }
+}
+
+impl<R: gimli::Reader> InlinedFunction<R> {
+    fn parse(
+        state: &mut InlinedState<R>,
+        dw_die_offset: gimli::UnitOffset<R::Offset>,
+        abbrev: &gimli::Abbreviation,
+        depth: isize,
+        inlined_depth: usize,
+    ) -> Result<(), Error> {
+        let unit = state.unit;
+        let mut ranges = RangeAttributes::default();
+        let mut name = None;
+        let mut call_file = None;
+        let mut call_line = 0;
+        let mut call_column = 0;
+        for spec in abbrev.attributes() {
+            match state.entries.read_attribute(*spec) {
+                Ok(ref attr) => match attr.name() {
+                    gimli::DW_AT_low_pc => match attr.value() {
+                        gimli::AttributeValue::Addr(val) => ranges.low_pc = Some(val),
+                        gimli::AttributeValue::DebugAddrIndex(index) => {
+                            ranges.low_pc = Some(unit.address(index)?);
+                        }
+                        _ => {}
+                    },
+                    gimli::DW_AT_high_pc => match attr.value() {
+                        gimli::AttributeValue::Addr(val) => ranges.high_pc = Some(val),
+                        gimli::AttributeValue::DebugAddrIndex(index) => {
+                            ranges.high_pc = Some(unit.address(index)?);
+                        }
+                        gimli::AttributeValue::Udata(val) => ranges.size = Some(val),
+                        _ => {}
+                    },
+                    gimli::DW_AT_ranges => {
+                        ranges.ranges_offset = unit.attr_ranges_offset(attr.value())?;
+                    }
+                    gimli::DW_AT_linkage_name | gimli::DW_AT_MIPS_linkage_name => {
+                        if let Ok(val) = unit.attr_string(attr.value()) {
+                            name = Some(val);
+                        }
+                    }
+                    gimli::DW_AT_name => {
+                        if name.is_none() {
+                            name = unit.attr_string(attr.value()).ok();
+                        }
+                    }
+                    gimli::DW_AT_abstract_origin | gimli::DW_AT_specification => {
+                        if name.is_none() {
+                            name = name_attr(attr.value(), state.file, unit, state.ctx, 16)?;
+                        }
+                    }
+                    gimli::DW_AT_call_file => {
+                        // There is a spec issue [1] with how DW_AT_call_file is specified in DWARF 5.
+                        // Before, a file index of 0 would indicate no source file, however in
+                        // DWARF 5 this could be a valid index into the file table.
+                        //
+                        // Implementations such as LLVM generates a file index of 0 when DWARF 5 is
+                        // used.
+                        //
+                        // Thus, if we see a version of 5 or later, treat a file index of 0 as such.
+                        // [1]: http://wiki.dwarfstd.org/index.php?title=DWARF5_Line_Table_File_Numbers
+                        if let gimli::AttributeValue::FileIndex(fi) = attr.value() {
+                            if fi > 0 || unit.header.version() >= 5 {
+                                call_file = Some(fi);
+                            }
+                        }
+                    }
+                    gimli::DW_AT_call_line => {
+                        call_line = attr.udata_value().unwrap_or(0) as u32;
+                    }
+                    gimli::DW_AT_call_column => {
+                        call_column = attr.udata_value().unwrap_or(0) as u32;
+                    }
+                    _ => {}
+                },
+                Err(e) => return Err(e),
+            }
+        }
+
+        let function_index = state.functions.len();
+        state.functions.push(InlinedFunction {
+            dw_die_offset,
+            name,
+            call_file,
+            call_line,
+            call_column,
+        });
+
+        ranges.for_each_range(unit, |range| {
+            state.addresses.push(InlinedFunctionAddress {
+                range,
+                call_depth: inlined_depth,
+                function: function_index,
+            });
+        })?;
+
+        Function::parse_children(state, depth, inlined_depth + 1)
+    }
+}
+
+struct InlinedState<'a, R: gimli::Reader> {
+    // Mutable fields.
+    entries: gimli::EntriesRaw<'a, 'a, R>,
+    functions: Vec<InlinedFunction<R>>,
+    addresses: Vec<InlinedFunctionAddress>,
+
+    // Constant fields.
+    file: DebugFile,
+    unit: gimli::UnitRef<'a, R>,
+    ctx: &'a Context<R>,
+}
+
+fn name_attr<R>(
+    attr: gimli::AttributeValue<R>,
+    mut file: DebugFile,
+    unit: gimli::UnitRef<R>,
+    ctx: &Context<R>,
+    recursion_limit: usize,
+) -> Result<Option<R>, Error>
+where
+    R: gimli::Reader,
+{
+    if recursion_limit == 0 {
+        return Ok(None);
+    }
+
+    match attr {
+        gimli::AttributeValue::UnitRef(offset) => {
+            name_entry(file, unit, offset, ctx, recursion_limit)
+        }
+        gimli::AttributeValue::DebugInfoRef(dr) => {
+            let sections = unit.dwarf;
+            let (unit, offset) = ctx.find_unit(dr, file)?;
+            let unit = gimli::UnitRef::new(sections, unit);
+            name_entry(file, unit, offset, ctx, recursion_limit)
+        }
+        gimli::AttributeValue::DebugInfoRefSup(dr) => {
+            if let Some(sup_sections) = unit.dwarf.sup.as_ref() {
+                file = DebugFile::Supplementary;
+                let (unit, offset) = ctx.find_unit(dr, file)?;
+                let unit = gimli::UnitRef::new(sup_sections, unit);
+                name_entry(file, unit, offset, ctx, recursion_limit)
+            } else {
+                Ok(None)
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
+fn name_entry<R>(
+    file: DebugFile,
+    unit: gimli::UnitRef<R>,
+    offset: gimli::UnitOffset<R::Offset>,
+    ctx: &Context<R>,
+    recursion_limit: usize,
+) -> Result<Option<R>, Error>
+where
+    R: gimli::Reader,
+{
+    let mut entries = unit.entries_raw(Some(offset))?;
+    let abbrev = if let Some(abbrev) = entries.read_abbreviation()? {
+        abbrev
+    } else {
+        return Err(gimli::Error::NoEntryAtGivenOffset);
+    };
+
+    let mut name = None;
+    let mut next = None;
+    for spec in abbrev.attributes() {
+        match entries.read_attribute(*spec) {
+            Ok(ref attr) => match attr.name() {
+                gimli::DW_AT_linkage_name | gimli::DW_AT_MIPS_linkage_name => {
+                    if let Ok(val) = unit.attr_string(attr.value()) {
+                        return Ok(Some(val));
+                    }
+                }
+                gimli::DW_AT_name => {
+                    if let Ok(val) = unit.attr_string(attr.value()) {
+                        name = Some(val);
+                    }
+                }
+                gimli::DW_AT_abstract_origin | gimli::DW_AT_specification => {
+                    next = Some(attr.value());
+                }
+                _ => {}
+            },
+            Err(e) => return Err(e),
+        }
+    }
+
+    if name.is_some() {
+        return Ok(name);
+    }
+
+    if let Some(next) = next {
+        return name_attr(next, file, unit, ctx, recursion_limit - 1);
+    }
+
+    Ok(None)
+}

--- a/libs/addr2line/src/lazy.rs
+++ b/libs/addr2line/src/lazy.rs
@@ -1,0 +1,34 @@
+use core::cell::UnsafeCell;
+
+pub(crate) type LazyResult<T> = LazyCell<Result<T, crate::Error>>;
+
+pub(crate) struct LazyCell<T> {
+    contents: UnsafeCell<Option<T>>,
+}
+
+impl<T> LazyCell<T> {
+    pub(crate) fn new() -> LazyCell<T> {
+        LazyCell {
+            contents: UnsafeCell::new(None),
+        }
+    }
+
+    pub(crate) fn borrow(&self) -> Option<&T> {
+        unsafe { &*self.contents.get() }.as_ref()
+    }
+
+    pub(crate) fn borrow_with(&self, closure: impl FnOnce() -> T) -> &T {
+        // First check if we're already initialized...
+        let ptr = self.contents.get();
+        if let Some(val) = unsafe { &*ptr } {
+            return val;
+        }
+        // Note that while we're executing `closure` our `borrow_with` may
+        // be called recursively. This means we need to check again after
+        // the closure has executed. For that we use the `get_or_insert`
+        // method which will only perform mutation if we aren't already
+        // `Some`.
+        let val = closure();
+        unsafe { (*ptr).get_or_insert(val) }
+    }
+}

--- a/libs/addr2line/src/lib.rs
+++ b/libs/addr2line/src/lib.rs
@@ -1,0 +1,275 @@
+//! `addr2line` provides a cross-platform library for retrieving per-address debug information
+//! from files with DWARF debug information. Given an address, it can return the file name,
+//! line number, and function name associated with that address, as well as the inline call
+//! stack leading to that address.
+//!
+//! At the lowest level, the library uses a [`Context`] to cache parsed information so that
+//! multiple lookups are efficient. To create a `Context`, you first need to open and parse the
+//! file using an object file parser such as [`object`](https://github.com/gimli-rs/object),
+//! create a [`gimli::Dwarf`], and finally call [`Context::from_dwarf`].
+//!
+//! Location information is obtained with [`Context::find_location`] or
+//! [`Context::find_location_range`]. Function information is obtained with
+//! [`Context::find_frames`], which returns a frame for each inline function. Each frame
+//! contains both name and location.
+#![deny(missing_docs)]
+#![no_std]
+
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
+
+use alloc::sync::Arc;
+use core::ops::ControlFlow;
+
+use crate::function::{Function, InlinedFunction, LazyFunctions};
+use crate::line::{LazyLines, LineLocationRangeIter, Lines};
+use crate::lookup::{LoopingLookup, SimpleLookup};
+use crate::unit::{ResUnit, ResUnits, SupUnits};
+
+mod maybe_small {
+    pub type Vec<T> = smallvec::SmallVec<[T; 16]>;
+    pub type IntoIter<T> = smallvec::IntoIter<[T; 16]>;
+}
+
+mod frame;
+pub use frame::{Frame, FrameIter, FunctionName, Location};
+
+mod function;
+// mod lazy;
+mod line;
+
+mod lookup;
+pub use lookup::{LookupContinuation, LookupResult, SplitDwarfLoad};
+use sync::OnceLock;
+
+mod unit;
+pub use unit::LocationRangeIter;
+
+type Error = gimli::Error;
+
+pub(crate) type LazyResult<T> = OnceLock<Result<T, Error>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DebugFile {
+    Primary,
+    Supplementary,
+    Dwo,
+}
+
+/// The state necessary to perform address to line translation.
+///
+/// Constructing a `Context` is somewhat costly, so users should aim to reuse `Context`s
+/// when performing lookups for many addresses in the same executable.
+pub struct Context<R: gimli::Reader> {
+    sections: Arc<gimli::Dwarf<R>>,
+    units: ResUnits<R>,
+    sup_units: SupUnits<R>,
+}
+
+impl<R: gimli::Reader> Context<R> {
+    /// Construct a new `Context` from DWARF sections.
+    ///
+    /// This method does not support using a supplementary object file.
+    #[allow(clippy::too_many_arguments)]
+    pub fn from_sections(
+        debug_abbrev: gimli::DebugAbbrev<R>,
+        debug_addr: gimli::DebugAddr<R>,
+        debug_aranges: gimli::DebugAranges<R>,
+        debug_info: gimli::DebugInfo<R>,
+        debug_line: gimli::DebugLine<R>,
+        debug_line_str: gimli::DebugLineStr<R>,
+        debug_ranges: gimli::DebugRanges<R>,
+        debug_rnglists: gimli::DebugRngLists<R>,
+        debug_str: gimli::DebugStr<R>,
+        debug_str_offsets: gimli::DebugStrOffsets<R>,
+        default_section: R,
+    ) -> Result<Self, Error> {
+        Self::from_dwarf(gimli::Dwarf {
+            debug_abbrev,
+            debug_addr,
+            debug_aranges,
+            debug_info,
+            debug_line,
+            debug_line_str,
+            debug_str,
+            debug_str_offsets,
+            debug_types: default_section.clone().into(),
+            locations: gimli::LocationLists::new(
+                default_section.clone().into(),
+                default_section.into(),
+            ),
+            ranges: gimli::RangeLists::new(debug_ranges, debug_rnglists),
+            file_type: gimli::DwarfFileType::Main,
+            sup: None,
+            abbreviations_cache: gimli::AbbreviationsCache::new(),
+        })
+    }
+
+    /// Construct a new `Context` from an existing [`gimli::Dwarf`] object.
+    #[inline]
+    pub fn from_dwarf(sections: gimli::Dwarf<R>) -> Result<Context<R>, Error> {
+        Self::from_arc_dwarf(Arc::new(sections))
+    }
+
+    /// Construct a new `Context` from an existing [`gimli::Dwarf`] object.
+    #[inline]
+    pub fn from_arc_dwarf(sections: Arc<gimli::Dwarf<R>>) -> Result<Context<R>, Error> {
+        let units = ResUnits::parse(&sections)?;
+        let sup_units = if let Some(sup) = sections.sup.as_ref() {
+            SupUnits::parse(sup)?
+        } else {
+            SupUnits::default()
+        };
+        Ok(Context {
+            sections,
+            units,
+            sup_units,
+        })
+    }
+}
+
+impl<R: gimli::Reader> Context<R> {
+    /// Find the source file and line corresponding to the given virtual memory address.
+    pub fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, Error> {
+        for unit in self.units.find(probe) {
+            if let Some(location) = unit.find_location(probe, &self.sections)? {
+                return Ok(Some(location));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Return source file and lines for a range of addresses. For each location it also
+    /// returns the address and size of the range of the underlying instructions.
+    pub fn find_location_range(
+        &self,
+        probe_low: u64,
+        probe_high: u64,
+    ) -> Result<LocationRangeIter<'_, R>, Error> {
+        self.units
+            .find_location_range(probe_low, probe_high, &self.sections)
+    }
+
+    /// Return an iterator for the function frames corresponding to the given virtual
+    /// memory address.
+    ///
+    /// If the probe address is not for an inline function then only one frame is
+    /// returned.
+    ///
+    /// If the probe address is for an inline function then the first frame corresponds
+    /// to the innermost inline function.  Subsequent frames contain the caller and call
+    /// location, until an non-inline caller is reached.
+    pub fn find_frames(
+        &self,
+        probe: u64,
+    ) -> LookupResult<impl LookupContinuation<Output = Result<FrameIter<'_, R>, Error>, Buf = R>>
+    {
+        let mut units_iter = self.units.find(probe);
+        if let Some(unit) = units_iter.next() {
+            LoopingLookup::new_lookup(unit.find_function_or_location(probe, self), move |r| {
+                ControlFlow::Break(match r {
+                    Err(e) => Err(e),
+                    Ok((Some(function), location)) => {
+                        let inlined_functions = function.find_inlined_functions(probe);
+                        Ok(FrameIter::new_frames(
+                            unit,
+                            &self.sections,
+                            function,
+                            inlined_functions,
+                            location,
+                        ))
+                    }
+                    Ok((None, Some(location))) => Ok(FrameIter::new_location(location)),
+                    Ok((None, None)) => match units_iter.next() {
+                        Some(next_unit) => {
+                            return ControlFlow::Continue(
+                                next_unit.find_function_or_location(probe, self),
+                            );
+                        }
+                        None => Ok(FrameIter::new_empty()),
+                    },
+                })
+            })
+        } else {
+            LoopingLookup::new_complete(Ok(FrameIter::new_empty()))
+        }
+    }
+}
+
+impl<R: gimli::Reader> Context<R> {
+    // Find the unit containing the given offset, and convert the offset into a unit offset.
+    fn find_unit(
+        &self,
+        offset: gimli::DebugInfoOffset<R::Offset>,
+        file: DebugFile,
+    ) -> Result<(&gimli::Unit<R>, gimli::UnitOffset<R::Offset>), Error> {
+        let unit = match file {
+            DebugFile::Primary => self.units.find_offset(offset)?,
+            DebugFile::Supplementary => self.sup_units.find_offset(offset)?,
+            DebugFile::Dwo => return Err(gimli::Error::NoEntryAtGivenOffset),
+        };
+
+        let unit_offset = offset
+            .to_unit_offset(&unit.header)
+            .ok_or(gimli::Error::NoEntryAtGivenOffset)?;
+        Ok((unit, unit_offset))
+    }
+}
+
+struct RangeAttributes<R: gimli::Reader> {
+    low_pc: Option<u64>,
+    high_pc: Option<u64>,
+    size: Option<u64>,
+    ranges_offset: Option<gimli::RangeListsOffset<<R as gimli::Reader>::Offset>>,
+}
+
+impl<R: gimli::Reader> Default for RangeAttributes<R> {
+    fn default() -> Self {
+        RangeAttributes {
+            low_pc: None,
+            high_pc: None,
+            size: None,
+            ranges_offset: None,
+        }
+    }
+}
+
+impl<R: gimli::Reader> RangeAttributes<R> {
+    fn for_each_range<F: FnMut(gimli::Range)>(
+        &self,
+        unit: gimli::UnitRef<R>,
+        mut f: F,
+    ) -> Result<bool, Error> {
+        let mut added_any = false;
+        let mut add_range = |range: gimli::Range| {
+            if range.begin < range.end {
+                f(range);
+                added_any = true
+            }
+        };
+        if let Some(ranges_offset) = self.ranges_offset {
+            let mut range_list = unit.ranges(ranges_offset)?;
+            while let Some(range) = range_list.next()? {
+                add_range(range);
+            }
+        } else if let (Some(begin), Some(end)) = (self.low_pc, self.high_pc) {
+            add_range(gimli::Range { begin, end });
+        } else if let (Some(begin), Some(size)) = (self.low_pc, self.size) {
+            // If `begin` is a -1 tombstone, this will overflow and the check in
+            // `add_range` will ignore it.
+            let end = begin.wrapping_add(size);
+            add_range(gimli::Range { begin, end });
+        }
+        Ok(added_any)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn context_is_send() {
+        fn assert_is_send<T: Send>() {}
+        assert_is_send::<crate::Context<gimli::read::EndianSlice<'_, gimli::LittleEndian>>>();
+    }
+}

--- a/libs/addr2line/src/line.rs
+++ b/libs/addr2line/src/line.rs
@@ -1,0 +1,313 @@
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::cmp::Ordering;
+use core::mem;
+use core::num::NonZeroU64;
+
+use crate::{Error, LazyResult, Location};
+
+pub(crate) struct LazyLines(LazyResult<Lines>);
+
+impl LazyLines {
+    pub(crate) fn new() -> Self {
+        LazyLines(LazyResult::new())
+    }
+
+    pub(crate) fn borrow<R: gimli::Reader>(
+        &self,
+        dw_unit: gimli::UnitRef<R>,
+        ilnp: &gimli::IncompleteLineProgram<R, R::Offset>,
+    ) -> Result<&Lines, Error> {
+        self.0
+            .get_or_init(|| Lines::parse(dw_unit, ilnp.clone()))
+            .as_ref()
+            .map_err(Error::clone)
+    }
+}
+
+struct LineSequence {
+    start: u64,
+    end: u64,
+    rows: Box<[LineRow]>,
+}
+
+struct LineRow {
+    address: u64,
+    file_index: u64,
+    line: u32,
+    column: u32,
+}
+
+pub(crate) struct Lines {
+    files: Box<[String]>,
+    sequences: Box<[LineSequence]>,
+}
+
+impl Lines {
+    fn parse<R: gimli::Reader>(
+        dw_unit: gimli::UnitRef<R>,
+        ilnp: gimli::IncompleteLineProgram<R, R::Offset>,
+    ) -> Result<Self, Error> {
+        let mut sequences = Vec::new();
+        let mut sequence_rows = Vec::<LineRow>::new();
+        let mut rows = ilnp.rows();
+        while let Some((_, row)) = rows.next_row()? {
+            if row.end_sequence() {
+                if let Some(start) = sequence_rows.first().map(|x| x.address) {
+                    let end = row.address();
+                    let mut rows = Vec::new();
+                    mem::swap(&mut rows, &mut sequence_rows);
+                    sequences.push(LineSequence {
+                        start,
+                        end,
+                        rows: rows.into_boxed_slice(),
+                    });
+                }
+                continue;
+            }
+
+            let address = row.address();
+            let file_index = row.file_index();
+            // Convert line and column to u32 to save a little memory.
+            // We'll handle the special case of line 0 later,
+            // and return left edge as column 0 in the public API.
+            let line = row.line().map(NonZeroU64::get).unwrap_or(0) as u32;
+            let column = match row.column() {
+                gimli::ColumnType::LeftEdge => 0,
+                gimli::ColumnType::Column(x) => x.get() as u32,
+            };
+
+            if let Some(last_row) = sequence_rows.last_mut() {
+                if last_row.address == address {
+                    last_row.file_index = file_index;
+                    last_row.line = line;
+                    last_row.column = column;
+                    continue;
+                }
+            }
+
+            sequence_rows.push(LineRow {
+                address,
+                file_index,
+                line,
+                column,
+            });
+        }
+        sequences.sort_by_key(|x| x.start);
+
+        let mut files = Vec::new();
+        let header = rows.header();
+        match header.file(0) {
+            Some(file) => files.push(render_file(dw_unit, file, header)?),
+            None => files.push(String::from("")), // DWARF version <= 4 may not have 0th index
+        }
+        let mut index = 1;
+        while let Some(file) = header.file(index) {
+            files.push(render_file(dw_unit, file, header)?);
+            index += 1;
+        }
+
+        Ok(Self {
+            files: files.into_boxed_slice(),
+            sequences: sequences.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn file(&self, index: u64) -> Option<&str> {
+        self.files.get(index as usize).map(String::as_str)
+    }
+
+    pub(crate) fn ranges(&self) -> impl Iterator<Item = gimli::Range> + '_ {
+        self.sequences.iter().map(|sequence| gimli::Range {
+            begin: sequence.start,
+            end: sequence.end,
+        })
+    }
+
+    fn row_location(&self, row: &LineRow) -> Location<'_> {
+        let file = self.files.get(row.file_index as usize).map(String::as_str);
+        Location {
+            file,
+            line: if row.line != 0 { Some(row.line) } else { None },
+            // If row.line is specified then row.column always has meaning.
+            column: if row.line != 0 {
+                Some(row.column)
+            } else {
+                None
+            },
+        }
+    }
+
+    pub(crate) fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, Error> {
+        let seq_idx = self.sequences.binary_search_by(|sequence| {
+            if probe < sequence.start {
+                Ordering::Greater
+            } else if probe >= sequence.end {
+                Ordering::Less
+            } else {
+                Ordering::Equal
+            }
+        });
+        let seq_idx = match seq_idx {
+            Ok(x) => x,
+            Err(_) => return Ok(None),
+        };
+        let sequence = &self.sequences[seq_idx];
+
+        let idx = sequence
+            .rows
+            .binary_search_by(|row| row.address.cmp(&probe));
+        let idx = match idx {
+            Ok(x) => x,
+            Err(0) => return Ok(None),
+            Err(x) => x - 1,
+        };
+        Ok(Some(self.row_location(&sequence.rows[idx])))
+    }
+
+    pub(crate) fn find_location_range(
+        &self,
+        probe_low: u64,
+        probe_high: u64,
+    ) -> Result<LineLocationRangeIter<'_>, Error> {
+        // Find index for probe_low.
+        let seq_idx = self.sequences.binary_search_by(|sequence| {
+            if probe_low < sequence.start {
+                Ordering::Greater
+            } else if probe_low >= sequence.end {
+                Ordering::Less
+            } else {
+                Ordering::Equal
+            }
+        });
+        let seq_idx = match seq_idx {
+            Ok(x) => x,
+            Err(x) => x, // probe below sequence, but range could overlap
+        };
+
+        let row_idx = if let Some(seq) = self.sequences.get(seq_idx) {
+            let idx = seq.rows.binary_search_by(|row| row.address.cmp(&probe_low));
+            match idx {
+                Ok(x) => x,
+                Err(0) => 0, // probe below sequence, but range could overlap
+                Err(x) => x - 1,
+            }
+        } else {
+            0
+        };
+
+        Ok(LineLocationRangeIter {
+            lines: self,
+            seq_idx,
+            row_idx,
+            probe_high,
+        })
+    }
+}
+
+pub(crate) struct LineLocationRangeIter<'ctx> {
+    lines: &'ctx Lines,
+    seq_idx: usize,
+    row_idx: usize,
+    probe_high: u64,
+}
+
+impl<'ctx> Iterator for LineLocationRangeIter<'ctx> {
+    type Item = (u64, u64, Location<'ctx>);
+
+    fn next(&mut self) -> Option<(u64, u64, Location<'ctx>)> {
+        while let Some(seq) = self.lines.sequences.get(self.seq_idx) {
+            if seq.start >= self.probe_high {
+                break;
+            }
+
+            match seq.rows.get(self.row_idx) {
+                Some(row) => {
+                    if row.address >= self.probe_high {
+                        break;
+                    }
+
+                    let nextaddr = seq
+                        .rows
+                        .get(self.row_idx + 1)
+                        .map(|row| row.address)
+                        .unwrap_or(seq.end);
+
+                    let item = (
+                        row.address,
+                        nextaddr - row.address,
+                        self.lines.row_location(row),
+                    );
+                    self.row_idx += 1;
+
+                    return Some(item);
+                }
+                None => {
+                    self.seq_idx += 1;
+                    self.row_idx = 0;
+                }
+            }
+        }
+        None
+    }
+}
+
+fn render_file<R: gimli::Reader>(
+    dw_unit: gimli::UnitRef<R>,
+    file: &gimli::FileEntry<R, R::Offset>,
+    header: &gimli::LineProgramHeader<R, R::Offset>,
+) -> Result<String, gimli::Error> {
+    let mut path = if let Some(ref comp_dir) = dw_unit.comp_dir {
+        comp_dir.to_string_lossy()?.into_owned()
+    } else {
+        String::new()
+    };
+
+    // The directory index 0 is defined to correspond to the compilation unit directory.
+    if file.directory_index() != 0 {
+        if let Some(directory) = file.directory(header) {
+            path_push(
+                &mut path,
+                dw_unit.attr_string(directory)?.to_string_lossy()?.as_ref(),
+            );
+        }
+    }
+
+    path_push(
+        &mut path,
+        dw_unit
+            .attr_string(file.path_name())?
+            .to_string_lossy()?
+            .as_ref(),
+    );
+
+    Ok(path)
+}
+
+fn path_push(path: &mut String, p: &str) {
+    if has_unix_root(p) || has_windows_root(p) {
+        *path = p.to_string();
+    } else {
+        let dir_separator = if has_windows_root(path.as_str()) {
+            '\\'
+        } else {
+            '/'
+        };
+
+        if !path.is_empty() && !path.ends_with(dir_separator) {
+            path.push(dir_separator);
+        }
+        *path += p;
+    }
+}
+
+/// Check if the path in the given string has a unix style root
+fn has_unix_root(p: &str) -> bool {
+    p.starts_with('/')
+}
+
+/// Check if the path in the given string has a windows style root
+fn has_windows_root(p: &str) -> bool {
+    p.starts_with('\\') || p.get(1..3) == Some(":\\")
+}

--- a/libs/addr2line/src/lookup.rs
+++ b/libs/addr2line/src/lookup.rs
@@ -1,0 +1,254 @@
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use core::ops::ControlFlow;
+
+/// This struct contains the information needed to find split DWARF data
+/// and to produce a `gimli::Dwarf<R>` for it.
+pub struct SplitDwarfLoad<R> {
+    /// The dwo id, for looking up in a DWARF package, or for
+    /// verifying an unpacked dwo found on the file system
+    pub dwo_id: gimli::DwoId,
+    /// The compilation directory `path` is relative to.
+    pub comp_dir: Option<R>,
+    /// A path on the filesystem, relative to `comp_dir` to find this dwo.
+    pub path: Option<R>,
+    /// Once the split DWARF data is loaded, the loader is expected
+    /// to call [make_dwo(parent)](gimli::read::Dwarf::make_dwo) before
+    /// returning the data.
+    pub parent: Arc<gimli::Dwarf<R>>,
+}
+
+/// Operations that consult debug information may require additional files
+/// to be loaded if split DWARF is being used. This enum returns the result
+/// of the operation in the `Output` variant, or information about the split
+/// DWARF that is required and a continuation to invoke once it is available
+/// in the `Load` variant.
+///
+/// This enum is intended to be used in a loop like so:
+/// ```no_run
+///   # use addr2line::*;
+///   # use std::sync::Arc;
+///   # let ctx: Context<gimli::EndianSlice<gimli::RunTimeEndian>> = todo!();
+///   # let do_split_dwarf_load = |load: SplitDwarfLoad<gimli::EndianSlice<gimli::RunTimeEndian>>| -> Option<Arc<gimli::Dwarf<gimli::EndianSlice<gimli::RunTimeEndian>>>> { None };
+///   const ADDRESS: u64 = 0xdeadbeef;
+///   let mut r = ctx.find_frames(ADDRESS);
+///   let result = loop {
+///     match r {
+///       LookupResult::Output(result) => break result,
+///       LookupResult::Load { load, continuation } => {
+///         let dwo = do_split_dwarf_load(load);
+///         r = continuation.resume(dwo);
+///       }
+///     }
+///   };
+/// ```
+pub enum LookupResult<L: LookupContinuation> {
+    /// The lookup requires split DWARF data to be loaded.
+    Load {
+        /// The information needed to find the split DWARF data.
+        load: SplitDwarfLoad<<L as LookupContinuation>::Buf>,
+        /// The continuation to resume with the loaded split DWARF data.
+        continuation: L,
+    },
+    /// The lookup has completed and produced an output.
+    Output(<L as LookupContinuation>::Output),
+}
+
+/// This trait represents a partially complete operation that can be resumed
+/// once a load of needed split DWARF data is completed or abandoned by the
+/// API consumer.
+pub trait LookupContinuation: Sized {
+    /// The final output of this operation.
+    type Output;
+    /// The type of reader used.
+    type Buf: gimli::Reader;
+
+    /// Resumes the operation with the provided data.
+    ///
+    /// After the caller loads the split DWARF data required, call this
+    /// method to resume the operation. The return value of this method
+    /// indicates if the computation has completed or if further data is
+    /// required.
+    ///
+    /// If the additional data cannot be located, or the caller does not
+    /// support split DWARF, `resume(None)` can be used to continue the
+    /// operation with the data that is available.
+    fn resume(self, input: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self>;
+}
+
+impl<L: LookupContinuation> LookupResult<L> {
+    /// Callers that do not handle split DWARF can call `skip_all_loads`
+    /// to fast-forward to the end result. This result is produced with
+    /// the data that is available and may be less accurate than the
+    /// the results that would be produced if the caller did properly
+    /// support split DWARF.
+    pub fn skip_all_loads(mut self) -> L::Output {
+        loop {
+            self = match self {
+                LookupResult::Output(t) => return t,
+                LookupResult::Load { continuation, .. } => continuation.resume(None),
+            };
+        }
+    }
+
+    pub(crate) fn map<T, F: FnOnce(L::Output) -> T>(
+        self,
+        f: F,
+    ) -> LookupResult<MappedLookup<T, L, F>> {
+        match self {
+            LookupResult::Output(t) => LookupResult::Output(f(t)),
+            LookupResult::Load { load, continuation } => LookupResult::Load {
+                load,
+                continuation: MappedLookup {
+                    original: continuation,
+                    mutator: f,
+                },
+            },
+        }
+    }
+}
+
+pub(crate) struct SimpleLookup<T, R, F>
+where
+    F: FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> T,
+    R: gimli::Reader,
+{
+    f: F,
+    phantom: PhantomData<(T, R)>,
+}
+
+impl<T, R, F> SimpleLookup<T, R, F>
+where
+    F: FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> T,
+    R: gimli::Reader,
+{
+    pub(crate) fn new_complete(t: F::Output) -> LookupResult<SimpleLookup<T, R, F>> {
+        LookupResult::Output(t)
+    }
+
+    pub(crate) fn new_needs_load(
+        load: SplitDwarfLoad<R>,
+        f: F,
+    ) -> LookupResult<SimpleLookup<T, R, F>> {
+        LookupResult::Load {
+            load,
+            continuation: SimpleLookup {
+                f,
+                phantom: PhantomData,
+            },
+        }
+    }
+}
+
+impl<T, R, F> LookupContinuation for SimpleLookup<T, R, F>
+where
+    F: FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> T,
+    R: gimli::Reader,
+{
+    type Output = T;
+    type Buf = R;
+
+    fn resume(self, v: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self> {
+        LookupResult::Output((self.f)(v))
+    }
+}
+
+pub(crate) struct MappedLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnOnce(L::Output) -> T,
+{
+    original: L,
+    mutator: F,
+}
+
+impl<T, L, F> LookupContinuation for MappedLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnOnce(L::Output) -> T,
+{
+    type Output = T;
+    type Buf = L::Buf;
+
+    fn resume(self, v: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self> {
+        match self.original.resume(v) {
+            LookupResult::Output(t) => LookupResult::Output((self.mutator)(t)),
+            LookupResult::Load { load, continuation } => LookupResult::Load {
+                load,
+                continuation: MappedLookup {
+                    original: continuation,
+                    mutator: self.mutator,
+                },
+            },
+        }
+    }
+}
+
+/// Some functions (e.g. `find_frames`) require considering multiple
+/// compilation units, each of which might require their own split DWARF
+/// lookup (and thus produce a continuation).
+///
+/// We store the underlying continuation here as well as a mutator function
+/// that will either a) decide that the result of this continuation is
+/// what is needed and mutate it to the final result or b) produce another
+/// `LookupResult`. `new_lookup` will in turn eagerly drive any non-continuation
+/// `LookupResult` with successive invocations of the mutator, until a new
+/// continuation or a final result is produced. And finally, the impl of
+/// `LookupContinuation::resume` will call `new_lookup` each time the
+/// computation is resumed.
+pub(crate) struct LoopingLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnMut(L::Output) -> ControlFlow<T, LookupResult<L>>,
+{
+    continuation: L,
+    mutator: F,
+}
+
+impl<T, L, F> LoopingLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnMut(L::Output) -> ControlFlow<T, LookupResult<L>>,
+{
+    pub(crate) fn new_complete(t: T) -> LookupResult<Self> {
+        LookupResult::Output(t)
+    }
+
+    pub(crate) fn new_lookup(mut r: LookupResult<L>, mut mutator: F) -> LookupResult<Self> {
+        // Drive the loop eagerly so that we only ever have to represent one state
+        // (the r == ControlFlow::Continue state) in LoopingLookup.
+        loop {
+            match r {
+                LookupResult::Output(l) => match mutator(l) {
+                    ControlFlow::Break(t) => return LookupResult::Output(t),
+                    ControlFlow::Continue(r2) => {
+                        r = r2;
+                    }
+                },
+                LookupResult::Load { load, continuation } => {
+                    return LookupResult::Load {
+                        load,
+                        continuation: LoopingLookup {
+                            continuation,
+                            mutator,
+                        },
+                    };
+                }
+            }
+        }
+    }
+}
+
+impl<T, L, F> LookupContinuation for LoopingLookup<T, L, F>
+where
+    L: LookupContinuation,
+    F: FnMut(L::Output) -> ControlFlow<T, LookupResult<L>>,
+{
+    type Output = T;
+    type Buf = L::Buf;
+
+    fn resume(self, v: Option<Arc<gimli::Dwarf<Self::Buf>>>) -> LookupResult<Self> {
+        let r = self.continuation.resume(v);
+        LoopingLookup::new_lookup(r, self.mutator)
+    }
+}

--- a/libs/addr2line/src/unit.rs
+++ b/libs/addr2line/src/unit.rs
@@ -1,0 +1,562 @@
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp;
+
+use crate::{
+    Context, DebugFile, Error, Function, LazyFunctions, LazyLines, LazyResult,
+    LineLocationRangeIter, Lines, Location, LookupContinuation, LookupResult, RangeAttributes,
+    SimpleLookup, SplitDwarfLoad,
+};
+
+pub(crate) struct UnitRange {
+    unit_id: usize,
+    min_begin: u64,
+    range: gimli::Range,
+}
+
+pub(crate) struct ResUnit<R: gimli::Reader> {
+    offset: gimli::DebugInfoOffset<R::Offset>,
+    dw_unit: gimli::Unit<R>,
+    pub(crate) lang: Option<gimli::DwLang>,
+    lines: LazyLines,
+    functions: LazyFunctions<R>,
+    dwo: LazyResult<Option<Box<DwoUnit<R>>>>,
+}
+
+type UnitRef<'unit, R> = (DebugFile, gimli::UnitRef<'unit, R>);
+
+impl<R: gimli::Reader> ResUnit<R> {
+    pub(crate) fn unit_ref<'a>(&'a self, sections: &'a gimli::Dwarf<R>) -> gimli::UnitRef<'a, R> {
+        gimli::UnitRef::new(sections, &self.dw_unit)
+    }
+
+    /// Returns the DWARF sections and the unit.
+    ///
+    /// Loads the DWO unit if necessary.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn dwarf_and_unit<'unit, 'ctx: 'unit>(
+        &'unit self,
+        ctx: &'ctx Context<R>,
+    ) -> LookupResult<
+        SimpleLookup<
+            Result<UnitRef<'unit, R>, Error>,
+            R,
+            impl FnOnce(Option<Arc<gimli::Dwarf<R>>>) -> Result<UnitRef<'unit, R>, Error>,
+        >,
+    > {
+        let map_dwo = move |dwo: &'unit Result<Option<Box<DwoUnit<R>>>, Error>| match dwo {
+            Ok(Some(dwo)) => Ok((DebugFile::Dwo, dwo.unit_ref())),
+            Ok(None) => Ok((DebugFile::Primary, self.unit_ref(&*ctx.sections))),
+            Err(e) => Err(*e),
+        };
+        let complete = |dwo| SimpleLookup::new_complete(map_dwo(dwo));
+
+        if let Some(dwo) = self.dwo.get() {
+            return complete(dwo);
+        }
+
+        let dwo_id = match self.dw_unit.dwo_id {
+            None => {
+                return complete(self.dwo.get_or_init(|| Ok(None)));
+            }
+            Some(dwo_id) => dwo_id,
+        };
+
+        let comp_dir = self.dw_unit.comp_dir.clone();
+
+        let dwo_name = self.dw_unit.dwo_name().and_then(|s| {
+            if let Some(s) = s {
+                Ok(Some(ctx.sections.attr_string(&self.dw_unit, s)?))
+            } else {
+                Ok(None)
+            }
+        });
+
+        let path = match dwo_name {
+            Ok(v) => v,
+            Err(e) => {
+                return complete(self.dwo.get_or_init(|| Err(e)));
+            }
+        };
+
+        let process_dwo = move |dwo_dwarf: Option<Arc<gimli::Dwarf<R>>>| {
+            let dwo_dwarf = match dwo_dwarf {
+                None => return Ok(None),
+                Some(dwo_dwarf) => dwo_dwarf,
+            };
+            let mut dwo_units = dwo_dwarf.units();
+            let dwo_header = match dwo_units.next()? {
+                Some(dwo_header) => dwo_header,
+                None => return Ok(None),
+            };
+
+            let mut dwo_unit = dwo_dwarf.unit(dwo_header)?;
+            dwo_unit.copy_relocated_attributes(&self.dw_unit);
+            Ok(Some(Box::new(DwoUnit {
+                sections: dwo_dwarf,
+                dw_unit: dwo_unit,
+            })))
+        };
+
+        SimpleLookup::new_needs_load(
+            SplitDwarfLoad {
+                dwo_id,
+                comp_dir,
+                path,
+                parent: ctx.sections.clone(),
+            },
+            move |dwo_dwarf| map_dwo(self.dwo.get_or_init(|| process_dwo(dwo_dwarf))),
+        )
+    }
+
+    pub(crate) fn parse_lines(&self, sections: &gimli::Dwarf<R>) -> Result<Option<&Lines>, Error> {
+        // NB: line information is always stored in the main debug file so this does not need
+        // to handle DWOs.
+        let ilnp = match self.dw_unit.line_program {
+            Some(ref ilnp) => ilnp,
+            None => return Ok(None),
+        };
+        self.lines.borrow(self.unit_ref(sections), ilnp).map(Some)
+    }
+
+    pub(crate) fn find_location(
+        &self,
+        probe: u64,
+        sections: &gimli::Dwarf<R>,
+    ) -> Result<Option<Location<'_>>, Error> {
+        let Some(lines) = self.parse_lines(sections)? else {
+            return Ok(None);
+        };
+        lines.find_location(probe)
+    }
+
+    #[inline]
+    pub(crate) fn find_location_range(
+        &self,
+        probe_low: u64,
+        probe_high: u64,
+        sections: &gimli::Dwarf<R>,
+    ) -> Result<Option<LineLocationRangeIter<'_>>, Error> {
+        let Some(lines) = self.parse_lines(sections)? else {
+            return Ok(None);
+        };
+        lines.find_location_range(probe_low, probe_high).map(Some)
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn find_function_or_location<'unit, 'ctx: 'unit>(
+        &'unit self,
+        probe: u64,
+        ctx: &'ctx Context<R>,
+    ) -> LookupResult<
+        impl LookupContinuation<
+            Output = Result<(Option<&'unit Function<R>>, Option<Location<'unit>>), Error>,
+            Buf = R,
+        >,
+    > {
+        self.dwarf_and_unit(ctx).map(move |r| {
+            let (file, unit) = r?;
+            let functions = self.functions.borrow(unit)?;
+            let function = match functions.find_address(probe) {
+                Some(address) => {
+                    let function_index = functions.addresses[address].function;
+                    let function = &functions.functions[function_index];
+                    Some(function.borrow(file, unit, ctx)?)
+                }
+                None => None,
+            };
+            let location = self.find_location(probe, unit.dwarf)?;
+            Ok((function, location))
+        })
+    }
+}
+
+pub(crate) struct ResUnits<R: gimli::Reader> {
+    ranges: Box<[UnitRange]>,
+    units: Box<[ResUnit<R>]>,
+}
+
+impl<R: gimli::Reader> ResUnits<R> {
+    pub(crate) fn parse(sections: &gimli::Dwarf<R>) -> Result<Self, Error> {
+        // Find all the references to compilation units in .debug_aranges.
+        // Note that we always also iterate through all of .debug_info to
+        // find compilation units, because .debug_aranges may be missing some.
+        let mut aranges = Vec::new();
+        let mut headers = sections.debug_aranges.headers();
+        while let Some(header) = headers.next()? {
+            aranges.push((header.debug_info_offset(), header.offset()));
+        }
+        aranges.sort_by_key(|i| i.0);
+
+        let mut unit_ranges = Vec::new();
+        let mut res_units = Vec::new();
+        let mut units = sections.units();
+        while let Some(header) = units.next()? {
+            let unit_id = res_units.len();
+            let offset = match header.offset().as_debug_info_offset() {
+                Some(offset) => offset,
+                None => continue,
+            };
+            // We mainly want compile units, but we may need to follow references to entries
+            // within other units for function names.  We don't need anything from type units.
+            let mut need_unit_range = match header.type_() {
+                gimli::UnitType::Type { .. } | gimli::UnitType::SplitType { .. } => continue,
+                gimli::UnitType::Partial => {
+                    // Partial units are only needed for references from other units.
+                    // They shouldn't have any address ranges.
+                    false
+                }
+                _ => true,
+            };
+            let dw_unit = match sections.unit(header) {
+                Ok(dw_unit) => dw_unit,
+                Err(_) => continue,
+            };
+            let dw_unit_ref = gimli::UnitRef::new(sections, &dw_unit);
+
+            let mut lang = None;
+            if need_unit_range {
+                let mut entries = dw_unit_ref.entries_raw(None)?;
+
+                let abbrev = match entries.read_abbreviation()? {
+                    Some(abbrev) => abbrev,
+                    None => continue,
+                };
+
+                let mut ranges = RangeAttributes::default();
+                for spec in abbrev.attributes() {
+                    let attr = entries.read_attribute(*spec)?;
+                    match attr.name() {
+                        gimli::DW_AT_low_pc => match attr.value() {
+                            gimli::AttributeValue::Addr(val) => ranges.low_pc = Some(val),
+                            gimli::AttributeValue::DebugAddrIndex(index) => {
+                                ranges.low_pc = Some(dw_unit_ref.address(index)?);
+                            }
+                            _ => {}
+                        },
+                        gimli::DW_AT_high_pc => match attr.value() {
+                            gimli::AttributeValue::Addr(val) => ranges.high_pc = Some(val),
+                            gimli::AttributeValue::DebugAddrIndex(index) => {
+                                ranges.high_pc = Some(dw_unit_ref.address(index)?);
+                            }
+                            gimli::AttributeValue::Udata(val) => ranges.size = Some(val),
+                            _ => {}
+                        },
+                        gimli::DW_AT_ranges => {
+                            ranges.ranges_offset = dw_unit_ref.attr_ranges_offset(attr.value())?;
+                        }
+                        gimli::DW_AT_language => {
+                            if let gimli::AttributeValue::Language(val) = attr.value() {
+                                lang = Some(val);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Find the address ranges for the CU, using in order of preference:
+                // - DW_AT_ranges
+                // - .debug_aranges
+                // - DW_AT_low_pc/DW_AT_high_pc
+                //
+                // Using DW_AT_ranges before .debug_aranges is possibly an arbitrary choice,
+                // but the feeling is that DW_AT_ranges is more likely to be reliable or complete
+                // if it is present.
+                //
+                // .debug_aranges must be used before DW_AT_low_pc/DW_AT_high_pc because
+                // it has been observed on macOS that DW_AT_ranges was not emitted even for
+                // discontiguous CUs.
+                let i = match ranges.ranges_offset {
+                    Some(_) => None,
+                    None => aranges.binary_search_by_key(&offset, |x| x.0).ok(),
+                };
+                if let Some(mut i) = i {
+                    // There should be only one set per CU, but in practice multiple
+                    // sets have been observed. This is probably a compiler bug, but
+                    // either way we need to handle it.
+                    while i > 0 && aranges[i - 1].0 == offset {
+                        i -= 1;
+                    }
+                    for (_, aranges_offset) in aranges[i..].iter().take_while(|x| x.0 == offset) {
+                        let aranges_header = sections.debug_aranges.header(*aranges_offset)?;
+                        let mut aranges = aranges_header.entries();
+                        while let Some(arange) = aranges.next()? {
+                            if arange.length() != 0 {
+                                unit_ranges.push(UnitRange {
+                                    range: arange.range(),
+                                    unit_id,
+                                    min_begin: 0,
+                                });
+                                need_unit_range = false;
+                            }
+                        }
+                    }
+                } else {
+                    need_unit_range &= !ranges.for_each_range(dw_unit_ref, |range| {
+                        unit_ranges.push(UnitRange {
+                            range,
+                            unit_id,
+                            min_begin: 0,
+                        });
+                    })?;
+                }
+            }
+
+            let lines = LazyLines::new();
+            if need_unit_range {
+                // The unit did not declare any ranges.
+                // Try to get some ranges from the line program sequences.
+                if let Some(ref ilnp) = dw_unit_ref.line_program {
+                    if let Ok(lines) = lines.borrow(dw_unit_ref, ilnp) {
+                        for range in lines.ranges() {
+                            unit_ranges.push(UnitRange {
+                                range,
+                                unit_id,
+                                min_begin: 0,
+                            })
+                        }
+                    }
+                }
+            }
+
+            res_units.push(ResUnit {
+                offset,
+                dw_unit,
+                lang,
+                lines,
+                functions: LazyFunctions::new(),
+                dwo: LazyResult::new(),
+            });
+        }
+
+        // Sort this for faster lookup in `Self::find_range`.
+        unit_ranges.sort_by_key(|i| i.range.end);
+
+        // Calculate the `min_begin` field now that we've determined the order of
+        // CUs.
+        let mut min = !0;
+        for i in unit_ranges.iter_mut().rev() {
+            min = min.min(i.range.begin);
+            i.min_begin = min;
+        }
+
+        Ok(ResUnits {
+            ranges: unit_ranges.into_boxed_slice(),
+            units: res_units.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn find_offset(
+        &self,
+        offset: gimli::DebugInfoOffset<R::Offset>,
+    ) -> Result<&gimli::Unit<R>, Error> {
+        match self
+            .units
+            .binary_search_by_key(&offset.0, |unit| unit.offset.0)
+        {
+            // There is never a DIE at the unit offset or before the first unit.
+            Ok(_) | Err(0) => Err(gimli::Error::NoEntryAtGivenOffset),
+            Err(i) => Ok(&self.units[i - 1].dw_unit),
+        }
+    }
+
+    /// Finds the CUs for the function address given.
+    ///
+    /// There might be multiple CUs whose range contains this address.
+    /// Weak symbols have shown up in the wild which cause this to happen
+    /// but otherwise this can happen if the CU has non-contiguous functions
+    /// but only reports a single range.
+    ///
+    /// Consequently we return an iterator for all CUs which may contain the
+    /// address, and the caller must check if there is actually a function or
+    /// location in the CU for that address.
+    pub(crate) fn find(&self, probe: u64) -> impl Iterator<Item = &ResUnit<R>> {
+        self.find_range(probe, probe + 1).map(|(unit, _range)| unit)
+    }
+
+    /// Finds the CUs covering the range of addresses given.
+    ///
+    /// The range is [low, high) (ie, the upper bound is exclusive). This can return multiple
+    /// ranges for the same unit.
+    #[inline]
+    pub(crate) fn find_range(
+        &self,
+        probe_low: u64,
+        probe_high: u64,
+    ) -> impl Iterator<Item = (&ResUnit<R>, &gimli::Range)> {
+        // Find the position of the next range after a range which
+        // ends at `probe_low` or lower.
+        let pos = match self
+            .ranges
+            .binary_search_by_key(&probe_low, |i| i.range.end)
+        {
+            Ok(i) => i + 1, // Range `i` ends at exactly `probe_low`.
+            Err(i) => i,    // Range `i - 1` ends at a lower address.
+        };
+
+        // Iterate from that position to find matching CUs.
+        self.ranges[pos..]
+            .iter()
+            .take_while(move |i| {
+                // We know that this CU's end is at least `probe_low` because
+                // of our sorted array.
+                debug_assert!(i.range.end >= probe_low);
+
+                // Each entry keeps track of the minimum begin address for the
+                // remainder of the array of unit ranges. If our probe is before
+                // the minimum range begin of this entry, then it's guaranteed
+                // to not fit in any subsequent entries, so we break out.
+                probe_high > i.min_begin
+            })
+            .filter_map(move |i| {
+                // If this CU doesn't actually contain this address, move to the
+                // next CU.
+                if probe_low >= i.range.end || probe_high <= i.range.begin {
+                    return None;
+                }
+                Some((&self.units[i.unit_id], &i.range))
+            })
+    }
+
+    pub(crate) fn find_location_range<'a>(
+        &'a self,
+        probe_low: u64,
+        probe_high: u64,
+        sections: &'a gimli::Dwarf<R>,
+    ) -> Result<LocationRangeIter<'a, R>, Error> {
+        let unit_iter = Box::new(self.find_range(probe_low, probe_high));
+        Ok(LocationRangeIter {
+            unit_iter,
+            iter: None,
+            probe_low,
+            probe_high,
+            sections,
+        })
+    }
+}
+
+/// A DWO unit has its own DWARF sections.
+struct DwoUnit<R: gimli::Reader> {
+    sections: Arc<gimli::Dwarf<R>>,
+    dw_unit: gimli::Unit<R>,
+}
+
+impl<R: gimli::Reader> DwoUnit<R> {
+    fn unit_ref(&self) -> gimli::UnitRef<R> {
+        gimli::UnitRef::new(&self.sections, &self.dw_unit)
+    }
+}
+
+pub(crate) struct SupUnit<R: gimli::Reader> {
+    offset: gimli::DebugInfoOffset<R::Offset>,
+    dw_unit: gimli::Unit<R>,
+}
+
+pub(crate) struct SupUnits<R: gimli::Reader> {
+    units: Box<[SupUnit<R>]>,
+}
+
+impl<R: gimli::Reader> Default for SupUnits<R> {
+    fn default() -> Self {
+        SupUnits {
+            units: Box::default(),
+        }
+    }
+}
+
+impl<R: gimli::Reader> SupUnits<R> {
+    pub(crate) fn parse(sections: &gimli::Dwarf<R>) -> Result<Self, Error> {
+        let mut sup_units = Vec::new();
+        let mut units = sections.units();
+        while let Some(header) = units.next()? {
+            let offset = match header.offset().as_debug_info_offset() {
+                Some(offset) => offset,
+                None => continue,
+            };
+            let dw_unit = match sections.unit(header) {
+                Ok(dw_unit) => dw_unit,
+                Err(_) => continue,
+            };
+            sup_units.push(SupUnit { dw_unit, offset });
+        }
+        Ok(SupUnits {
+            units: sup_units.into_boxed_slice(),
+        })
+    }
+
+    pub(crate) fn find_offset(
+        &self,
+        offset: gimli::DebugInfoOffset<R::Offset>,
+    ) -> Result<&gimli::Unit<R>, Error> {
+        match self
+            .units
+            .binary_search_by_key(&offset.0, |unit| unit.offset.0)
+        {
+            // There is never a DIE at the unit offset or before the first unit.
+            Ok(_) | Err(0) => Err(gimli::Error::NoEntryAtGivenOffset),
+            Err(i) => Ok(&self.units[i - 1].dw_unit),
+        }
+    }
+}
+
+/// Iterator over `Location`s in a range of addresses, returned by `Context::find_location_range`.
+pub struct LocationRangeIter<'ctx, R: gimli::Reader> {
+    unit_iter: Box<dyn Iterator<Item = (&'ctx ResUnit<R>, &'ctx gimli::Range)> + 'ctx>,
+    iter: Option<LineLocationRangeIter<'ctx>>,
+
+    probe_low: u64,
+    probe_high: u64,
+    sections: &'ctx gimli::Dwarf<R>,
+}
+
+impl<'ctx, R: gimli::Reader> LocationRangeIter<'ctx, R> {
+    fn next_loc(&mut self) -> Result<Option<(u64, u64, Location<'ctx>)>, Error> {
+        loop {
+            let iter = self.iter.take();
+            match iter {
+                None => match self.unit_iter.next() {
+                    Some((unit, range)) => {
+                        self.iter = unit.find_location_range(
+                            cmp::max(self.probe_low, range.begin),
+                            cmp::min(self.probe_high, range.end),
+                            self.sections,
+                        )?;
+                    }
+                    None => return Ok(None),
+                },
+                Some(mut iter) => {
+                    if let item @ Some(_) = iter.next() {
+                        self.iter = Some(iter);
+                        return Ok(item);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'ctx, R> Iterator for LocationRangeIter<'ctx, R>
+where
+    R: gimli::Reader + 'ctx,
+{
+    type Item = (u64, u64, Location<'ctx>);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_loc().unwrap_or_default()
+    }
+}
+
+impl<'ctx, R> fallible_iterator::FallibleIterator for LocationRangeIter<'ctx, R>
+where
+    R: gimli::Reader + 'ctx,
+{
+    type Item = (u64, u64, Location<'ctx>);
+    type Error = Error;
+
+    #[inline]
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        self.next_loc()
+    }
+}

--- a/libs/backtrace/Cargo.toml
+++ b/libs/backtrace/Cargo.toml
@@ -9,10 +9,8 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-cfg-if.workspace = true
 unwind2.workspace = true
 gimli.workspace = true
-addr2line = { version = "0.24.1", default-features = false }
-rustc-demangle = { version = "0.1.24", default-features = false }
+addr2line.workspace = true
 xmas-elf.workspace = true
-log.workspace = true
+rustc-demangle.workspace = true

--- a/libs/backtrace/src/lib.rs
+++ b/libs/backtrace/src/lib.rs
@@ -106,11 +106,11 @@ impl fmt::Display for Backtrace<'_, '_> {
             }
         }
 
-        writeln!(
-            f,
-            "note: Some details are omitted, \
-             run with `RUST_BACKTRACE=full` for a verbose backtrace."
-        )?;
+        // writeln!(
+        //     f,
+        //     "note: Some details are omitted, \
+        //      run with `RUST_BACKTRACE=full` for a verbose backtrace."
+        // )?;
 
         Ok(())
     }


### PR DESCRIPTION
This change - in the spirit of `backtrace` and `unwind2` - vendors the `addr2line` crate to make it more compatible with k23s needs, in particular upgrading its rustc version and making use of k23 synchronization primitives.