### PR TITLE
feat(kernel): `Mmap`

### DIFF
--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -37,10 +37,10 @@ pub enum AddressSpaceKind {
 /// Represents the address space of a process (or the kernel).
 pub struct AddressSpace {
     /// A binary search tree of regions that make up this address space.
-    pub(crate) regions: wavltree::WAVLTree<AddressSpaceRegion>,
+    pub(super) regions: wavltree::WAVLTree<AddressSpaceRegion>,
     /// The hardware address space backing this "logical" address space that changes need to be
     /// materialized into in order to take effect.
-    arch: arch::AddressSpace,
+    pub(super) arch: arch::AddressSpace,
     /// The maximum range this address space can encompass.
     ///
     /// This is used to check new mappings against and speed up page fault handling.
@@ -136,6 +136,7 @@ impl AddressSpace {
         permissions: Permissions,
         name: Option<String>,
     ) -> Result<Pin<&mut AddressSpaceRegion>, Error> {
+        let layout = layout.pad_to_align(); 
         let base = self.find_spot(layout, VIRT_ALLOC_ENTROPY);
         let range = Range::from(base..base.checked_add(layout.size()).unwrap());
 

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -136,7 +136,7 @@ impl AddressSpace {
         permissions: Permissions,
         name: Option<String>,
     ) -> Result<Pin<&mut AddressSpaceRegion>, Error> {
-        let layout = layout.pad_to_align(); 
+        let layout = layout.pad_to_align();
         let base = self.find_spot(layout, VIRT_ALLOC_ENTROPY);
         let range = Range::from(base..base.checked_add(layout.size()).unwrap());
 

--- a/kernel/src/vm/mmap.rs
+++ b/kernel/src/vm/mmap.rs
@@ -1,0 +1,139 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::arch;
+use crate::vm::address::AddressRangeExt;
+use crate::vm::address_space_region::AddressSpaceRegion;
+use crate::vm::vmo::Vmo;
+use crate::vm::{
+    AddressSpace, ArchAddressSpace, Error, Permissions, VirtualAddress, THE_ZERO_FRAME,
+};
+use core::alloc::Layout;
+use core::num::NonZeroUsize;
+use core::pin::Pin;
+use core::ptr::NonNull;
+use core::range::Range;
+use core::{iter, ptr, slice};
+
+/// A memory mapping, essentially handle to an `AddressSpaceRegion`
+pub struct Mmap {
+    ptr: *mut AddressSpaceRegion,
+    range: Range<VirtualAddress>,
+}
+
+impl Mmap {
+    /// Creates a new empty `Mmap`.
+    ///
+    /// Note that the size of this cannot be changed after the fact, all accessors will return empty
+    /// slices and permission changing methods will always fail.
+    pub fn new_empty() -> Self {
+        Self {
+            ptr: ptr::null_mut(),
+            range: Range::default(),
+        }
+    }
+
+    /// Creates a new read-write (`RW`) memory mapping in the given address space.
+    pub fn new(aspace: &mut AddressSpace, len: usize) -> Result<Self, Error> {
+        let layout = Layout::from_size_align(len, arch::PAGE_SIZE).unwrap();
+        let vmo = Vmo::new_paged(iter::repeat_n(
+            THE_ZERO_FRAME.clone(),
+            layout.size().div_ceil(arch::PAGE_SIZE),
+        ));
+
+        let region = aspace.map(
+            layout,
+            vmo,
+            0,
+            Permissions::READ | Permissions::WRITE,
+            None,
+        )?;
+
+        #[allow(tail_expr_drop_order)]
+        Ok(Self {
+            range: region.range,
+            ptr: ptr::from_mut(unsafe { Pin::into_inner_unchecked(region) }),
+        })
+    }
+
+    /// Returns a slice to the memory mapped by this `Mmap`.
+    #[inline]
+    pub unsafe fn slice(&self, range: Range<usize>) -> &[u8] {
+        assert!(range.end <= self.len());
+        let len = range.end.checked_sub(range.start).unwrap();
+        unsafe { slice::from_raw_parts(self.as_ptr().add(range.start), len) }
+    }
+
+    /// Returns a mutable slice to the memory mapped by this `Mmap`.
+    #[inline]
+    pub unsafe fn slice_mut(&mut self, range: Range<usize>) -> &mut [u8] {
+        assert!(range.end <= self.len());
+        let len = range.end.checked_sub(range.start).unwrap();
+        unsafe { slice::from_raw_parts_mut(self.as_mut_ptr().add(range.start), len) }
+    }
+
+    /// Returns a pointer to the start of the memory mapped by this `Mmap`.
+    #[inline]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.range.start.as_ptr()
+    }
+
+    /// Returns a mutable pointer to the start of the memory mapped by this `Mmap`.
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.range.start.as_mut_ptr()
+    }
+
+    /// Returns the size in bytes of this memory mapping.
+    #[inline]
+    pub fn len(&self) -> usize {
+        // Safety: the constructor ensures that the NonNull is valid.
+        self.range.size()
+    }
+
+    /// Whether this is a mapping of zero bytes
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Mark this memory mapping as executable (`RX`) this will by-design make it not-writable too.
+    pub fn make_executable(&mut self, aspace: &mut AddressSpace) -> Result<(), Error> {
+        self.protect(aspace, Permissions::READ | Permissions::EXECUTE)
+    }
+
+    /// Mark this memory mapping as read-only (`R`) essentially removing the write permission.
+    pub fn make_readonly(&mut self, aspace: &mut AddressSpace) -> Result<(), Error> {
+        self.protect(aspace, Permissions::READ)
+    }
+
+    fn protect(
+        &mut self,
+        aspace: &mut AddressSpace,
+        new_permissions: Permissions,
+    ) -> Result<(), Error> {
+        if let Some(ptr) = NonNull::new(self.ptr) {
+            let mut c = unsafe { aspace.regions.cursor_mut_from_ptr(ptr) };
+            let mut region = c.get_mut().unwrap();
+
+            region.permissions = new_permissions;
+
+            let mut flush = aspace.arch.new_flush();
+            unsafe {
+                aspace.arch.protect(
+                    self.range.start,
+                    NonZeroUsize::new(self.range.size()).unwrap(),
+                    new_permissions.into(),
+                    &mut flush,
+                )?
+            };
+            flush.flush()?;
+        }
+
+        Ok(())
+    }
+}

--- a/kernel/src/vm/mmap.rs
+++ b/kernel/src/vm/mmap.rs
@@ -20,8 +20,11 @@ pub struct MmapSlice {
 }
 
 impl MmapSlice {
-    pub unsafe fn from_raw(ptr: *mut AddressSpaceRegion, range: Range<VirtualAddress>) -> Self {
-        Self { ptr, range }
+    pub unsafe fn from_raw(ptr: *mut AddressSpaceRegion) -> Self {
+        Self {
+            ptr,
+            range: unsafe { ptr.as_ref().unwrap().range },
+        }
     }
 
     // /// Creates a new empty `Mmap`.

--- a/kernel/src/vm/mmap.rs
+++ b/kernel/src/vm/mmap.rs
@@ -45,13 +45,7 @@ impl Mmap {
             layout.size().div_ceil(arch::PAGE_SIZE),
         ));
 
-        let region = aspace.map(
-            layout,
-            vmo,
-            0,
-            Permissions::READ | Permissions::WRITE,
-            None,
-        )?;
+        let region = aspace.map(layout, vmo, 0, Permissions::READ | Permissions::WRITE, None)?;
 
         #[allow(tail_expr_drop_order)]
         Ok(Self {

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -13,6 +13,7 @@ mod error;
 pub mod flush;
 pub mod frame_alloc;
 mod frame_list;
+mod mmap;
 mod vmo;
 
 use crate::arch;

--- a/kernel/src/vm/vmo/mod.rs
+++ b/kernel/src/vm/vmo/mod.rs
@@ -8,6 +8,10 @@
 mod paged;
 mod wired;
 
+use crate::vm::frame_alloc::Frame;
+use crate::vm::PhysicalAddress;
+use alloc::sync::Arc;
+use core::range::Range;
 pub use paged::PagedVmo;
 use sync::RwLock;
 pub use wired::WiredVmo;
@@ -16,6 +20,17 @@ pub use wired::WiredVmo;
 pub enum Vmo {
     Wired(WiredVmo),
     Paged(RwLock<PagedVmo>),
+}
+
+impl Vmo {
+    pub fn new_wired(range: Range<PhysicalAddress>) -> Arc<Self> {
+        #[allow(tail_expr_drop_order)]
+        Arc::new(Self::Wired(WiredVmo::new(range)))
+    }
+    pub fn new_paged(into_iter: impl IntoIterator<Item = Frame>) -> Arc<Self> {
+        #[allow(tail_expr_drop_order)]
+        Arc::new(Self::Paged(RwLock::new(PagedVmo::from_iter(into_iter))))
+    }
 }
 
 impl Vmo {


### PR DESCRIPTION
This PR implements a basic version of `MmapSlice` which essentially is a handle to an `AddressSpaceRegion` for use in other parts of the kernel. Just like the vm subsystem it currently doesn't support partial mutation but importantly it doesn't automatically unmap its region on drop, so it is not a complete RAII wrapper.

It is expected that the `InstanceAllocator` will take care of managing the lifecycle. For this reason `MmapSlice` doesn't expose a real constructor, instead `InstanceAllocator` should allocate the `AddressSpaceRegion` in the `AddressSpace` and then construct a `MmapSlice` using `MmapSlice::from_raw`.