### PR TITLE
refactor(loader): replace usage of `mmu`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,12 +388,12 @@ name = "loader"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "bitflags",
  "cfg-if",
  "dtb-parser",
  "fallible-iterator",
  "loader-api",
  "log",
- "mmu",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "riscv",
@@ -403,9 +403,6 @@ dependencies = [
 [[package]]
 name = "loader-api"
 version = "0.1.0"
-dependencies = [
- "mmu",
-]
 
 [[package]]
 name = "lock_api"

--- a/justfile
+++ b/justfile
@@ -94,7 +94,7 @@ clippy crate="" *cargo_args="":
         {{ _buildstd }} \
         {{ _fmt_clippy }} \
         {{ cargo_args }}
-    KERNEL=main.rs {{ _cargo }} clippy \
+    KERNEL=Cargo.toml {{ _cargo }} clippy \
             -p loader \
             --target loader/riscv64imac-k23-none-loader.json \
             {{ _buildstd }} \

--- a/justfile
+++ b/justfile
@@ -94,6 +94,12 @@ clippy crate="" *cargo_args="":
         {{ _buildstd }} \
         {{ _fmt_clippy }} \
         {{ cargo_args }}
+    KERNEL=main.rs {{ _cargo }} clippy \
+            -p loader \
+            --target loader/riscv64imac-k23-none-loader.json \
+            {{ _buildstd }} \
+            {{ _fmt_clippy }} \
+            {{ cargo_args }}
 
 # check formatting for a crate or the entire workspace.
 check-fmt crate="" *cargo_args="":
@@ -113,6 +119,12 @@ build-docs crate="" *cargo_args="":
         {{ _buildstd }} \
         {{ _fmt }} \
         {{ cargo_args }}
+    KERNEL=Cargo.toml {{ _rustdoc }} \
+            -p loader \
+            --target loader/riscv64imac-k23-none-loader.json \
+            {{ _buildstd }} \
+            {{ _fmt }} \
+            {{ cargo_args }}
 
 # test documentation for a crate or the entire workspace.
 test-docs crate="" *cargo_args="":

--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -11,7 +11,6 @@ use core::range::Range;
 use loader_api::BootInfo;
 use mmu::arch::PAGE_SIZE;
 use mmu::frame_alloc::{BootstrapAllocator, FrameAllocator};
-use mmu::AddressRangeExt;
 use talc::{ErrOnOom, Span, Talc, Talck};
 
 #[global_allocator]
@@ -32,7 +31,10 @@ pub fn init(boot_alloc: &mut BootstrapAllocator, boot_info: &BootInfo) {
     };
 
     let mut alloc = KERNEL_ALLOCATOR.lock();
-    let span = Span::from_base_size(virt.start.as_mut_ptr(), virt.size());
+    let span = Span::from_base_size(
+        virt.start as *mut u8,
+        virt.end.checked_sub(virt.start).unwrap(),
+    );
     unsafe {
         let old_heap = alloc.claim(span).unwrap();
         alloc.extend(old_heap, span);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -37,7 +37,7 @@ use core::alloc::Layout;
 use core::cell::RefCell;
 use core::range::Range;
 use core::{cmp, slice};
-use loader_api::{BootInfo, MemoryRegionKind};
+use loader_api::{BootInfo, MemoryRegionKind, TlsTemplate};
 use mmu::arch::PAGE_SIZE;
 use mmu::frame_alloc::{BootstrapAllocator, FrameAllocator as _};
 use mmu::{PhysicalAddress, VirtualAddress};
@@ -61,7 +61,12 @@ pub const INITIAL_HEAP_SIZE_PAGES: usize = 2048; // 32 MiB
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-pub static BOOT_INFO: OnceLock<&'static BootInfo> = OnceLock::new();
+pub static PHYS_OFFSET: OnceLock<VirtualAddress> = OnceLock::new();
+#[inline]
+pub fn physical_address_offset() -> VirtualAddress {
+    *PHYS_OFFSET.get().unwrap()
+}
+
 pub static MACHINE_INFO: OnceLock<MachineInfo> = OnceLock::new();
 
 thread_local!(
@@ -70,21 +75,30 @@ thread_local!(
 );
 
 pub fn main(hartid: usize, boot_info: &'static BootInfo) -> ! {
-    BOOT_INFO.get_or_init(|| boot_info);
+    let physical_address_offset = *PHYS_OFFSET
+        .get_or_init(|| VirtualAddress::new(boot_info.physical_address_offset).unwrap());
 
     // initialize a simple bump allocator for allocating memory before our virtual memory subsystem
     // is available
     let allocatable_memories = allocatable_memory_regions(boot_info);
     let mut boot_alloc = BootstrapAllocator::new(&allocatable_memories);
-    boot_alloc.set_phys_offset(boot_info.physical_address_offset);
+    boot_alloc.set_phys_offset(physical_address_offset);
 
     // initializing the global allocator
     allocator::init(&mut boot_alloc, boot_info);
 
+    // initialize the panic backtracing subsystem after the allocator has been set up
+    // since setting up the symbolization context requires allocation
+    panic::init(boot_info);
+
     // initialize thread-local storage
     // done after global allocator initialization since TLS destructors are registered in a heap
     // allocated Vec
-    let tls = init_tls(&mut boot_alloc, boot_info);
+    let tls = init_tls(
+        &mut boot_alloc,
+        &boot_info.tls_template,
+        physical_address_offset,
+    );
 
     // initialize the logger
     // done after TLS initialization since we maintain per-hart host stdio channels
@@ -114,7 +128,7 @@ pub fn main(hartid: usize, boot_info: &'static BootInfo) -> ! {
     log::debug!("\n{hart_local_minfo}");
     HART_LOCAL_MACHINE_INFO.set(hart_local_minfo);
 
-    frame_alloc::init(boot_alloc, boot_info.physical_address_offset);
+    frame_alloc::init(boot_alloc, physical_address_offset);
 
     // TODO init kernel address space (requires global allocator)
 
@@ -147,20 +161,24 @@ pub fn main(hartid: usize, boot_info: &'static BootInfo) -> ! {
     arch::exit(0);
 }
 
-fn init_tls(boot_alloc: &mut BootstrapAllocator, boot_info: &BootInfo) -> Option<VirtualAddress> {
-    if let Some(template) = &boot_info.tls_template {
+fn init_tls(
+    boot_alloc: &mut BootstrapAllocator,
+    maybe_tls_template: &Option<TlsTemplate>,
+    physical_address_offset: VirtualAddress,
+) -> Option<VirtualAddress> {
+    if let Some(template) = &maybe_tls_template {
         let layout =
             Layout::from_size_align(template.mem_size, cmp::max(template.align, PAGE_SIZE))
                 .unwrap();
         let phys = boot_alloc.allocate_contiguous_zeroed(layout).unwrap();
 
         // Use the phys_map to access the newly allocated TLS region
-        let virt = VirtualAddress::from_phys(phys, boot_info.physical_address_offset).unwrap();
+        let virt = VirtualAddress::from_phys(phys, physical_address_offset).unwrap();
 
         if template.file_size != 0 {
             unsafe {
                 let src: &[u8] =
-                    slice::from_raw_parts(template.start_addr.as_ptr(), template.file_size);
+                    slice::from_raw_parts(template.start_addr as *const u8, template.file_size);
                 let dst: &mut [u8] =
                     slice::from_raw_parts_mut(virt.as_mut_ptr(), template.file_size);
 
@@ -188,7 +206,13 @@ fn allocatable_memory_regions(boot_info: &BootInfo) -> ArrayVec<Range<PhysicalAd
     let temp: ArrayVec<Range<PhysicalAddress>, 16> = boot_info
         .memory_regions
         .iter()
-        .filter_map(|region| region.kind.is_usable().then_some(region.range))
+        .filter_map(|region| {
+            let range = Range::from(
+                PhysicalAddress::new(region.range.start)..PhysicalAddress::new(region.range.end),
+            );
+
+            region.kind.is_usable().then_some(range)
+        })
         .collect();
 
     // merge adjacent regions
@@ -220,7 +244,6 @@ fn locate_device_tree(boot_info: &BootInfo) -> *const u8 {
 
     boot_info
         .physical_address_offset
-        .checked_add(fdt.range.start.get())
-        .unwrap()
-        .as_ptr()
+        .checked_add(fdt.range.start)
+        .unwrap() as *const u8
 }

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -19,14 +19,14 @@ use sync::{LazyLock, OnceLock};
 static GLOBAL_PANIC_STATE: OnceLock<GlobalPanicState> = OnceLock::new();
 
 struct GlobalPanicState {
-    kernerl_virt_base: u64,
+    kernel_virt_base: u64,
     elf: &'static [u8],
 }
 
 #[cold]
 pub fn init(boot_info: &BootInfo) {
     GLOBAL_PANIC_STATE.get_or_init(|| GlobalPanicState {
-        kernerl_virt_base: boot_info.kernel_virt.start as u64,
+        kernel_virt_base: boot_info.kernel_virt.start as u64,
         elf: unsafe {
             let base = boot_info
                 .physical_address_offset
@@ -50,7 +50,7 @@ static SYMBOLIZE_CONTEXT: LazyLock<Option<SymbolizeContext>> = LazyLock::new(|| 
     let state = GLOBAL_PANIC_STATE.get()?;
 
     let elf = xmas_elf::ElfFile::new(state.elf).unwrap();
-    Some(SymbolizeContext::new(elf, state.kernerl_virt_base).unwrap())
+    Some(SymbolizeContext::new(elf, state.kernel_virt_base).unwrap())
 });
 
 /// Determines whether the current thread is unwinding because of panic.

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -5,33 +5,52 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch;
 use crate::panic::panic_count::MustAbort;
-use crate::{arch, BOOT_INFO};
 use alloc::boxed::Box;
 use alloc::string::String;
 use backtrace::{Backtrace, SymbolizeContext};
 use core::any::Any;
 use core::panic::{PanicPayload, UnwindSafe};
 use core::{fmt, mem, slice};
-use mmu::{AddressRangeExt, VirtualAddress};
-use sync::LazyLock;
+use loader_api::BootInfo;
+use sync::{LazyLock, OnceLock};
 
-static SYMBOLIZE_CONTEXT: LazyLock<SymbolizeContext> = LazyLock::new(|| {
+static GLOBAL_PANIC_STATE: OnceLock<GlobalPanicState> = OnceLock::new();
+
+struct GlobalPanicState {
+    kernerl_virt_base: u64,
+    elf: &'static [u8],
+}
+
+#[cold]
+pub fn init(boot_info: &BootInfo) {
+    GLOBAL_PANIC_STATE.get_or_init(|| GlobalPanicState {
+        kernerl_virt_base: boot_info.kernel_virt.start as u64,
+        elf: unsafe {
+            let base = boot_info
+                .physical_address_offset
+                .checked_add(boot_info.kernel_phys.start)
+                .unwrap() as *const u8;
+
+            slice::from_raw_parts(
+                base,
+                boot_info
+                    .kernel_phys
+                    .end
+                    .checked_sub(boot_info.kernel_phys.start)
+                    .unwrap(),
+            )
+        },
+    });
+}
+
+static SYMBOLIZE_CONTEXT: LazyLock<Option<SymbolizeContext>> = LazyLock::new(|| {
     log::trace!("Setting up symbolize context...");
-    let boot_info = BOOT_INFO.get().unwrap();
+    let state = GLOBAL_PANIC_STATE.get()?;
 
-    let elf = xmas_elf::ElfFile::new(unsafe {
-        let base = VirtualAddress::from_phys(
-            boot_info.kernel_phys.start,
-            boot_info.physical_address_offset,
-        )
-        .unwrap();
-
-        slice::from_raw_parts(base.as_ptr(), boot_info.kernel_phys.size())
-    })
-    .unwrap();
-
-    SymbolizeContext::new(elf, boot_info.kernel_virt.start.get() as u64).unwrap()
+    let elf = xmas_elf::ElfFile::new(state.elf).unwrap();
+    Some(SymbolizeContext::new(elf, state.kernerl_virt_base).unwrap())
 });
 
 /// Determines whether the current thread is unwinding because of panic.
@@ -83,8 +102,14 @@ fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
             thread_local::destructors::run();
         }
 
-        let backtrace = Backtrace::capture(&SYMBOLIZE_CONTEXT);
-        log::error!("{backtrace}");
+        if let Some(ctx) = SYMBOLIZE_CONTEXT.as_ref() {
+            let backtrace = Backtrace::capture(ctx);
+            log::error!("{backtrace}");
+        } else {
+            log::error!(
+                "Backtrace unavailable. Panic happened before panic subsystem initialization."
+            );
+        }
 
         panic_count::finished_panic_hook();
 

--- a/kernel/src/vm/address_space_region.rs
+++ b/kernel/src/vm/address_space_region.rs
@@ -9,7 +9,6 @@ use crate::error::Error;
 use crate::vm::address_space::Batch;
 use crate::vm::Vmo;
 use crate::vm::{PageFaultFlags, Permissions};
-use crate::BOOT_INFO;
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::sync::Arc;
@@ -146,12 +145,10 @@ impl AddressSpaceRegion {
                 )?;
             }
             Vmo::Paged(vmo) => {
-                let phys_off = BOOT_INFO.get().unwrap().physical_address_offset;
-
                 if flags.cause_is_write() {
                     let mut vmo = vmo.write();
 
-                    let frame = vmo.require_owned_frame(vmo_relative_offset, phys_off)?;
+                    let frame = vmo.require_owned_frame(vmo_relative_offset)?;
                     batch.append(addr, frame.addr(), PAGE_SIZE, self.permissions.into())?;
                 } else {
                     let vmo = vmo.read();

--- a/kernel/src/vm/frame_alloc/mod.rs
+++ b/kernel/src/vm/frame_alloc/mod.rs
@@ -8,9 +8,9 @@
 mod arena;
 mod frame;
 
+use crate::physical_address_offset;
 use crate::thread_local::ThreadLocal;
 use crate::vm::frame_list::FrameList;
-use crate::BOOT_INFO;
 use alloc::vec::Vec;
 use arena::{select_arenas, Arena};
 use core::alloc::Layout;
@@ -107,14 +107,7 @@ pub fn alloc_one_zeroed() -> Result<Frame, AllocError> {
     let frame = alloc_one()?;
 
     // Translate the physical address into a virtual one through the physmap
-    let virt = VirtualAddress::from_phys(
-        frame.addr(),
-        BOOT_INFO
-            .get()
-            .expect("cannot access BOOT_INFO before it is initialized")
-            .physical_address_offset,
-    )
-    .unwrap();
+    let virt = VirtualAddress::from_phys(frame.addr(), physical_address_offset()).unwrap();
 
     // memset'ing the slice to zero
     unsafe {
@@ -163,14 +156,8 @@ pub fn alloc_contiguous_zeroed(layout: Layout) -> Result<FrameList, AllocError> 
     let frames = alloc_contiguous(layout)?;
 
     // Translate the physical address into a virtual one through the physmap
-    let virt = VirtualAddress::from_phys(
-        frames.first().unwrap().addr(),
-        BOOT_INFO
-            .get()
-            .expect("cannot access BOOT_INFO before it is initialized")
-            .physical_address_offset,
-    )
-    .unwrap();
+    let virt = VirtualAddress::from_phys(frames.first().unwrap().addr(), physical_address_offset())
+        .unwrap();
 
     // memset'ing the slice to zero
     unsafe {

--- a/kernel/src/vm/paged_vmo.rs
+++ b/kernel/src/vm/paged_vmo.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::physical_address_offset;
 use crate::vm::frame_alloc::Frame;
 use crate::vm::frame_list::FrameList;
 use crate::vm::{frame_alloc, THE_ZERO_FRAME};
 use core::range::Range;
-use mmu::VirtualAddress;
 
 #[derive(Debug)]
 pub struct PagedVmo {
@@ -26,11 +26,7 @@ impl FromIterator<Frame> for PagedVmo {
 }
 
 impl PagedVmo {
-    pub fn require_owned_frame(
-        &mut self,
-        at_offset: usize,
-        phys_off: VirtualAddress,
-    ) -> crate::Result<&Frame> {
+    pub fn require_owned_frame(&mut self, at_offset: usize) -> crate::Result<&Frame> {
         if let Some(old_frame) = self.frames.get(at_offset) {
             log::trace!("require_owned_frame for resident frame, allocating new...");
 
@@ -40,10 +36,10 @@ impl PagedVmo {
             // all zeroes anyway
             if !Frame::ptr_eq(old_frame, &THE_ZERO_FRAME) {
                 log::trace!("performing copy-on-write...");
-                let src = old_frame.as_slice(phys_off);
+                let src = old_frame.as_slice(physical_address_offset());
                 let dst = Frame::get_mut(&mut new_frame)
                     .expect("newly allocated frame should be unique")
-                    .as_mut_slice(phys_off);
+                    .as_mut_slice(physical_address_offset());
 
                 log::trace!(
                     "copying from {:?} to {:?}",

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-mmu.workspace = true
 dtb-parser.workspace = true
 loader-api.workspace = true
 
@@ -20,6 +19,7 @@ rand.workspace = true
 arrayvec.workspace = true
 xmas-elf.workspace = true
 fallible-iterator.workspace = true
+bitflags.workspace = true
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
 riscv.workspace = true

--- a/loader/api/Cargo.toml
+++ b/loader/api/Cargo.toml
@@ -6,4 +6,3 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-mmu = { workspace = true }

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -8,7 +8,6 @@
 use core::ops::{Deref, DerefMut};
 use core::range::Range;
 use core::{fmt, slice};
-use mmu::{PhysicalAddress, VirtualAddress};
 
 #[derive(Debug)]
 #[non_exhaustive]
@@ -28,25 +27,18 @@ pub struct BootInfo {
     /// frames that are also mapped at other virtual addresses can easily break memory safety and
     /// cause undefined behavior. Only frames reported as `USABLE` by the memory map in the `BootInfo`
     /// can be safely accessed.
-    pub physical_address_offset: VirtualAddress,
-    pub physical_memory_map: Range<VirtualAddress>,
+    pub physical_address_offset: usize, // VirtualAddress
+    pub physical_memory_map: Range<usize>, // VirtualAddress
     /// The thread local storage (TLS) template of the kernel executable, if present.
     pub tls_template: Option<TlsTemplate>,
     /// Virtual address of the loaded kernel image.
-    pub kernel_virt: Range<VirtualAddress>,
+    pub kernel_virt: Range<usize>, // VirtualAddress
     /// Physical memory region where the kernel ELF file resides.
     ///
     /// This field can be used by the kernel to perform introspection of its own ELF file.
-    pub kernel_phys: Range<PhysicalAddress>,
+    pub kernel_phys: Range<usize>, // PhysicalAddress
     pub boot_ticks: u64,
 }
-
-// TODO remove these as they are most definitely not sound. But removing these impls below right now
-//  means  we cant stick it into a `static` anymore which breaks *a lot*.
-//  Our current use is unproblematic (i think) as we're careful to only ever read and never write.
-//  Nonetheless this sucks.
-unsafe impl Send for BootInfo {}
-unsafe impl Sync for BootInfo {}
 
 impl BootInfo {
     /// Create a new boot info structure with the given memory map.
@@ -112,7 +104,7 @@ impl From<MemoryRegions> for &'static mut [MemoryRegion] {
 #[repr(C)]
 pub struct MemoryRegion {
     /// The physical start address region.
-    pub range: Range<PhysicalAddress>,
+    pub range: Range<usize>, // PhysicalAddress
     /// The memory type of the memory region.
     ///
     /// Only [`Usable`][MemoryRegionKind::Usable] regions can be freely used.
@@ -193,7 +185,7 @@ impl fmt::Display for BootInfo {
 #[derive(Debug, Clone)]
 pub struct TlsTemplate {
     /// The address of TLS template
-    pub start_addr: VirtualAddress,
+    pub start_addr: usize, // VirtualAddress
     /// The size of the TLS segment in memory
     pub mem_size: usize,
     /// The size of the TLS segment in the elf file.

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -136,28 +136,28 @@ impl fmt::Display for BootInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
             f,
-            "{:<23} : {}",
+            "{:<23} : {:#x}",
             "PHYSICAL ADDRESS OFFSET", self.physical_address_offset
         )?;
         writeln!(
             f,
-            "{:<23} : {}..{}",
+            "{:<23} : {:#x}..{:#x}",
             "PHYSICAL MEMORY MAP", self.physical_memory_map.start, self.physical_memory_map.end
         )?;
         writeln!(
             f,
-            "{:<23} : {}..{}",
+            "{:<23} : {:#x}..{:#x}",
             "KERNEL VIRT", self.kernel_virt.start, self.kernel_virt.end
         )?;
         writeln!(
             f,
-            "{:<23} : {}..{}",
+            "{:<23} : {:#x}..{:#x}",
             "KERNEL PHYS", self.kernel_phys.start, self.kernel_phys.end
         )?;
         if let Some(tls) = self.tls_template.as_ref() {
             writeln!(
                 f,
-                "{:<23} : .tdata: {}..{}, .tbss: {}..{}",
+                "{:<23} : .tdata: {:#x}..{:#x}, .tbss: {:#x}..{:#x}",
                 "TLS TEMPLATE",
                 tls.start_addr,
                 tls.start_addr.checked_add(tls.file_size).unwrap(),
@@ -171,7 +171,7 @@ impl fmt::Display for BootInfo {
             for (idx, region) in self.memory_regions.iter().enumerate() {
                 writeln!(
                     f,
-                    "MEMORY REGION {:<10}: {}..{} {:?}",
+                    "MEMORY REGION {:<10}: {:#x}..{:#x} {:?}",
                     idx, region.range.start, region.range.end, region.kind,
                 )?;
             }

--- a/loader/src/arch/mod.rs
+++ b/loader/src/arch/mod.rs
@@ -5,6 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::frame_alloc::FrameAllocator;
+use crate::mapping::Flags;
+use core::num::NonZero;
+
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "riscv64")] {
         mod riscv64;
@@ -23,4 +27,26 @@ pub fn abort() -> ! {
             loop {}
         }
     }
+}
+
+pub(crate) unsafe fn map_contiguous(
+    p0: &mut FrameAllocator,
+    p1: usize,
+    p2: usize,
+    p3: NonZero<usize>,
+    p4: Flags,
+) -> crate::Result<()> {
+    todo!()
+}
+
+pub(crate) unsafe fn remap_contiguous(
+    p0: usize,
+    p1: usize,
+    p2: NonZero<usize>,
+) -> crate::Result<()> {
+    todo!()
+}
+
+pub(crate) unsafe fn activate_aspace(p0: usize) {
+    todo!()
 }

--- a/loader/src/arch/mod.rs
+++ b/loader/src/arch/mod.rs
@@ -5,10 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::frame_alloc::FrameAllocator;
-use crate::mapping::Flags;
-use core::num::NonZero;
-
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "riscv64")] {
         mod riscv64;
@@ -27,26 +23,4 @@ pub fn abort() -> ! {
             loop {}
         }
     }
-}
-
-pub(crate) unsafe fn map_contiguous(
-    p0: &mut FrameAllocator,
-    p1: usize,
-    p2: usize,
-    p3: NonZero<usize>,
-    p4: Flags,
-) -> crate::Result<()> {
-    todo!()
-}
-
-pub(crate) unsafe fn remap_contiguous(
-    p0: usize,
-    p1: usize,
-    p2: NonZero<usize>,
-) -> crate::Result<()> {
-    todo!()
-}
-
-pub(crate) unsafe fn activate_aspace(p0: usize) {
-    todo!()
 }

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -5,8 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::error::Error;
+use crate::frame_alloc::FrameAllocator;
+use crate::mapping::Flags;
+use bitflags::bitflags;
 use core::arch::{asm, naked_asm};
+use core::fmt;
+use core::num::NonZero;
+use core::ptr::NonNull;
 use loader_api::BootInfo;
+use riscv::satp;
 
 pub const KERNEL_ASID: usize = 0;
 pub const KERNEL_ASPACE_BASE: usize = 0xffffffc000000000;
@@ -18,6 +26,9 @@ pub const VIRT_ADDR_BITS: u32 = 38;
 
 pub const PAGE_SHIFT: usize = (PAGE_SIZE - 1).count_ones() as usize;
 pub const PAGE_ENTRY_SHIFT: usize = (PAGE_TABLE_ENTRIES - 1).count_ones() as usize;
+
+/// On `RiscV` targets the page table entry's physical address bits are shifted 2 bits to the right.
+const PTE_PPN_SHIFT: usize = 2;
 
 const BOOT_STACK_SIZE: usize = 32 * PAGE_SIZE;
 
@@ -86,7 +97,7 @@ unsafe extern "C" fn _start() -> ! {
 
 pub unsafe fn handoff_to_kernel(hartid: usize, boot_info: *mut BootInfo, entry: usize) -> ! {
     log::debug!("Hart {hartid} Jumping to kernel...");
-    log::trace!("Hart {hartid} entry: {entry}, arguments: a0={hartid} a1={boot_info:?}");
+    log::trace!("Hart {hartid} entry: {entry:#x}, arguments: a0={hartid} a1={boot_info:?}");
 
     unsafe {
         asm! {
@@ -108,6 +119,169 @@ pub unsafe fn handoff_to_kernel(hartid: usize, boot_info: *mut BootInfo, entry: 
     }
 }
 
+pub unsafe fn map_contiguous(
+    root_pgtable: usize,
+    frame_alloc: &mut FrameAllocator,
+    mut virt: usize,
+    mut phys: usize,
+    len: NonZero<usize>,
+    flags: Flags,
+    phys_off: usize,
+) -> crate::Result<()> {
+    let mut remaining_bytes = len.get();
+    debug_assert!(
+        remaining_bytes >= PAGE_SIZE,
+        "address range span be at least one page"
+    );
+    debug_assert!(
+        virt % PAGE_SIZE == 0,
+        "virtual address must be aligned to at least 4KiB page size {virt:?}"
+    );
+    debug_assert!(
+        phys % PAGE_SIZE == 0,
+        "physical address must be aligned to at least 4KiB page size {phys:?}"
+    );
+
+    // To map out contiguous chunk of physical memory into the virtual address space efficiently
+    // we'll attempt to map as much of the chunk using as large of a page size as possible.
+    //
+    // We'll follow the page table down starting at the root page table entry (PTE) and check at
+    // every level if we can map there. This is dictated by the combination of virtual and
+    // physical address alignment as well as chunk size. If we can map at the current level
+    // well subtract the page size from `remaining_bytes`, advance the current virtual and physical
+    // addresses by the page size and repeat the process until there are no more bytes to map.
+    //
+    // IF we can't map at a given level, we'll either allocate a new PTE or follow and existing PTE
+    // to the next level (and therefore smaller page size) until we reach a level that we can map at.
+    // Note that, because we require a minimum alignment and size of PAGE_SIZE, we will always be
+    // able to map a chunk using level 0 pages.
+    //
+    // In effect this algorithm will map the start and ends of chunks using smaller page sizes
+    // while mapping the vast majority of the middle of a chunk using larger page sizes.
+    'outer: while remaining_bytes > 0 {
+        let mut pgtable: NonNull<PageTableEntry> = pgtable_ptr_from_phys(root_pgtable, phys_off);
+
+        for lvl in (0..PAGE_TABLE_LEVELS).rev() {
+            let index = pte_index_for_level(virt, lvl);
+            let pte = unsafe { pgtable.add(index).as_mut() };
+
+            if !pte.is_valid() {
+                // If the PTE is invalid that means we reached a vacant slot to map into.
+                //
+                // First, lets check if we can map at this level of the page table given our
+                // current virtual and physical address as well as the number of remaining bytes.
+                if can_map_at_level(virt, phys, remaining_bytes, lvl) {
+                    let page_size = page_size_for_level(lvl);
+
+                    // This PTE is vacant AND we can map at this level
+                    // mark this PTE as a valid leaf node pointing to the physical frame
+                    pte.replace_address_and_flags(phys, PTEFlags::VALID | PTEFlags::from(flags));
+
+                    virt = virt.checked_add(page_size).unwrap();
+                    phys = phys.checked_add(page_size).unwrap();
+                    remaining_bytes -= page_size;
+                    continue 'outer;
+                } else if !pte.is_valid() {
+                    // The current PTE is vacant, but we couldn't map at this level (because the
+                    // page size was too large, or the request wasn't sufficiently aligned or
+                    // because the architecture just can't map at this level). This means
+                    // we need to allocate a new sub-table and retry.
+                    // allocate a new physical frame to hold the next level table and
+                    // mark this PTE as a valid internal node pointing to that sub-table.
+                    let frame = frame_alloc
+                        .allocate_one_zeroed(phys_off)
+                        .ok_or(Error::NoMemory)?; // we should always be able to map a single page
+
+                    // TODO memory barrier
+
+                    pte.replace_address_and_flags(frame, PTEFlags::VALID);
+
+                    pgtable = pgtable_ptr_from_phys(frame, phys_off);
+                }
+            } else if !pte.is_leaf() {
+                // This PTE is an internal node pointing to another page table
+                pgtable = pgtable_ptr_from_phys(pte.get_address_and_flags().0, phys_off);
+            } else {
+                unreachable!("Invalid state: PTE can't be valid leaf (this means {virt:?} is already mapped) {pte:?} {pte:p}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub unsafe fn remap_contiguous(
+    root_pgtable: usize,
+    mut virt: usize,
+    mut phys: usize,
+    len: NonZero<usize>,
+    phys_off: usize,
+) -> crate::Result<()> {
+    let mut remaining_bytes = len.get();
+    debug_assert!(
+        remaining_bytes >= PAGE_SIZE,
+        "virtual address range must span be at least one page"
+    );
+    debug_assert!(
+        virt % PAGE_SIZE == 0,
+        "virtual address must be aligned to at least 4KiB page size"
+    );
+    debug_assert!(
+        phys % PAGE_SIZE == 0,
+        "physical address must be aligned to at least 4KiB page size"
+    );
+
+    // This algorithm behaves a lot like the above one for `map_contiguous` but with an important
+    // distinction: Since we require the entire range to already be mapped, we follow the page tables
+    // until we reach a valid PTE. Once we reached, we assert that we can map the given physical
+    // address here and simply update the PTEs address. We then again repeat this until we have
+    // no more bytes to process.
+    'outer: while remaining_bytes > 0 {
+        let mut pgtable = pgtable_ptr_from_phys(root_pgtable, phys_off);
+
+        for lvl in (0..PAGE_TABLE_LEVELS).rev() {
+            let pte = unsafe {
+                let index = pte_index_for_level(virt, lvl);
+                pgtable.add(index).as_mut()
+            };
+
+            if pte.is_valid() && pte.is_leaf() {
+                // We reached the previously mapped leaf node that we want to edit
+                // assert that we can actually map at this level (remap requires users to remap
+                // only to equal or larger alignments, but we should make sure.
+                let page_size = page_size_for_level(lvl);
+
+                debug_assert!(
+                    can_map_at_level(virt, phys, remaining_bytes, lvl),
+                    "remapping requires the same alignment ({page_size}) but found {phys:?}, {remaining_bytes}bytes"
+                );
+
+                let (_old_phys, flags) = pte.get_address_and_flags();
+                pte.replace_address_and_flags(phys, flags);
+
+                virt = virt.checked_add(page_size).unwrap();
+                phys = phys.checked_add(page_size).unwrap();
+                remaining_bytes -= page_size;
+                continue 'outer;
+            } else if pte.is_valid() {
+                // This PTE is an internal node pointing to another page table
+                pgtable = pgtable_ptr_from_phys(pte.get_address_and_flags().0, phys_off);
+            } else {
+                unreachable!("Invalid state: PTE cant be vacant or invalid+leaf {pte:?}");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub unsafe fn activate_aspace(pgtable: usize) {
+    unsafe {
+        let ppn = pgtable >> 12;
+        satp::set(satp::Mode::Sv39, KERNEL_ASID, ppn);
+    }
+}
+
 /// Return the page size for the given page table level.
 ///
 /// # Panics
@@ -118,4 +292,129 @@ pub fn page_size_for_level(level: usize) -> usize {
     let page_size = 1 << (PAGE_SHIFT + level * PAGE_ENTRY_SHIFT);
     debug_assert!(page_size == 4096 || page_size == 2097152 || page_size == 1073741824);
     page_size
+}
+
+/// Parse the `level`nth page table entry index from the given virtual address.
+///
+/// # Panics
+///
+/// Panics if the provided level is `>= PAGE_TABLE_LEVELS`.
+pub fn pte_index_for_level(virt: usize, lvl: usize) -> usize {
+    assert!(lvl < PAGE_TABLE_LEVELS);
+    let index = (virt >> (PAGE_SHIFT + lvl * PAGE_ENTRY_SHIFT)) & (PAGE_TABLE_ENTRIES - 1);
+    debug_assert!(index < PAGE_TABLE_ENTRIES);
+
+    index
+}
+
+/// Return whether the combination of `virt`,`phys`, and `remaining_bytes` can be mapped at the given `level`.
+///
+/// This is the case when both the virtual and physical address are aligned to the page size at this level
+/// AND the remaining size is at least the page size.
+pub fn can_map_at_level(virt: usize, phys: usize, remaining_bytes: usize, lvl: usize) -> bool {
+    let page_size = page_size_for_level(lvl);
+    virt % page_size == 0 && phys % page_size == 0 && remaining_bytes >= page_size
+}
+
+fn pgtable_ptr_from_phys(phys: usize, phys_off: usize) -> NonNull<PageTableEntry> {
+    NonNull::new(phys_off.checked_add(phys).unwrap() as *mut PageTableEntry).unwrap()
+}
+
+#[repr(transparent)]
+pub struct PageTableEntry {
+    bits: usize,
+}
+
+impl fmt::Debug for PageTableEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let rsw = (self.bits & ((1 << 2) - 1) << 8) >> 8;
+        let ppn0 = (self.bits & ((1 << 9) - 1) << 10) >> 10;
+        let ppn1 = (self.bits & ((1 << 9) - 1) << 19) >> 19;
+        let ppn2 = (self.bits & ((1 << 26) - 1) << 28) >> 28;
+        let reserved = (self.bits & ((1 << 7) - 1) << 54) >> 54;
+        let pbmt = (self.bits & ((1 << 2) - 1) << 61) >> 61;
+        let n = (self.bits & ((1 << 1) - 1) << 63) >> 63;
+
+        f.debug_struct("PageTableEntry")
+            .field("n", &format_args!("{n:01b}"))
+            .field("pbmt", &format_args!("{pbmt:02b}"))
+            .field("reserved", &format_args!("{reserved:07b}"))
+            .field("ppn2", &format_args!("{ppn2:026b}"))
+            .field("ppn1", &format_args!("{ppn1:09b}"))
+            .field("ppn0", &format_args!("{ppn0:09b}"))
+            .field("rsw", &format_args!("{rsw:02b}"))
+            .field("flags", &self.get_address_and_flags().1)
+            .finish()
+    }
+}
+
+impl PageTableEntry {
+    pub fn is_valid(&self) -> bool {
+        PTEFlags::from_bits_retain(self.bits).contains(PTEFlags::VALID)
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        PTEFlags::from_bits_retain(self.bits)
+            .intersects(PTEFlags::READ | PTEFlags::WRITE | PTEFlags::EXECUTE)
+    }
+
+    pub fn replace_address_and_flags(&mut self, address: usize, flags: PTEFlags) {
+        self.bits &= PTEFlags::all().bits(); // clear all previous flags
+        self.bits |= (address >> PTE_PPN_SHIFT) | flags.bits();
+    }
+
+    pub fn get_address_and_flags(&self) -> (usize, PTEFlags) {
+        // TODO correctly mask out address
+        let addr = (self.bits & !PTEFlags::all().bits()) << PTE_PPN_SHIFT;
+        let flags = PTEFlags::from_bits_truncate(self.bits);
+        (addr, flags)
+    }
+}
+
+bitflags! {
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+    pub struct PTEFlags: usize {
+        const VALID     = 1 << 0;
+        const READ      = 1 << 1;
+        const WRITE     = 1 << 2;
+        const EXECUTE   = 1 << 3;
+        const USER      = 1 << 4;
+        const GLOBAL    = 1 << 5;
+        const ACCESSED    = 1 << 6;
+        const DIRTY     = 1 << 7;
+    }
+}
+
+impl From<Flags> for PTEFlags {
+    fn from(flags: Flags) -> Self {
+        let mut out = Self::VALID | Self::DIRTY | Self::ACCESSED;
+
+        for flag in flags {
+            match flag {
+                Flags::READ => out.insert(Self::READ),
+                Flags::WRITE => out.insert(Self::WRITE),
+                Flags::EXECUTE => out.insert(Self::EXECUTE),
+                _ => unreachable!(),
+            }
+        }
+
+        out
+    }
+}
+
+impl From<PTEFlags> for Flags {
+    fn from(arch_flags: PTEFlags) -> Self {
+        let mut out = Flags::empty();
+
+        for flag in arch_flags {
+            match flag {
+                PTEFlags::READ => out.insert(Self::READ),
+                PTEFlags::WRITE => out.insert(Self::WRITE),
+                PTEFlags::EXECUTE => out.insert(Self::EXECUTE),
+                _ => unreachable!(),
+            }
+        }
+
+        out
+    }
 }

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -5,24 +5,24 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch;
 use crate::error::Error;
+use crate::frame_alloc::FrameAllocator;
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
 use core::range::Range;
 use core::slice;
 use loader_api::{BootInfo, MemoryRegion, MemoryRegionKind, MemoryRegions, TlsTemplate};
-use mmu::frame_alloc::{BootstrapAllocator, FrameAllocator};
-use mmu::{arch, PhysicalAddress, VirtualAddress};
 
 pub fn prepare_boot_info(
-    mut frame_alloc: BootstrapAllocator,
-    physical_address_offset: VirtualAddress,
-    physical_memory_map: Range<VirtualAddress>,
-    kernel_virt: Range<VirtualAddress>,
+    mut frame_alloc: FrameAllocator,
+    physical_address_offset: usize,
+    physical_memory_map: Range<usize>,
+    kernel_virt: Range<usize>,
     maybe_tls_template: Option<TlsTemplate>,
-    loader_phys: Range<PhysicalAddress>,
-    kernel_phys: Range<PhysicalAddress>,
-    fdt_phys: Range<PhysicalAddress>,
+    loader_phys: Range<usize>,
+    kernel_phys: Range<usize>,
+    fdt_phys: Range<usize>,
     boot_ticks: u64,
 ) -> crate::Result<*mut BootInfo> {
     let frame = frame_alloc
@@ -30,7 +30,7 @@ pub fn prepare_boot_info(
             Layout::from_size_align(arch::PAGE_SIZE, arch::PAGE_SIZE).unwrap(),
         )
         .ok_or(Error::NoMemory)?;
-    let page = VirtualAddress::from_phys(frame, physical_address_offset).unwrap();
+    let page = physical_address_offset.checked_add(frame).unwrap();
 
     let memory_regions =
         init_boot_info_memory_regions(page, frame_alloc, fdt_phys, loader_phys.clone());
@@ -43,23 +43,23 @@ pub fn prepare_boot_info(
     boot_info.kernel_phys = kernel_phys;
     boot_info.boot_ticks = boot_ticks;
 
-    let boot_info_ptr = page.as_mut_ptr().cast::<BootInfo>();
+    let boot_info_ptr = page as *mut BootInfo;
     unsafe { boot_info_ptr.write(boot_info) }
 
     Ok(boot_info_ptr)
 }
 
 fn init_boot_info_memory_regions(
-    page: VirtualAddress,
-    frame_alloc: BootstrapAllocator,
-    fdt_phys: Range<PhysicalAddress>,
-    loader_phys: Range<PhysicalAddress>,
+    page: usize,
+    frame_alloc: FrameAllocator,
+    fdt_phys: Range<usize>,
+    loader_phys: Range<usize>,
 ) -> MemoryRegions {
     let regions: &mut [MaybeUninit<MemoryRegion>] = unsafe {
         let base = page.checked_add(size_of::<BootInfo>()).unwrap();
         let len = (arch::PAGE_SIZE - size_of::<BootInfo>()) / size_of::<MemoryRegion>();
 
-        slice::from_raw_parts_mut(base.as_mut_ptr().cast(), len)
+        slice::from_raw_parts_mut(base as *mut MaybeUninit<MemoryRegion>, len)
     };
 
     let mut len = 0;

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -14,6 +14,7 @@ use core::range::Range;
 use core::slice;
 use loader_api::{BootInfo, MemoryRegion, MemoryRegionKind, MemoryRegions, TlsTemplate};
 
+#[allow(clippy::too_many_arguments)]
 pub fn prepare_boot_info(
     mut frame_alloc: FrameAllocator,
     physical_address_offset: usize,
@@ -28,12 +29,12 @@ pub fn prepare_boot_info(
     let frame = frame_alloc
         .allocate_contiguous_zeroed(
             Layout::from_size_align(arch::PAGE_SIZE, arch::PAGE_SIZE).unwrap(),
+            arch::KERNEL_ASPACE_BASE,
         )
         .ok_or(Error::NoMemory)?;
     let page = physical_address_offset.checked_add(frame).unwrap();
 
-    let memory_regions =
-        init_boot_info_memory_regions(page, frame_alloc, fdt_phys, loader_phys.clone());
+    let memory_regions = init_boot_info_memory_regions(page, frame_alloc, fdt_phys, loader_phys);
 
     let mut boot_info = BootInfo::new(memory_regions);
     boot_info.physical_address_offset = physical_address_offset;

--- a/loader/src/error.rs
+++ b/loader/src/error.rs
@@ -9,8 +9,6 @@ use core::fmt::{Display, Formatter};
 
 #[derive(Debug)]
 pub enum Error {
-    /// MMU error
-    Mmu(mmu::Error),
     /// Failed to convert number
     TryFromInt(core::num::TryFromIntError),
     /// Failed to parse device tree blob
@@ -19,16 +17,6 @@ pub enum Error {
     Elf(&'static str),
     /// The system was not able to allocate memory needed for the operation.
     NoMemory,
-}
-
-impl From<mmu::Error> for Error {
-    fn from(err: mmu::Error) -> Self {
-        if matches!(err, mmu::Error::NoMemory) {
-            Error::NoMemory
-        } else {
-            Error::Mmu(err)
-        }
-    }
 }
 
 impl From<core::num::TryFromIntError> for Error {
@@ -46,7 +34,6 @@ impl From<dtb_parser::Error> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
-            Error::Mmu(err) => write!(f, "MMU error: {err}"),
             Error::NoMemory => write!(
                 f,
                 "The system was not able to allocate memory needed for the operation"

--- a/loader/src/frame_alloc.rs
+++ b/loader/src/frame_alloc.rs
@@ -1,0 +1,216 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::arch;
+use core::alloc::Layout;
+use core::range::Range;
+use core::{iter, slice};
+
+#[derive(Debug, Default)]
+pub struct FrameUsage {
+    pub used: usize,
+    pub total: usize,
+}
+
+pub struct FrameAllocator<'a> {
+    regions: &'a [Range<usize>],
+    // offset from the top of memory regions
+    offset: usize,
+    phys_offset: usize,
+}
+
+impl<'a> FrameAllocator<'a> {
+    /// Create a new frame allocator over a given set of physical memory regions.
+    #[must_use]
+    pub fn new(regions: &'a [Range<usize>]) -> Self {
+        Self {
+            regions,
+            offset: 0,
+            phys_offset: 0,
+        }
+    }
+
+    pub fn set_phys_offset(&mut self, phys_offset: usize) {
+        self.phys_offset = phys_offset;
+    }
+
+    #[must_use]
+    pub fn free_regions(&self) -> FreeRegions<'_> {
+        FreeRegions {
+            offset: self.offset,
+            inner: self.regions.iter().rev().cloned(),
+        }
+    }
+
+    #[must_use]
+    pub fn used_regions(&self) -> UsedRegions<'_> {
+        UsedRegions {
+            offset: self.offset,
+            inner: self.regions.iter().rev().cloned(),
+        }
+    }
+
+    pub fn frame_usage(&self) -> FrameUsage {
+        let mut total = 0;
+        for region in self.regions {
+            let region_size = region.end.checked_sub(region.start).unwrap();
+            total += region_size >> arch::PAGE_SHIFT;
+        }
+        let used = self.offset >> arch::PAGE_SHIFT;
+        FrameUsage { used, total }
+    }
+
+    pub fn allocate_one_zeroed(&mut self) -> Option<usize> {
+        todo!()
+    }
+
+    pub fn allocate_contiguous(&mut self, layout: Layout) -> Option<usize> {
+        todo!()
+    }
+
+    pub fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<usize> {
+        todo!()
+    }
+}
+
+// impl FrameAllocator for mmu::frame_alloc::BootstrapAllocator<'_> {
+//     fn allocate_one(&mut self) -> Option<PhysicalAddress> {
+//         self.allocate_contiguous(unsafe { Layout::from_size_align_unchecked(PAGE_SIZE, PAGE_SIZE) })
+//     }
+//
+//
+//     fn allocate_contiguous(&mut self, layout: Layout) -> Option<PhysicalAddress> {
+//         let requested_size = layout.pad_to_align().size();
+//         assert_eq!(
+//             layout.align(),
+//             arch::PAGE_SIZE,
+//             "BootstrapAllocator only supports page-aligned allocations"
+//         );
+//         let mut offset = self.offset;
+//
+//         for region in self.regions.iter().rev() {
+//             // only consider regions that we haven't already exhausted
+//             if offset < region.size() {
+//                 // Allocating a contiguous range has different requirements than "regular" allocation
+//                 // contiguous are rare and often happen in very critical paths where e.g. virtual
+//                 // memory is not available yet. So we rather waste some memory than outright crash.
+//                 if region.size() - offset < requested_size {
+//                     log::warn!("Skipped memory region {region:?} since it was fulfill request for {requested_size} bytes. Wasted {} bytes in the process...", region.size() - offset);
+//
+//                     self.offset += region.size() - offset;
+//                     offset = 0;
+//                     continue;
+//                 }
+//
+//                 let frame = region.end.checked_sub(offset + requested_size).unwrap();
+//                 self.offset += requested_size;
+//
+//                 return Some(frame);
+//             }
+//
+//             offset -= region.size();
+//         }
+//
+//         None
+//     }
+//
+//     fn deallocate_contiguous(&mut self, _addr: PhysicalAddress, _layout: Layout) {
+//         unimplemented!("Bootstrap allocator can't free");
+//     }
+//
+//     fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<PhysicalAddress> {
+//         let requested_size = layout.pad_to_align().size();
+//         let addr = self.allocate_contiguous(layout)?;
+//         unsafe {
+//             ptr::write_bytes::<u8>(
+//                 self.phys_offset
+//                     .checked_add(addr.get())
+//                     .unwrap()
+//                     .as_mut_ptr(),
+//                 0,
+//                 requested_size,
+//             )
+//         }
+//         Some(addr)
+//     }
+//
+//     fn allocate_partial(&mut self, layout: Layout) -> Option<(PhysicalAddress, usize)> {
+//         let requested_size = layout.pad_to_align().size();
+//         assert_eq!(
+//             layout.align(),
+//             arch::PAGE_SIZE,
+//             "BootstrapAllocator only supports page-aligned allocations"
+//         );
+//         let mut offset = self.offset;
+//
+//         for region in self.regions.iter().rev() {
+//             // only consider regions that we haven't already exhausted
+//             if offset < region.size() {
+//                 let alloc_size = cmp::min(requested_size, region.size() - offset);
+//
+//                 let frame = region.end.checked_sub(offset + alloc_size).unwrap();
+//                 self.offset += alloc_size;
+//
+//                 return Some((frame, alloc_size));
+//             }
+//
+//             offset -= region.size();
+//         }
+//
+//         None
+//     }
+// }
+
+pub struct FreeRegions<'a> {
+    offset: usize,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<usize>>>>,
+}
+
+impl Iterator for FreeRegions<'_> {
+    type Item = Range<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let mut region = self.inner.next()?;
+            // keep advancing past already fully used memory regions
+            let region_size = region.end.checked_sub(region.start).unwrap();
+            if self.offset >= region_size {
+                self.offset -= region_size;
+                continue;
+            } else if self.offset > 0 {
+                region.end = region.end.checked_sub(self.offset).unwrap();
+                self.offset = 0;
+            }
+
+            return Some(region);
+        }
+    }
+}
+
+pub struct UsedRegions<'a> {
+    offset: usize,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<usize>>>>,
+}
+
+impl Iterator for UsedRegions<'_> {
+    type Item = Range<usize>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut region = self.inner.next()?;
+
+        if self.offset >= region.end.checked_sub(region.start).unwrap() {
+            Some(region)
+        } else if self.offset > 0 {
+            region.start = region.end.checked_sub(self.offset).unwrap();
+            self.offset = 0;
+
+            Some(region)
+        } else {
+            None
+        }
+    }
+}

--- a/loader/src/frame_alloc.rs
+++ b/loader/src/frame_alloc.rs
@@ -8,13 +8,7 @@
 use crate::arch;
 use core::alloc::Layout;
 use core::range::Range;
-use core::{iter, slice};
-
-#[derive(Debug, Default)]
-pub struct FrameUsage {
-    pub used: usize,
-    pub total: usize,
-}
+use core::{iter, ptr, slice};
 
 pub struct FrameAllocator<'a> {
     regions: &'a [Range<usize>],
@@ -54,116 +48,71 @@ impl<'a> FrameAllocator<'a> {
         }
     }
 
-    pub fn frame_usage(&self) -> FrameUsage {
-        let mut total = 0;
-        for region in self.regions {
-            let region_size = region.end.checked_sub(region.start).unwrap();
-            total += region_size >> arch::PAGE_SHIFT;
-        }
-        let used = self.offset >> arch::PAGE_SHIFT;
-        FrameUsage { used, total }
+    pub fn frame_usage(&self) -> usize {
+        self.offset >> arch::PAGE_SHIFT
     }
 
-    pub fn allocate_one_zeroed(&mut self) -> Option<usize> {
-        todo!()
+    pub fn allocate_one_zeroed(&mut self, phys_offset: usize) -> Option<usize> {
+        self.allocate_contiguous_zeroed(
+            unsafe { Layout::from_size_align_unchecked(arch::PAGE_SIZE, arch::PAGE_SIZE) },
+            phys_offset,
+        )
     }
 
     pub fn allocate_contiguous(&mut self, layout: Layout) -> Option<usize> {
-        todo!()
+        let requested_size = layout.pad_to_align().size();
+        assert_eq!(
+            layout.align(),
+            arch::PAGE_SIZE,
+            "BootstrapAllocator only supports page-aligned allocations"
+        );
+        let mut offset = self.offset;
+
+        for region in self.regions.iter().rev() {
+            let region_size = region.end.checked_sub(region.start).unwrap();
+
+            // only consider regions that we haven't already exhausted
+            if offset < region_size {
+                // Allocating a contiguous range has different requirements than "regular" allocation
+                // contiguous are rare and often happen in very critical paths where e.g. virtual
+                // memory is not available yet. So we rather waste some memory than outright crash.
+                if region_size - offset < requested_size {
+                    log::warn!("Skipped memory region {region:?} since it was fulfill request for {requested_size} bytes. Wasted {} bytes in the process...", region_size - offset);
+
+                    self.offset += region_size - offset;
+                    offset = 0;
+                    continue;
+                }
+
+                let frame = region.end.checked_sub(offset + requested_size).unwrap();
+                self.offset += requested_size;
+
+                return Some(frame);
+            }
+
+            offset -= region_size;
+        }
+
+        None
     }
 
-    pub fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<usize> {
-        todo!()
+    pub fn allocate_contiguous_zeroed(
+        &mut self,
+        layout: Layout,
+        phys_offset: usize,
+    ) -> Option<usize> {
+        let requested_size = layout.pad_to_align().size();
+        let addr = self.allocate_contiguous(layout)?;
+        unsafe {
+            ptr::write_bytes::<u8>(
+                phys_offset.checked_add(addr).unwrap() as *mut u8,
+                0,
+                requested_size,
+            )
+        }
+        Some(addr)
     }
 }
-
-// impl FrameAllocator for mmu::frame_alloc::BootstrapAllocator<'_> {
-//     fn allocate_one(&mut self) -> Option<PhysicalAddress> {
-//         self.allocate_contiguous(unsafe { Layout::from_size_align_unchecked(PAGE_SIZE, PAGE_SIZE) })
-//     }
-//
-//
-//     fn allocate_contiguous(&mut self, layout: Layout) -> Option<PhysicalAddress> {
-//         let requested_size = layout.pad_to_align().size();
-//         assert_eq!(
-//             layout.align(),
-//             arch::PAGE_SIZE,
-//             "BootstrapAllocator only supports page-aligned allocations"
-//         );
-//         let mut offset = self.offset;
-//
-//         for region in self.regions.iter().rev() {
-//             // only consider regions that we haven't already exhausted
-//             if offset < region.size() {
-//                 // Allocating a contiguous range has different requirements than "regular" allocation
-//                 // contiguous are rare and often happen in very critical paths where e.g. virtual
-//                 // memory is not available yet. So we rather waste some memory than outright crash.
-//                 if region.size() - offset < requested_size {
-//                     log::warn!("Skipped memory region {region:?} since it was fulfill request for {requested_size} bytes. Wasted {} bytes in the process...", region.size() - offset);
-//
-//                     self.offset += region.size() - offset;
-//                     offset = 0;
-//                     continue;
-//                 }
-//
-//                 let frame = region.end.checked_sub(offset + requested_size).unwrap();
-//                 self.offset += requested_size;
-//
-//                 return Some(frame);
-//             }
-//
-//             offset -= region.size();
-//         }
-//
-//         None
-//     }
-//
-//     fn deallocate_contiguous(&mut self, _addr: PhysicalAddress, _layout: Layout) {
-//         unimplemented!("Bootstrap allocator can't free");
-//     }
-//
-//     fn allocate_contiguous_zeroed(&mut self, layout: Layout) -> Option<PhysicalAddress> {
-//         let requested_size = layout.pad_to_align().size();
-//         let addr = self.allocate_contiguous(layout)?;
-//         unsafe {
-//             ptr::write_bytes::<u8>(
-//                 self.phys_offset
-//                     .checked_add(addr.get())
-//                     .unwrap()
-//                     .as_mut_ptr(),
-//                 0,
-//                 requested_size,
-//             )
-//         }
-//         Some(addr)
-//     }
-//
-//     fn allocate_partial(&mut self, layout: Layout) -> Option<(PhysicalAddress, usize)> {
-//         let requested_size = layout.pad_to_align().size();
-//         assert_eq!(
-//             layout.align(),
-//             arch::PAGE_SIZE,
-//             "BootstrapAllocator only supports page-aligned allocations"
-//         );
-//         let mut offset = self.offset;
-//
-//         for region in self.regions.iter().rev() {
-//             // only consider regions that we haven't already exhausted
-//             if offset < region.size() {
-//                 let alloc_size = cmp::min(requested_size, region.size() - offset);
-//
-//                 let frame = region.end.checked_sub(offset + alloc_size).unwrap();
-//                 self.offset += alloc_size;
-//
-//                 return Some((frame, alloc_size));
-//             }
-//
-//             offset -= region.size();
-//         }
-//
-//         None
-//     }
-// }
 
 pub struct FreeRegions<'a> {
     offset: usize,

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -45,7 +45,7 @@ pub struct Kernel<'a> {
     pub _loader_config: &'a LoaderConfig,
 }
 
-impl<'a> Kernel<'a> {
+impl Kernel<'_> {
     /// Returns the size of the kernel in memory.
     pub fn mem_size(&self) -> u64 {
         let max_addr = self

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -9,11 +9,11 @@
 #![no_main]
 #![feature(naked_functions)]
 #![feature(new_range_api)]
-#![feature(slice_from_ptr_range)]
 #![feature(maybe_uninit_slice)]
 
 use crate::boot_info::prepare_boot_info;
 use crate::error::Error;
+use crate::frame_alloc::FrameAllocator;
 use crate::kernel::{parse_kernel, INLINED_KERNEL_BYTES};
 use crate::machine_info::MachineInfo;
 use crate::mapping::{identity_map_self, map_kernel, map_physical_memory};
@@ -22,13 +22,11 @@ use core::alloc::Layout;
 use core::ffi::c_void;
 use core::range::Range;
 use core::{ptr, slice};
-use mmu::arch::PAGE_SIZE;
-use mmu::frame_alloc::{BootstrapAllocator, FrameAllocator};
-use mmu::{AddressRangeExt, AddressSpace, Flush, PhysicalAddress, VirtualAddress, KIB};
 
 mod arch;
 mod boot_info;
 mod error;
+mod frame_alloc;
 mod kernel;
 mod logger;
 mod machine_info;
@@ -67,7 +65,7 @@ pub fn main(hartid: usize, opaque: *const c_void, boot_ticks: u64) -> ! {
 
     // Initialize the frame allocator
     let allocatable_memories = allocatable_memory_regions(&minfo, &self_regions);
-    let mut frame_alloc = BootstrapAllocator::new(&allocatable_memories);
+    let mut frame_alloc = FrameAllocator::new(&allocatable_memories);
 
     // Initialize the page allocator
     let mut page_alloc = page_alloc::init(&minfo);
@@ -75,13 +73,7 @@ pub fn main(hartid: usize, opaque: *const c_void, boot_ticks: u64) -> ! {
     let fdt_phys = allocate_and_copy(&mut frame_alloc, minfo.fdt).unwrap();
     let kernel_phys = allocate_and_copy(&mut frame_alloc, &INLINED_KERNEL_BYTES.0).unwrap();
 
-    // Initialize the kernel address space
-    let (mut aspace, mut flush) = AddressSpace::new(
-        &mut frame_alloc,
-        arch::KERNEL_ASID,
-        VirtualAddress::default(),
-    )
-    .unwrap();
+    let root_pgtable = frame_alloc.allocate_one_zeroed().unwrap();
 
     // Identity map the loader itself (this binary).
     //
@@ -89,55 +81,46 @@ pub fn main(hartid: usize, opaque: *const c_void, boot_ticks: u64) -> ! {
     // as opposed to m-mode where it would take effect after the jump to s-mode.
     // This means we need to temporarily identity map the loader here, so we can continue executing our own code.
     // We will then unmap the loader in the kernel.
-    identity_map_self(&mut aspace, &mut frame_alloc, &self_regions, &mut flush).unwrap();
+    identity_map_self(&mut frame_alloc, &self_regions).unwrap();
 
     // Map the physical memory into kernel address space.
     //
     // This will be used by the kernel to access the page tables, BootInfo struct and maybe
     // more in the future.
-    let (phys_off, phys_map) = map_physical_memory(
-        &mut aspace,
-        &mut frame_alloc,
-        &mut page_alloc,
-        &minfo,
-        &mut flush,
-    )
-    .unwrap();
+    let (phys_off, phys_map) =
+        map_physical_memory(&mut frame_alloc, &mut page_alloc, &minfo).unwrap();
 
-    // Turn on the MMU
-    let (mut aspace, mut flush) = enable_mmu(aspace, flush, &mut frame_alloc, phys_off);
+    // Activate the MMU with the address space we have built so far.
+    // the rest of the address space setup will happen in virtual memory (mostly so that we
+    // can correctly apply relocations without having to do expensive virt to phys queries)
+    unsafe {
+        log::trace!("activating MMU...");
+        arch::activate_aspace(root_pgtable);
+        log::trace!("activated.");
+    }
+    frame_alloc.set_phys_offset(phys_off);
 
     // The kernel elf file is inlined into the loader executable as part of the build setup
     // which means we just need to parse it here.
     let kernel = parse_kernel(unsafe {
-        slice::from_ptr_range(
-            kernel_phys
-                .clone()
-                .checked_add(phys_off.get())
-                .unwrap()
-                .as_ptr_range()
-                .into(),
-        )
+        let base = phys_off.checked_add(kernel_phys.start).unwrap();
+        let len = kernel_phys.end.checked_sub(kernel_phys.start).unwrap();
+
+        slice::from_raw_parts(base as *mut u8, len)
     })
     .unwrap();
     // print the elf sections for debugging purposes
     log::debug!("\n{kernel}");
 
-    let (kernel_virt, maybe_tls_template) = map_kernel(
-        &mut aspace,
-        &mut frame_alloc,
-        &mut page_alloc,
-        &kernel,
-        &mut flush,
-    )
-    .unwrap();
+    let (kernel_virt, maybe_tls_template) =
+        map_kernel(&mut frame_alloc, &mut page_alloc, &kernel).unwrap();
 
     log::trace!("KASLR: Kernel image at {}", kernel_virt.start);
 
     let frame_usage = frame_alloc.frame_usage();
     log::debug!(
         "Mapping complete, permanently used {} KiB.",
-        (frame_usage.used * PAGE_SIZE) / KIB,
+        (frame_usage.used * arch::PAGE_SIZE) / 1024,
     );
 
     let boot_info = prepare_boot_info(
@@ -163,9 +146,9 @@ pub fn main(hartid: usize, opaque: *const c_void, boot_ticks: u64) -> ! {
 
 #[derive(Debug)]
 struct SelfRegions {
-    pub executable: Range<PhysicalAddress>,
-    pub read_only: Range<PhysicalAddress>,
-    pub read_write: Range<PhysicalAddress>,
+    pub executable: Range<usize>,
+    pub read_only: Range<usize>,
+    pub read_write: Range<usize>,
 }
 
 impl SelfRegions {
@@ -181,16 +164,16 @@ impl SelfRegions {
 
         SelfRegions {
             executable: Range {
-                start: PhysicalAddress::new(&raw const __text_start as usize),
-                end: PhysicalAddress::new(&raw const __text_end as usize),
+                start: &raw const __text_start as usize,
+                end: &raw const __text_end as usize,
             },
             read_only: Range {
-                start: PhysicalAddress::new(&raw const __rodata_start as usize),
-                end: PhysicalAddress::new(&raw const __rodata_end as usize),
+                start: &raw const __rodata_start as usize,
+                end: &raw const __rodata_end as usize,
             },
             read_write: Range {
-                start: PhysicalAddress::new(&raw const __bss_start as usize),
-                end: PhysicalAddress::new(&raw const __data_end as usize),
+                start: &raw const __bss_start as usize,
+                end: &raw const __data_end as usize,
             },
         }
     }
@@ -199,7 +182,7 @@ impl SelfRegions {
 fn allocatable_memory_regions(
     minfo: &MachineInfo,
     self_regions: &SelfRegions,
-) -> ArrayVec<Range<PhysicalAddress>, 16> {
+) -> ArrayVec<Range<usize>, 16> {
     let mut out = ArrayVec::new();
     let to_exclude = Range::from(self_regions.executable.start..self_regions.read_write.end);
 
@@ -224,42 +207,17 @@ fn allocatable_memory_regions(
     out
 }
 
-fn allocate_and_copy(
-    frame_alloc: &mut BootstrapAllocator,
-    src: &[u8],
-) -> Result<Range<PhysicalAddress>> {
-    let layout = Layout::from_size_align(src.len(), PAGE_SIZE).unwrap();
+fn allocate_and_copy(frame_alloc: &mut FrameAllocator, src: &[u8]) -> Result<Range<usize>> {
+    let layout = Layout::from_size_align(src.len(), arch::PAGE_SIZE).unwrap();
     let base = frame_alloc
         .allocate_contiguous(layout)
         .ok_or(Error::NoMemory)?;
 
     unsafe {
-        let dst = slice::from_raw_parts_mut(base.as_mut_ptr(), src.len());
+        let dst = slice::from_raw_parts_mut(base as *mut u8, src.len());
 
         ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr(), dst.len());
     }
 
     Ok(Range::from(base..base.checked_add(layout.size()).unwrap()))
-}
-
-fn enable_mmu(
-    aspace: AddressSpace,
-    flush: Flush,
-    frame_alloc: &mut BootstrapAllocator,
-    phys_off: VirtualAddress,
-) -> (AddressSpace, Flush) {
-    // Activate the MMU with the address space we have built so far.
-    // the rest of the address space setup will happen in virtual memory (mostly so that we
-    // can correctly apply relocations without having to do expensive virt to phys queries)
-    unsafe {
-        log::trace!("activating MMU...");
-        flush.ignore();
-        aspace.activate();
-        log::trace!("activated.");
-    }
-    frame_alloc.set_phys_offset(phys_off);
-
-    // Reconstruct the aspace with the new physical memory mapping offset since we're in virtual
-    // memory mode now.
-    AddressSpace::from_active(arch::KERNEL_ASID, phys_off)
 }

--- a/loader/src/mapping.rs
+++ b/loader/src/mapping.rs
@@ -6,62 +6,58 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::error::Error;
+use crate::frame_alloc::FrameAllocator;
 use crate::kernel::Kernel;
 use crate::machine_info::MachineInfo;
 use crate::page_alloc::PageAllocator;
 use crate::{arch, SelfRegions};
+use bitflags::bitflags;
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
 use core::range::Range;
 use core::{ptr, slice};
 use loader_api::TlsTemplate;
-use mmu::arch::PAGE_SIZE;
-use mmu::frame_alloc::{BootstrapAllocator, FrameAllocator, NonContiguousFrames};
-use mmu::{AddressRangeExt, AddressSpace, Flush, PhysicalAddress, VirtualAddress};
 use xmas_elf::dynamic::Tag;
 use xmas_elf::program::{SegmentData, Type};
 use xmas_elf::P64;
 
+bitflags! {
+    #[derive(Debug, Copy, Clone, PartialEq)]
+    pub struct Flags: u8 {
+        const READ = 1 << 0;
+        const WRITE = 1 << 1;
+        const EXECUTE = 1 << 2;
+    }
+}
+
 pub fn identity_map_self(
-    aspace: &mut AddressSpace,
-    frame_alloc: &mut BootstrapAllocator,
+    frame_alloc: &mut FrameAllocator,
     self_regions: &SelfRegions,
-    flush: &mut Flush,
 ) -> crate::Result<()> {
     log::trace!(
         "Identity mapping loader executable region {:?}...",
         self_regions.executable
     );
     identity_map_range(
-        aspace,
         frame_alloc,
         self_regions.executable.clone(),
-        mmu::Flags::READ | mmu::Flags::EXECUTE,
-        flush,
+        Flags::READ | Flags::EXECUTE,
     )?;
 
     log::trace!(
         "Identity mapping loader read-only region {:?}...",
         self_regions.read_only
     );
-    identity_map_range(
-        aspace,
-        frame_alloc,
-        self_regions.read_only.clone(),
-        mmu::Flags::READ,
-        flush,
-    )?;
+    identity_map_range(frame_alloc, self_regions.read_only.clone(), Flags::READ)?;
 
     log::trace!(
         "Identity mapping loader read-write region {:?}...",
         self_regions.read_write
     );
     identity_map_range(
-        aspace,
         frame_alloc,
         self_regions.read_write.clone(),
-        mmu::Flags::READ | mmu::Flags::WRITE,
-        flush,
+        Flags::READ | Flags::WRITE,
     )?;
 
     Ok(())
@@ -69,79 +65,68 @@ pub fn identity_map_self(
 
 #[inline]
 fn identity_map_range(
-    aspace: &mut AddressSpace,
-    frame_alloc: &mut dyn FrameAllocator,
-    phys: Range<PhysicalAddress>,
-    flags: mmu::Flags,
-    flush: &mut Flush,
+    frame_alloc: &mut FrameAllocator,
+    phys: Range<usize>,
+    flags: Flags,
 ) -> crate::Result<()> {
-    let virt = VirtualAddress::new(phys.start.get()).unwrap();
-    let len = NonZeroUsize::new(phys.size()).unwrap();
+    let len = NonZeroUsize::new(phys.end.checked_sub(phys.start).unwrap()).unwrap();
 
     // Safety: Leaving the address space in an invalid state here is fine since on panic we'll
     // abort startup anyway
-    unsafe {
-        aspace
-            .map_contiguous(frame_alloc, virt, phys.start, len, flags, flush)
-            .map_err(Into::into)
-    }
+    unsafe { arch::map_contiguous(frame_alloc, phys.start, phys.start, len, flags) }
 }
 
 pub fn map_physical_memory(
-    aspace: &mut AddressSpace,
-    frame_alloc: &mut BootstrapAllocator,
+    frame_alloc: &mut FrameAllocator,
     page_alloc: &mut PageAllocator,
     minfo: &MachineInfo,
-    flush: &mut Flush,
-) -> crate::Result<(VirtualAddress, Range<VirtualAddress>)> {
-    let alignment = mmu::arch::page_size_for_level(2);
+) -> crate::Result<(usize, Range<usize>)> {
+    let alignment = arch::page_size_for_level(2);
 
-    let phys = minfo.memory_hull().checked_align_out(alignment).unwrap();
-    let virt = Range::from(
-        VirtualAddress::from_phys(phys.start, arch::KERNEL_ASPACE_BASE).unwrap()
-            ..VirtualAddress::from_phys(phys.end, arch::KERNEL_ASPACE_BASE).unwrap(),
+    let phys = minfo.memory_hull();
+    let phys = Range::from(
+        align_down(phys.start, alignment)..checked_align_up(phys.end, alignment).unwrap(),
     );
+    let virt = Range::from(
+        arch::KERNEL_ASPACE_BASE.checked_add(phys.start).unwrap()
+            ..arch::KERNEL_ASPACE_BASE.checked_add(phys.end).unwrap(),
+    );
+    let size = NonZeroUsize::new(phys.end.checked_sub(phys.start).unwrap()).unwrap();
 
-    debug_assert!(phys.start.is_aligned_to(alignment) && phys.end.is_aligned_to(alignment));
-    debug_assert!(virt.start.is_aligned_to(alignment) && virt.end.is_aligned_to(alignment));
-    debug_assert_eq!(phys.size(), virt.size());
+    debug_assert!(phys.start % alignment == 0 && phys.end % alignment == 0);
+    debug_assert!(virt.end % alignment == 0 && virt.end % alignment == 0);
 
     log::trace!("Mapping physical memory {phys:?} => {virt:?}...");
     // Safety: Leaving the address space in an invalid state here is fine since on panic we'll
     // abort startup anyway
     unsafe {
-        aspace.map_contiguous(
+        arch::map_contiguous(
             frame_alloc,
             virt.start,
             phys.start,
-            NonZeroUsize::new(phys.size()).unwrap(),
-            mmu::Flags::READ | mmu::Flags::WRITE,
-            flush,
+            size,
+            Flags::READ | Flags::WRITE,
         )?;
     }
 
     // exclude the physical memory map region from page allocation
-    page_alloc.reserve(virt.start, phys.size());
+    page_alloc.reserve(virt.start, size.get());
 
     Ok((arch::KERNEL_ASPACE_BASE, virt))
 }
 
 pub fn map_kernel(
-    aspace: &mut AddressSpace,
-    frame_alloc: &mut dyn FrameAllocator,
+    frame_alloc: &mut FrameAllocator,
     page_alloc: &mut PageAllocator,
     kernel: &Kernel,
-    flush: &mut Flush,
-) -> crate::Result<(Range<VirtualAddress>, Option<TlsTemplate>)> {
+) -> crate::Result<(Range<usize>, Option<TlsTemplate>)> {
     let kernel_virt = page_alloc.allocate(
         Layout::from_size_align(kernel.mem_size() as usize, kernel.max_align() as usize).unwrap(),
     );
 
-    let phys_base = PhysicalAddress::new(
-        kernel.elf_file.input.as_ptr() as usize - aspace.physical_memory_offset().get(),
-    );
+    let phys_base = kernel.elf_file.input.as_ptr() as usize - arch::KERNEL_ASPACE_BASE;
     assert!(
-        phys_base.is_aligned_to(PAGE_SIZE),
+        phys_base % arch::PAGE_SIZE == 0,
         "Loaded ELF file is not sufficiently aligned"
     );
 
@@ -151,12 +136,10 @@ pub fn map_kernel(
     for ph in kernel.elf_file.program_iter() {
         match ph.get_type().unwrap() {
             Type::Load => handle_load_segment(
-                aspace,
                 frame_alloc,
                 &ProgramHeader::try_from(ph)?,
                 phys_base,
                 kernel_virt.start,
-                flush,
             )?,
             Type::Tls => {
                 let ph = ProgramHeader::try_from(ph)?;
@@ -184,30 +167,28 @@ pub fn map_kernel(
         }
     }
 
-    // Mark some memory regions as read-only after relocations have been
-    // applied.
-    for ph in kernel.elf_file.program_iter() {
-        if ph.get_type().unwrap() == Type::GnuRelro {
-            handle_relro_segment(
-                aspace,
-                &ProgramHeader::try_from(ph).unwrap(),
-                kernel_virt.start,
-                flush,
-            )?;
-        }
-    }
+    //     // Mark some memory regions as read-only after relocations have been
+    //     // applied.
+    //     for ph in kernel.elf_file.program_iter() {
+    //         if ph.get_type().unwrap() == Type::GnuRelro {
+    //             handle_relro_segment(
+    //                 aspace,
+    //                 &ProgramHeader::try_from(ph).unwrap(),
+    //                 kernel_virt.start,
+    //                 flush,
+    //             )?;
+    //         }
+    //     }
 
     Ok((kernel_virt, maybe_tls_allocation))
 }
 
 /// Map an ELF LOAD segment.
 fn handle_load_segment(
-    aspace: &mut AddressSpace,
-    frame_alloc: &mut dyn FrameAllocator,
+    frame_alloc: &mut FrameAllocator,
     ph: &ProgramHeader,
-    phys_base: PhysicalAddress,
-    virt_base: VirtualAddress,
-    flush: &mut Flush,
+    phys_base: usize,
+    virt_base: usize,
 ) -> crate::Result<()> {
     let flags = flags_for_segment(ph);
 
@@ -224,32 +205,31 @@ fn handle_load_segment(
         let start = phys_base.checked_add(ph.offset).unwrap();
         let end = start.checked_add(ph.file_size).unwrap();
 
-        Range::from(start..end).checked_align_out(ph.align).unwrap()
+        Range::from(align_down(start, ph.align)..checked_align_up(end, ph.align).unwrap())
     };
 
     let virt = {
         let start = virt_base.checked_add(ph.virtual_address).unwrap();
         let end = start.checked_add(ph.file_size).unwrap();
 
-        Range::from(start..end).checked_align_out(ph.align).unwrap()
+        Range::from(align_down(start, ph.align)..checked_align_up(end, ph.align).unwrap())
     };
 
     log::trace!("mapping {virt:?} => {phys:?}");
     // Safety: Leaving the address space in an invalid state here is fine since on panic we'll
     // abort startup anyway
     unsafe {
-        aspace.map_contiguous(
+        arch::map_contiguous(
             frame_alloc,
             virt.start,
             phys.start,
-            NonZeroUsize::new(phys.size()).unwrap(),
+            NonZeroUsize::new(phys.end.checked_sub(phys.start).unwrap()).unwrap(),
             flags,
-            flush,
         )?;
     }
 
     if ph.file_size < ph.mem_size {
-        handle_bss_section(aspace, frame_alloc, ph, flags, phys_base, virt_base, flush)?;
+        handle_bss_section(frame_alloc, ph, flags, phys_base, virt_base)?;
     }
 
     Ok(())
@@ -270,19 +250,17 @@ fn handle_load_segment(
 ///     2.3. and lastly replace last page previously mapped by `handle_load_segment` to stitch things up.
 /// 3. If the BSS section is larger than that one page, we allocate additional zeroed frames and map them in.
 fn handle_bss_section(
-    aspace: &mut AddressSpace,
-    frame_alloc: &mut dyn FrameAllocator,
+    frame_alloc: &mut FrameAllocator,
     ph: &ProgramHeader,
-    flags: mmu::Flags,
-    phys_base: PhysicalAddress,
-    virt_base: VirtualAddress,
-    flush: &mut Flush,
+    flags: Flags,
+    phys_base: usize,
+    virt_base: usize,
 ) -> crate::Result<()> {
     let virt_start = virt_base.checked_add(ph.virtual_address).unwrap();
     let zero_start = virt_start.checked_add(ph.file_size).unwrap();
     let zero_end = virt_start.checked_add(ph.mem_size).unwrap();
 
-    let data_bytes_before_zero = zero_start.get() & 0xfff;
+    let data_bytes_before_zero = zero_start & 0xfff;
 
     log::debug!(
         "handling BSS {:?}, data bytes before {data_bytes_before_zero}",
@@ -290,27 +268,31 @@ fn handle_bss_section(
     );
 
     if data_bytes_before_zero != 0 {
-        let last_page = virt_start
-            .checked_add(ph.file_size.saturating_sub(1))
-            .unwrap()
-            .align_down(ph.align);
-        let last_frame = phys_base
-            .checked_add(ph.offset + ph.file_size - 1)
-            .unwrap()
-            .align_down(ph.align);
+        let last_page = align_down(
+            virt_start
+                .checked_add(ph.file_size.saturating_sub(1))
+                .unwrap(),
+            ph.align,
+        );
+        let last_frame = align_down(
+            phys_base.checked_add(ph.offset + ph.file_size - 1).unwrap(),
+            ph.align,
+        );
 
         let new_frame = frame_alloc
-            .allocate_contiguous_zeroed(Layout::from_size_align(PAGE_SIZE, PAGE_SIZE).unwrap())
-            .ok_or(mmu::Error::NoMemory)?;
+            .allocate_contiguous_zeroed(
+                Layout::from_size_align(arch::PAGE_SIZE, arch::PAGE_SIZE).unwrap(),
+            )
+            .ok_or(Error::NoMemory)?;
 
         unsafe {
             let src = slice::from_raw_parts(
-                aspace.phys_to_virt(last_frame).as_ptr(),
+                arch::KERNEL_ASPACE_BASE.checked_add(last_frame).unwrap() as *mut u8,
                 data_bytes_before_zero,
             );
 
             let dst = slice::from_raw_parts_mut(
-                aspace.phys_to_virt(new_frame).as_mut_ptr(),
+                arch::KERNEL_ASPACE_BASE.checked_add(new_frame).unwrap() as *mut u8,
                 data_bytes_before_zero,
             );
 
@@ -321,39 +303,44 @@ fn handle_bss_section(
         // Safety: Leaving the address space in an invalid state here is fine since on panic we'll
         // abort startup anyway
         unsafe {
-            aspace.remap_contiguous(
+            arch::remap_contiguous(
                 last_page,
                 new_frame,
-                NonZeroUsize::new(PAGE_SIZE).unwrap(),
-                flush,
+                NonZeroUsize::new(arch::PAGE_SIZE).unwrap(),
             )?;
         }
     }
 
     log::trace!("zero_start {zero_start:?} zero_end {zero_end:?}");
-    let (additional_virt_base, additional_len) = {
+    let (additional_virt, additional_len) = {
         // zero_start either lies at a page boundary OR somewhere within the first page
         // by aligning up, we move it to the beginning of the *next* page.
-        let start = zero_start.checked_align_up(ph.align).unwrap();
-        let end = zero_end.checked_align_up(ph.align).unwrap();
-        (start, Range::from(start..end).size())
+        let start = checked_align_up(zero_start, ph.align).unwrap();
+        let end = checked_align_up(zero_end, ph.align).unwrap();
+        (start, end.checked_sub(start).unwrap())
     };
 
     if additional_len > 0 {
-        let additional_phys = NonContiguousFrames::new_zeroed(
-            frame_alloc,
-            Layout::from_size_align(additional_len, PAGE_SIZE).unwrap(),
-            aspace.physical_memory_offset(),
-        );
+        let additional_phys = frame_alloc
+            .allocate_contiguous_zeroed(
+                Layout::from_size_align(additional_len, arch::PAGE_SIZE).unwrap(),
+            )
+            .unwrap();
 
         log::trace!(
-            "mapping additional zeros {additional_virt_base:?}..{:?}",
-            additional_virt_base.checked_add(additional_len).unwrap()
+            "mapping additional zeros {additional_virt:?}..{:?}",
+            additional_virt.checked_add(additional_len).unwrap()
         );
         // Safety: Leaving the address space in an invalid state here is fine since on panic we'll
         // abort startup anyway
         unsafe {
-            aspace.map(additional_virt_base, additional_phys, flags, flush)?;
+            arch::map_contiguous(
+                frame_alloc,
+                additional_virt,
+                additional_phys,
+                NonZeroUsize::new(additional_len).unwrap(),
+                flags,
+            )?;
         }
     }
 
@@ -363,7 +350,7 @@ fn handle_bss_section(
 fn handle_dynamic_segment(
     ph: &ProgramHeader,
     elf_file: &xmas_elf::ElfFile,
-    virt_base: VirtualAddress,
+    virt_base: usize,
 ) -> crate::Result<()> {
     log::trace!("parsing RELA info...");
 
@@ -386,10 +373,7 @@ fn handle_dynamic_segment(
     Ok(())
 }
 
-fn apply_relocation(
-    rela: &xmas_elf::sections::Rela<P64>,
-    virt_base: VirtualAddress,
-) -> crate::Result<()> {
+fn apply_relocation(rela: &xmas_elf::sections::Rela<P64>, virt_base: usize) -> crate::Result<()> {
     assert_eq!(
         rela.get_symbol_table_index(),
         0,
@@ -412,44 +396,10 @@ fn apply_relocation(
 
             // log::trace!("reloc R_RISCV_RELATIVE offset: {:#x}; addend: {:#x} => target {target:?} value {value:?}", rela.get_offset(), rela.get_addend());
             unsafe {
-                target
-                    .as_mut_ptr()
-                    .cast::<usize>()
-                    .write_unaligned(value.get());
+                (target as *mut usize).write_unaligned(value);
             }
         }
         _ => unimplemented!("unsupported relocation type {}", rela.get_type()),
-    }
-
-    Ok(())
-}
-
-fn handle_relro_segment(
-    aspace: &mut AddressSpace,
-    ph: &ProgramHeader,
-    virt_base: VirtualAddress,
-    flush: &mut Flush,
-) -> crate::Result<()> {
-    let virt = {
-        let start = virt_base.checked_add(ph.virtual_address).unwrap();
-
-        start..start.checked_add(ph.mem_size).unwrap()
-    };
-
-    let virt_aligned =
-        Range::from(virt.start.align_down(PAGE_SIZE)..virt.end.align_down(PAGE_SIZE));
-
-    log::debug!("Marking RELRO segment {virt_aligned:?} as read-only");
-
-    // Safety: Leaving the address space in an invalid state here is fine since on panic we'll
-    // abort startup anyway
-    unsafe {
-        aspace.protect(
-            virt_aligned.start,
-            NonZeroUsize::new(virt_aligned.size()).unwrap(),
-            mmu::Flags::READ,
-            flush,
-        )?;
     }
 
     Ok(())
@@ -552,27 +502,61 @@ impl<'a> TryFrom<xmas_elf::program::ProgramHeader<'a>> for ProgramHeader<'a> {
     }
 }
 
-fn flags_for_segment(ph: &ProgramHeader) -> mmu::Flags {
-    let mut out = mmu::Flags::empty();
+fn flags_for_segment(ph: &ProgramHeader) -> Flags {
+    let mut out = Flags::empty();
 
     if ph.p_flags.is_read() {
-        out |= mmu::Flags::READ;
+        out |= Flags::READ;
     }
 
     if ph.p_flags.is_write() {
-        out |= mmu::Flags::WRITE;
+        out |= Flags::WRITE;
     }
 
     if ph.p_flags.is_execute() {
-        out |= mmu::Flags::EXECUTE;
+        out |= Flags::EXECUTE;
     }
 
     assert!(
-        !out.contains(mmu::Flags::WRITE | mmu::Flags::EXECUTE),
+        !out.contains(Flags::WRITE | Flags::EXECUTE),
         "elf segment (virtual range {:#x}..{:#x}) is marked as write-execute",
         ph.virtual_address,
         ph.virtual_address + ph.mem_size
     );
 
     out
+}
+
+#[must_use]
+#[inline]
+pub const fn checked_align_up(this: usize, align: usize) -> Option<usize> {
+    if !align.is_power_of_two() {
+        panic!("checked_align_up: align is not a power-of-two");
+    }
+
+    // SAFETY: `align` has been checked to be a power of 2 above
+    let align_minus_one = unsafe { align.unchecked_sub(1) };
+
+    // addr.wrapping_add(align_minus_one) & 0usize.wrapping_sub(align)
+    if let Some(addr_plus_align) = this.checked_add(align_minus_one) {
+        let aligned = addr_plus_align & 0usize.wrapping_sub(align);
+        debug_assert!(aligned % align == 0);
+        debug_assert!(aligned >= this);
+        Some(aligned)
+    } else {
+        None
+    }
+}
+
+#[must_use]
+#[inline]
+pub const fn align_down(this: usize, align: usize) -> usize {
+    if !align.is_power_of_two() {
+        panic!("checked_align_up: align is not a power-of-two");
+    }
+
+    let aligned = this & 0usize.wrapping_sub(align);
+    debug_assert!(aligned % align == 0);
+    debug_assert!(aligned <= this);
+    aligned
 }

--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -70,7 +70,7 @@ impl PageAllocator {
 
     pub fn reserve(&mut self, mut virt_base: usize, mut remaining_bytes: usize) {
         log::trace!(
-            "marking {virt_base:?}..{:?} as used",
+            "marking {virt_base:#x}..{:#x} as used",
             virt_base.checked_add(remaining_bytes).unwrap()
         );
 

--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::arch;
 use crate::machine_info::MachineInfo;
 use crate::ENABLE_KASLR;
 use core::alloc::Layout;
 use core::range::Range;
-use mmu::VirtualAddress;
 use rand::distributions::{Distribution, Uniform};
 use rand::prelude::IteratorRandom;
 use rand::SeedableRng;
@@ -17,7 +17,7 @@ use rand_chacha::ChaCha20Rng;
 
 pub fn init(minfo: &MachineInfo) -> PageAllocator {
     PageAllocator {
-        page_state: [false; mmu::arch::PAGE_TABLE_ENTRIES / 2],
+        page_state: [false; arch::PAGE_TABLE_ENTRIES / 2],
         prng: ENABLE_KASLR.then_some(ChaCha20Rng::from_seed(
             minfo.rng_seed.unwrap()[0..32].try_into().unwrap(),
         )),
@@ -30,7 +30,7 @@ pub fn init(minfo: &MachineInfo) -> PageAllocator {
 #[derive(Debug)]
 pub struct PageAllocator {
     /// Whether a top-level page is in use.
-    page_state: [bool; mmu::arch::PAGE_TABLE_ENTRIES / 2],
+    page_state: [bool; arch::PAGE_TABLE_ENTRIES / 2],
     /// A random number generator that should be used to generate random addresses or
     /// `None` if aslr is disabled.
     prng: Option<ChaCha20Rng>,
@@ -68,18 +68,17 @@ impl PageAllocator {
         }
     }
 
-    pub fn reserve(&mut self, mut virt_base: VirtualAddress, mut remaining_bytes: usize) {
+    pub fn reserve(&mut self, mut virt_base: usize, mut remaining_bytes: usize) {
         log::trace!(
             "marking {virt_base:?}..{:?} as used",
             virt_base.checked_add(remaining_bytes).unwrap()
         );
 
-        let top_level_page_size = mmu::arch::page_size_for_level(mmu::arch::PAGE_TABLE_LEVELS - 1);
-        assert!(virt_base.is_aligned_to(top_level_page_size));
+        let top_level_page_size = arch::page_size_for_level(arch::PAGE_TABLE_LEVELS - 1);
+        debug_assert!(virt_base % top_level_page_size == 0);
 
         while remaining_bytes > 0 {
-            let page_idx =
-                (virt_base.get() - (usize::MAX << mmu::arch::VIRT_ADDR_BITS)) / top_level_page_size;
+            let page_idx = (virt_base - (usize::MAX << arch::VIRT_ADDR_BITS)) / top_level_page_size;
 
             self.page_state[page_idx] = true;
 
@@ -88,10 +87,10 @@ impl PageAllocator {
         }
     }
 
-    pub fn allocate(&mut self, layout: Layout) -> Range<VirtualAddress> {
+    pub fn allocate(&mut self, layout: Layout) -> Range<usize> {
         assert!(layout.align().is_power_of_two());
 
-        let top_level_page_size = mmu::arch::page_size_for_level(mmu::arch::PAGE_TABLE_LEVELS - 1);
+        let top_level_page_size = arch::page_size_for_level(arch::PAGE_TABLE_LEVELS - 1);
 
         // how many top-level pages are needed to map `size` bytes
         // and attempt to allocate them
@@ -104,10 +103,7 @@ impl PageAllocator {
         //
         // we can then take the lowest possible address of the higher half (`usize::MAX << VA_BITS`)
         // and add the `idx` multiple of the size of a top-level entry to it
-        let base = VirtualAddress::new(
-            (usize::MAX << mmu::arch::VIRT_ADDR_BITS) + page_idx * top_level_page_size,
-        )
-        .unwrap();
+        let base = (usize::MAX << arch::VIRT_ADDR_BITS) + page_idx * top_level_page_size;
 
         let offset = if let Some(rng) = self.prng.as_mut() {
             // Choose a random offset.


### PR DESCRIPTION
This PR begins the process of removing the `mmu` crate. It has served us well, but as the virtual memory subsystem in the kernel begins to mature, the `loader` and `kernel` requirements for hardware memory management are diverging.

This PR then starts and removed the `mmu` crate as a dependency of the `loader`. This introduces some code duplication, but this appears more sensible to me.  