### PR TITLE
feat: implement `AddressSpace::unmap`

### DIFF
--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -15,6 +15,7 @@ use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::alloc::Layout;
+use core::cmp;
 use core::num::NonZeroUsize;
 use core::ops::Bound;
 use core::pin::Pin;
@@ -150,8 +151,64 @@ impl AddressSpace {
         Ok(())
     }
 
-    pub fn unmap(&mut self) {
-        todo!()
+    pub fn unmap(&mut self, range: Range<VirtualAddress>) -> crate::Result<()> {
+        assert!(range.start.is_aligned_to(PAGE_SIZE));
+        let range = range.checked_align_out(PAGE_SIZE).unwrap();
+        let mut iter = self.regions.range_mut(range);
+
+        while let Some(mut region) = iter.next() {
+            log::trace!("{region:?}");
+            let start = cmp::max(region.range.start, range.start);
+            let end = cmp::min(region.range.end, range.end);
+
+            if range.start <= region.range.start && range.end >= region.range.end {
+                // this mappings range is entirely contained within `range`, so we need
+                // fully remove the mapping from the tree
+                log::trace!("TODO remove region");
+            } else if range.start > region.range.start && range.end < region.range.end {
+                // `range` is entirely contained within the mappings range, we
+                // need to split the range in two
+                log::trace!("splitting region");
+                let right = Range::from(range.end..region.range.end);
+                let right_vmo_offset = region.range.end.checked_sub_addr(range.end).unwrap();
+                log::trace!("right_vmo_offset {right_vmo_offset}");
+
+                iter.tree().insert(AddressSpaceRegion::new(
+                    right,
+                    region.permissions,
+                    region.vmo.clone(),
+                    right_vmo_offset,
+                    region.name.clone(),
+                ));
+
+                region.range.end = range.start;
+            } else if range.start > region.range.start {
+                // `range` is mostly past this mappings range, but overlaps partially
+                // we need adjust the ranges end
+                log::trace!("adjusting region end");
+                region.range.end = range.start;
+            } else if range.end < region.range.end {
+                // `range` is mostly before this mappings range, but overlaps partially
+                // we need adjust the ranges start
+                log::trace!("adjusting region start");
+                region.range.start = range.end;
+            } else {
+                unreachable!()
+            }
+
+            region.unmap(Range::from(start..end))?;
+        }
+
+        let mut flush = Flush::empty(self.mmu.asid());
+        self.mmu.unmap(
+            &mut self.mmu_frames,
+            range.start,
+            NonZeroUsize::new(range.size()).unwrap(),
+            &mut flush,
+        )?;
+        flush.flush()?;
+
+        Ok(())
     }
 
     /// Page fault handling
@@ -538,9 +595,7 @@ impl mmu::frame_alloc::FrameAllocator for MmuFrames {
         Some(addr)
     }
 
-    fn deallocate_contiguous(&mut self, _addr: PhysicalAddress, _layout: Layout) {
-        todo!()
-    }
+    fn deallocate_contiguous(&mut self, _addr: PhysicalAddress, _layout: Layout) {}
 
     fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<PhysicalAddress> {
         let frame = frame_alloc::alloc_contiguous_zeroed(layout).ok()?;

--- a/kernel/src/vm/frame_alloc/mod.rs
+++ b/kernel/src/vm/frame_alloc/mod.rs
@@ -9,7 +9,7 @@ mod arena;
 mod frame;
 
 use crate::thread_local::ThreadLocal;
-pub use crate::vm::frame_list::FrameList;
+use crate::vm::frame_list::FrameList;
 use crate::BOOT_INFO;
 use alloc::vec::Vec;
 use arena::{select_arenas, Arena};

--- a/kernel/src/vm/paged_vmo.rs
+++ b/kernel/src/vm/paged_vmo.rs
@@ -5,8 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::vm::frame_alloc::{Frame, FrameList};
+use crate::vm::frame_alloc::Frame;
+use crate::vm::frame_list::FrameList;
 use crate::vm::{frame_alloc, THE_ZERO_FRAME};
+use core::range::Range;
 use mmu::VirtualAddress;
 
 #[derive(Debug)]
@@ -62,6 +64,16 @@ impl PagedVmo {
             Ok(frame)
         } else {
             todo!("TODO request bytes from source (later when we actually have sources)");
+        }
+    }
+
+    pub fn free_frames(&mut self, range: Range<usize>) {
+        let mut c = self.frames.cursor_mut(range.start);
+
+        while c.offset() < range.end {
+            let _frame = c.remove();
+
+            c.move_next();
         }
     }
 }

--- a/libs/wavltree/src/cursor.rs
+++ b/libs/wavltree/src/cursor.rs
@@ -110,6 +110,7 @@ where
     pub fn remove(&mut self) -> Option<T::Handle> {
         unsafe {
             let handle = self._tree.remove_internal(self.current?);
+            self.current = None;
             Some(handle)
         }
     }


### PR DESCRIPTION
Implements the `AddressSpace::unmap(range: Range<VirtualAddress>)` method which can be used to unmap previously established mappings in the address space.

I'm not super happy with the current solution, as it silently ignores attempts to unmap already unmapped regions, but it will suffice as a first version.