### PR TITLE
chore: optional `AddressSpaceRegion` name

### DIFF
--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -122,7 +122,7 @@ impl AddressSpace {
         vmo: Arc<Vmo>,
         vmo_offset: usize,
         permissions: Permissions,
-        name: String,
+        name: Option<String>,
     ) -> crate::Result<Pin<&mut AddressSpaceRegion>> {
         assert!(virt.start.is_aligned_to(PAGE_SIZE));
         assert!(virt.end.is_aligned_to(PAGE_SIZE));

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -112,7 +112,7 @@ impl AddressSpace {
         name: Option<String>,
         flush: &mut Flush,
     ) -> crate::Result<()> {
-        log::trace!("reserving {range:?} with flags {permissions:?} and name {name}");
+        log::trace!("reserving {range:?} with flags {permissions:?} and name {name:?}");
 
         let vmo = self
             .placeholder_vmo

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -84,7 +84,7 @@ impl AddressSpace {
         vmo: Arc<Vmo>,
         vmo_offset: usize,
         permissions: Permissions,
-        name: String,
+        name: Option<String>,
     ) -> crate::Result<Pin<&mut AddressSpaceRegion>> {
         let base = self.find_spot(layout, VIRT_ALLOC_ENTROPY);
         let virt = Range::from(base..base.checked_add(layout.size()).unwrap());
@@ -109,7 +109,7 @@ impl AddressSpace {
         &mut self,
         range: Range<VirtualAddress>,
         permissions: Permissions,
-        name: String,
+        name: Option<String>,
         flush: &mut Flush,
     ) -> crate::Result<()> {
         log::trace!("reserving {range:?} with flags {permissions:?} and name {name}");

--- a/kernel/src/vm/address_space_region.rs
+++ b/kernel/src/vm/address_space_region.rs
@@ -38,7 +38,7 @@ pub struct AddressSpaceRegion {
     /// The permissions of this region
     pub permissions: Permissions,
     /// The name of this region, for debugging
-    pub name: String,
+    pub name: Option<String>,
     /// The Virtual Memory Object backing this region
     pub vmo: Arc<Vmo>,
     pub vmo_offset: usize,
@@ -50,7 +50,7 @@ impl AddressSpaceRegion {
         permissions: Permissions,
         vmo: Arc<Vmo>,
         vmo_offset: usize,
-        name: String,
+        name: Option<String>,
     ) -> Pin<Box<Self>> {
         Box::pin(Self {
             links: Default::default(),

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -56,7 +56,7 @@ pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) -> crate::Result<()> {
 
         for region in aspace.regions.iter() {
             log::trace!(
-                "{:<40} {}..{} {}",
+                "{:<40?} {}..{} {}",
                 region.name,
                 region.range.start,
                 region.range.end,
@@ -79,7 +79,7 @@ fn reserve_wired_regions(
     aspace.reserve(
         boot_info.physical_memory_map,
         Permissions::READ | Permissions::WRITE,
-        "Physical Memory Map".to_string(),
+        Some("Physical Memory Map".to_string()),
         flush,
     )?;
 
@@ -133,7 +133,7 @@ fn reserve_wired_regions(
                     .unwrap(),
             },
             permissions,
-            format!("Kernel {permissions} Segment"),
+            Some(format!("Kernel {permissions} Segment")),
             flush,
         )?;
     }


### PR DESCRIPTION
This change makes the `AddressSpaceRegion` name optional, as it is used for debugging anyway and regions might not actually have any associated name.