### PR TITLE
chore(kernel/vm): validate RISCV flags

### DIFF
--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -231,6 +231,12 @@ impl crate::vm::ArchAddressSpace for AddressSpace {
         flush: &mut Flush,
     ) -> Result<(), Error> {
         let mut remaining_bytes = len.get();
+        if flags.contains(PTEFlags::WRITE) {
+            debug_assert!(
+                flags.contains(PTEFlags::READ),
+                "writable pages must also be marked readable"
+            );
+        }
         debug_assert!(
             remaining_bytes >= PAGE_SIZE,
             "address range span be at least one page"
@@ -321,6 +327,12 @@ impl crate::vm::ArchAddressSpace for AddressSpace {
         flush: &mut Flush,
     ) -> Result<(), Error> {
         let mut remaining_bytes = len.get();
+        if new_flags.contains(PTEFlags::WRITE) {
+            debug_assert!(
+                new_flags.contains(PTEFlags::READ),
+                "writable pages must also be marked readable"
+            );
+        }
         debug_assert!(
             remaining_bytes >= PAGE_SIZE,
             "virtual address range must span be at least one page"


### PR DESCRIPTION
This PR adds debug validation to the RISCV flags, to ensure the flags align with the spec:
" Writable pages must also be marked readable; the contrary combinations are reserved for future use."