### PR TITLE
fix: don't panic on non address space address

### DIFF
--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -360,13 +360,13 @@ impl AddressSpace {
 
         // make sure addr is even a valid address for this address space
         match self.kind {
-            AddressSpaceKind::User => assert!(
+            AddressSpaceKind::User => ensure!(
                 addr.is_user_accessible(),
-                "non-user address fault in user address space addr={addr:?}"
+                Error::KernelFaultInUserSpace(addr)
             ),
-            AddressSpaceKind::Kernel => assert!(
+            AddressSpaceKind::Kernel => ensure!(
                 arch::is_kernel_address(addr),
-                "non-kernel address fault in kernel address space addr={addr:?}"
+                Error::UserFaultInKernelSpace(addr)
             ),
         }
         ensure!(

--- a/kernel/src/vm/error.rs
+++ b/kernel/src/vm/error.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::vm::VirtualAddress;
 use core::fmt::{Display, Formatter};
 
 #[derive(Debug)]
@@ -29,6 +30,8 @@ pub enum Error {
     /// Errors returned by SBI calls
     #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))]
     Sbi(riscv::sbi::Error),
+    KernelFaultInUserSpace(VirtualAddress),
+    UserFaultInKernelSpace(VirtualAddress),
 }
 
 impl From<crate::vm::frame_alloc::AllocError> for Error {
@@ -62,6 +65,8 @@ impl Display for Error {
             Error::AddressSpaceMismatch { expected, found } => write!(f, "Attempted to operate on mismatched address space. Expected {expected} but found {found}."),
             #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))]
             Error::Sbi(err) => write!(f, "SBI call failed: {err}"),
+            Error::KernelFaultInUserSpace(addr) => write!(f, "non-user address fault in user address space addr={addr:?}"),
+            Error::UserFaultInKernelSpace(addr) => write!(f, "non-kernel address fault in kernel address space addr={addr:?}")
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where the `AddressSpace::page_fault` method would panic if called with a virtual address not belonging to the address space. After this PR the method will return an error.