### PR TITLE
feat(kernel): kernel metrics

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -24,6 +24,7 @@ mod arch;
 mod error;
 mod logger;
 mod machine_info;
+mod metrics;
 mod panic;
 mod thread_local;
 mod time;

--- a/kernel/src/metrics.rs
+++ b/kernel/src/metrics.rs
@@ -1,0 +1,121 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+//! Kernel counters
+//!
+//! Kernel counters are per-hart, unsigned integer counters that facilitate diagnostics across the
+//! whole kernel. Questions like "how many times has <x> happened over <n> seconds?", "has <x> ever happened?"
+//! can be answered using this API.
+//!
+//! Counters are declared in their respective modules like so:
+//! ```rust
+//! use crate::metrics::{Counter, counter};
+//!
+//! static TEST_CNT: Counter = counter!("test-event");
+//!
+//! fn some_function() {
+//!     TEST_CNT.increment(1);
+//! }
+//! ```
+//!
+//! Kernel counters are always per-hart, which means each hart keeps an individual counter. Methods
+//! on `Counter` can be used to sum events across harts or even get the maximum or minimum value across
+//! harts.
+
+use crate::thread_local::ThreadLocal;
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// Declares a new counter.
+#[macro_export]
+macro_rules! counter {
+    ($name:expr) => {{
+        let name: &str = $name;
+
+        #[unsafe(link_section = concat!(".bss.kcounter.", name))]
+        static ARENA: $crate::thread_local::ThreadLocal<AtomicU64> =
+            $crate::thread_local::ThreadLocal::new();
+
+        Counter {
+            arena: &ARENA,
+            name,
+        }
+    }};
+}
+
+/// A kernel counter.
+struct Counter {
+    arena: &'static ThreadLocal<AtomicU64>,
+    name: &'static str,
+}
+
+impl Counter {
+    /// Increment the counter.
+    pub fn increment(&self, value: u64) {
+        self.arena
+            .get_or_default()
+            .fetch_add(value, Ordering::Relaxed);
+    }
+
+    /// Decrement the counter.
+    pub fn decrement(&self, value: u64) {
+        self.arena
+            .get_or_default()
+            .fetch_sub(value, Ordering::Relaxed);
+    }
+
+    /// Set the absolute value of the counter.
+    pub fn set(&self, value: u64) {
+        self.arena.get_or_default().store(value, Ordering::Relaxed);
+    }
+
+    /// Set the absolute value of the counter if the provided value is larger than the current value.
+    pub fn max(&self, value: u64) {
+        let _ =
+            self.arena
+                .get_or_default()
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
+                    (old < value).then_some(value)
+                });
+    }
+
+    /// Set the absolute value of the counter if the provided value is smaller than the current value.
+    pub fn min(&self, value: u64) {
+        let _ =
+            self.arena
+                .get_or_default()
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |old| {
+                    (old > value).then_some(value)
+                });
+    }
+
+    /// Get the counter value of the calling hart, or `None` if the counter was never written to.
+    pub fn get(&self) -> Option<u64> {
+        Some(self.arena.get()?.load(Ordering::Relaxed))
+    }
+
+    /// Return the sum of all counters across all harts.
+    pub fn sum_across_all_harts(&self) -> u64 {
+        self.arena.iter().map(|v| v.load(Ordering::Relaxed)).sum()
+    }
+
+    /// Return the largest value from across all harts.
+    pub fn max_across_all_harts(&self) -> u64 {
+        self.arena
+            .iter()
+            .map(|v| v.load(Ordering::Relaxed))
+            .max()
+            .unwrap()
+    }
+
+    /// Return the smallest value from across all harts.
+    pub fn min_across_all_harts(&self) -> u64 {
+        self.arena
+            .iter()
+            .map(|v| v.load(Ordering::Relaxed))
+            .min()
+            .unwrap()
+    }
+}

--- a/kernel/src/metrics.rs
+++ b/kernel/src/metrics.rs
@@ -7,7 +7,7 @@
 //! Kernel counters
 //!
 //! Kernel counters are per-hart, unsigned integer counters that facilitate diagnostics across the
-//! whole kernel. Questions like "how many times has <x> happened over <n> seconds?", "has <x> ever happened?"
+//! whole kernel. Questions like "how many times has X happened over N seconds?", "has X ever happened?"
 //! can be answered using this API.
 //!
 //! Counters are declared in their respective modules like so:


### PR DESCRIPTION
This PR introduces the facilities around kernel counters, as the next debugging primitive after logging. Kernel counters are per-hart, `u64` counters that can be used to track events across the kernel. 

This PR only introduces the ability to declare counters, followup work should make use of them across the kernel (specifically the vm subsystem) and even later followup work should implement the ability to read out counters via some shell.