### PR TITLE
feat: user address space functionality

### DIFF
--- a/kernel/fib_cpp.wat
+++ b/kernel/fib_cpp.wat
@@ -97,7 +97,7 @@
     local.get 21
     return)
   (table (;0;) 1 1 funcref)
-  (memory (;0;) 2)
+  (memory (;0;) 1)
   (global (;0;) (mut i32) (i32.const 66560))
   (export "memory" (memory 0))
   (export "fib" (func 0))

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -225,9 +225,9 @@ pub fn rmb() {
 }
 
 #[inline]
-pub unsafe fn with_user_memory_access<F>(f: F)
+pub unsafe fn with_user_memory_access<F, R>(f: F) -> R
 where
-    F: FnOnce(),
+    F: FnOnce() -> R,
 {
     // Allow supervisor access to user memory
     // Safety: register access
@@ -235,11 +235,13 @@ where
         sstatus::set_sum();
     }
 
-    f();
+    let r = f();
 
     // Disable supervisor access to user memory
     // Safety: register access
     unsafe {
         sstatus::clear_sum();
     }
+    
+    r
 }

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -242,6 +242,6 @@ where
     unsafe {
         sstatus::clear_sum();
     }
-    
+
     r
 }

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -84,7 +84,7 @@ unsafe extern "C" fn default_trap_entry() {
     unsafe {
         naked_asm! {
             ".align 2",
-            // "mv t0, sp", // save the correct stack pointer
+
             "csrrw sp, sscratch, sp", // sp points to the TrapFrame
             "add sp, sp, -0x210",
 
@@ -251,6 +251,12 @@ fn default_trap_handler(
     a6: usize,
     a7: usize,
 ) -> *mut TrapFrame {
+    // Clear the SUM bit to prevent userspace memory access in case we interrupted the kernel
+    // Safety: register access
+    unsafe {
+        sstatus::clear_sum();
+    }
+
     let cause = scause::read().cause();
 
     log::trace!("{:?}", sstatus::read());

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -8,12 +8,12 @@
 use super::utils::{define_op, load_fp, load_gp, save_fp, save_gp};
 use crate::arch::PAGE_SIZE;
 use crate::trap_handler::TrapReason;
+use crate::vm::VirtualAddress;
 use crate::TRAP_STACK_SIZE_PAGES;
 use core::arch::{asm, naked_asm};
 use riscv::scause::{Exception, Interrupt, Trap};
 use riscv::{scause, sepc, sstatus, stval, stvec};
 use thread_local::thread_local;
-use crate::vm::VirtualAddress;
 
 thread_local! {
     static TRAP_STACK: [u8; TRAP_STACK_SIZE_PAGES * PAGE_SIZE] = const { [0; TRAP_STACK_SIZE_PAGES * PAGE_SIZE] };

--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -604,7 +604,7 @@ bitflags! {
         ///
         /// Global mappings exist in all address space.
         ///
-        /// Note that as stated in the RISCV privileged spec, forgetting to mark a global mapping as gobal
+        /// Note that as stated in the RISCV privileged spec, forgetting to mark a global mapping as global
         /// is *fine* since it just results in slower performance. However, marking a non-global mapping as
         /// global by accident will result in undefined behaviour (the CPU might use any of the competing
         /// mappings for the address).

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -60,7 +60,7 @@ pub const TRAP_STACK_SIZE_PAGES: usize = 64; // TODO find a lower more appropria
 /// doesn't cause startup slowdown & inefficient mapping, but large enough so we can bootstrap
 /// our own virtual memory subsystem. At that point we are no longer reliant on this initial heap
 /// size and can dynamically grow the heap as needed.
-pub const INITIAL_HEAP_SIZE_PAGES: usize = 4096; // 32 MiB
+pub const INITIAL_HEAP_SIZE_PAGES: usize = 4096 * 2; // 32 MiB
 
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -132,7 +132,7 @@ fn main(hartid: usize, boot_info: &'static BootInfo) -> ! {
         Instant::now().duration_since(Instant::ZERO),
         Instant::from_ticks(boot_info.boot_ticks).elapsed()
     );
-    // wasm::test();
+    wasm::test();
 
     // - [all][global] parse cmdline
     // - [all][global] `vm::init()` init virtual memory management

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -14,6 +14,7 @@
 #![feature(debug_closure_helpers)]
 #![expect(internal_features, reason = "panic internals")]
 #![feature(std_internals, panic_can_unwind, fmt_internals)]
+#![feature(step_trait)]
 #![expect(dead_code, reason = "TODO")] // TODO remove
 #![expect(edition_2024_expr_fragment_specifier, reason = "vetted")]
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -132,7 +132,7 @@ fn main(hartid: usize, boot_info: &'static BootInfo) -> ! {
         Instant::now().duration_since(Instant::ZERO),
         Instant::from_ticks(boot_info.boot_ticks).elapsed()
     );
-    wasm::test();
+    // wasm::test();
 
     // - [all][global] parse cmdline
     // - [all][global] `vm::init()` init virtual memory management

--- a/kernel/src/metrics.rs
+++ b/kernel/src/metrics.rs
@@ -32,26 +32,26 @@ use core::sync::atomic::{AtomicU64, Ordering};
 #[macro_export]
 macro_rules! counter {
     ($name:expr) => {{
-        let name: &str = $name;
-
-        #[unsafe(link_section = concat!(".bss.kcounter.", name))]
-        static ARENA: $crate::thread_local::ThreadLocal<AtomicU64> =
+        #[unsafe(link_section = concat!(".bss.kcounter.", $name))]
+        static ARENA: $crate::thread_local::ThreadLocal<::core::sync::atomic::AtomicU64> =
             $crate::thread_local::ThreadLocal::new();
 
-        Counter {
-            arena: &ARENA,
-            name,
-        }
+        Counter::new(&ARENA, $name)
     }};
 }
 
 /// A kernel counter.
-struct Counter {
+pub struct Counter {
     arena: &'static ThreadLocal<AtomicU64>,
     name: &'static str,
 }
 
 impl Counter {
+    #[doc(hidden)]
+    pub const fn new(arena: &'static ThreadLocal<AtomicU64>, name: &'static str) -> Self {
+        Self { arena, name }
+    }
+
     /// Increment the counter.
     pub fn increment(&self, value: u64) {
         self.arena

--- a/kernel/src/trap_handler.rs
+++ b/kernel/src/trap_handler.rs
@@ -11,7 +11,6 @@ use core::cell::Cell;
 use core::fmt::Write;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::ControlFlow;
-use core::panic::UnwindSafe;
 use core::ptr;
 use core::ptr::addr_of_mut;
 use thread_local::thread_local;
@@ -103,18 +102,10 @@ pub fn resume_trap(trap: Trap) -> ! {
 /// result if the closure didn't trigger a trap, and will return `Err(trap)` if it did. The `trap` object
 /// holds further information about the traps instruction pointer, faulting address and trap reason.
 ///
-/// # `UnwindSafe`
-///
-/// This function borrows the [`UnwindSafe`] trait bound from [`catch_unwind`][1] for the same reasons.
-/// A hardware trap might happen while a data structure is in a temporarily invalid state (i.e. during
-/// mutation) and continuing to access such data would lead to hard to debug bugs. If in the future we
-/// determine the restrictions implied by `UnwindSafe` aren't enough for the purposes of
-/// signal safety we can introduce a new trait.
-///
 /// [1]: [crate::panic::catch_unwind]
 pub fn catch_traps<F, R>(f: F) -> Result<R, Trap>
 where
-    F: FnOnce() -> R + UnwindSafe,
+    F: FnOnce() -> R,
 {
     union Data<R> {
         // when the closure completed successfully, this will hold the return

--- a/kernel/src/trap_handler.rs
+++ b/kernel/src/trap_handler.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::arch::longjmp;
+use crate::vm::VirtualAddress;
 use crate::{arch, vm};
 use core::cell::Cell;
 use core::fmt::Write;
@@ -14,7 +15,6 @@ use core::ops::ControlFlow;
 use core::ptr;
 use core::ptr::addr_of_mut;
 use thread_local::thread_local;
-use crate::vm::VirtualAddress;
 
 thread_local! {
     static TRAP_RESUME_STATE: Cell<*mut TrapResumeState> = Cell::new(ptr::null_mut());
@@ -152,7 +152,12 @@ where
     }
 }
 
-fn fault_resume_panic(reason: TrapReason, pc: VirtualAddress, fp: VirtualAddress, faulting_address: VirtualAddress) -> ! {
+fn fault_resume_panic(
+    reason: TrapReason,
+    pc: VirtualAddress,
+    fp: VirtualAddress,
+    faulting_address: VirtualAddress,
+) -> ! {
     panic!("UNCAUGHT KERNEL TRAP {reason:?} pc={pc};fp={fp};faulting_address={faulting_address};");
 }
 

--- a/kernel/src/trap_handler.rs
+++ b/kernel/src/trap_handler.rs
@@ -14,6 +14,7 @@ use core::ops::ControlFlow;
 use core::ptr;
 use core::ptr::addr_of_mut;
 use thread_local::thread_local;
+use crate::vm::VirtualAddress;
 
 thread_local! {
     static TRAP_RESUME_STATE: Cell<*mut TrapResumeState> = Cell::new(ptr::null_mut());
@@ -22,9 +23,9 @@ thread_local! {
 
 #[derive(Debug, Copy, Clone)]
 pub struct Trap {
-    pub pc: usize,
-    pub fp: usize,
-    pub faulting_address: usize,
+    pub pc: VirtualAddress,
+    pub fp: VirtualAddress,
+    pub faulting_address: VirtualAddress,
     pub reason: TrapReason,
 }
 
@@ -151,8 +152,8 @@ where
     }
 }
 
-fn fault_resume_panic(reason: TrapReason, pc: usize, fp: usize, faulting_address: usize) -> ! {
-    panic!("UNCAUGHT KERNEL TRAP {reason:?} pc={pc:#x};fp={fp:#x};faulting_address={faulting_address:#x};");
+fn fault_resume_panic(reason: TrapReason, pc: VirtualAddress, fp: VirtualAddress, faulting_address: VirtualAddress) -> ! {
+    panic!("UNCAUGHT KERNEL TRAP {reason:?} pc={pc};fp={fp};faulting_address={faulting_address};");
 }
 
 /// Begins processing a trap.

--- a/kernel/src/vm/address.rs
+++ b/kernel/src/vm/address.rs
@@ -225,7 +225,7 @@ macro_rules! address_impl {
                     .finish()
             }
         }
-        
+
         impl core::iter::Step for $addr {
             fn steps_between(start: &Self, end: &Self) -> Option<usize> {
                 core::iter::Step::steps_between(&start.0, &end.0)

--- a/kernel/src/vm/address.rs
+++ b/kernel/src/vm/address.rs
@@ -225,6 +225,38 @@ macro_rules! address_impl {
                     .finish()
             }
         }
+        
+        impl core::iter::Step for $addr {
+            fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+                core::iter::Step::steps_between(&start.0, &end.0)
+            }
+
+            fn forward_checked(start: Self, count: usize) -> Option<Self> {
+                core::iter::Step::forward_checked(start.0, count).map(Self)
+            }
+
+            fn forward(start: Self, count: usize) -> Self {
+                Self(core::iter::Step::forward(start.0, count))
+            }
+
+            unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
+                // Safety: checked by the caller
+                Self(unsafe { core::iter::Step::forward_unchecked(start.0, count) })
+            }
+
+            fn backward_checked(start: Self, count: usize) -> Option<Self> {
+                core::iter::Step::backward_checked(start.0, count).map(Self)
+            }
+
+            fn backward(start: Self, count: usize) -> Self {
+                Self(core::iter::Step::backward(start.0, count))
+            }
+
+            unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
+                // Safety: checked by the caller
+                Self(unsafe { core::iter::Step::backward_unchecked(start.0, count) })
+            }
+        }
     };
 }
 
@@ -290,6 +322,9 @@ macro_rules! address_range_impl {
             let a = Range::from(self.start..other.start);
             let b = Range::from(other.end..self.end);
             ((!a.is_empty()).then_some(a), (!b.is_empty()).then_some(b))
+        }
+        fn clamp(&self, range: Self) -> Self {
+            Range::from(self.start.max(range.start)..self.end.min(range.end))
         }
     };
 }
@@ -363,6 +398,7 @@ pub trait AddressRangeExt {
     fn difference(&self, other: Self) -> (Option<Self>, Option<Self>)
     where
         Self: Sized;
+    fn clamp(&self, range: Self) -> Self;
 }
 
 impl AddressRangeExt for Range<PhysicalAddress> {

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -38,10 +38,10 @@ pub enum AddressSpaceKind {
 /// Represents the address space of a process (or the kernel).
 pub struct AddressSpace {
     /// A binary search tree of regions that make up this address space.
-    pub(super) regions: wavltree::WAVLTree<AddressSpaceRegion>,
+    pub(crate) regions: wavltree::WAVLTree<AddressSpaceRegion>,
     /// The hardware address space backing this "logical" address space that changes need to be
     /// materialized into in order to take effect.
-    pub(super) arch: arch::AddressSpace,
+    pub arch: arch::AddressSpace,
     /// The maximum range this address space can encompass.
     ///
     /// This is used to check new mappings against and speed up page fault handling.

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -29,6 +29,7 @@ use rand_chacha::ChaCha20Rng;
 // const VIRT_ALLOC_ENTROPY: u8 = u8::try_from((arch::VIRT_ADDR_BITS - arch::PAGE_SHIFT as u32) + 1).unwrap();
 const VIRT_ALLOC_ENTROPY: u8 = 27;
 
+#[derive(Debug, Clone, Copy)]
 pub enum AddressSpaceKind {
     User,
     Kernel,
@@ -78,6 +79,10 @@ impl AddressSpace {
             placeholder_vmo: None,
             kind: AddressSpaceKind::Kernel,
         }
+    }
+
+    pub fn kind(&self) -> AddressSpaceKind {
+        self.kind
     }
 
     /// Crate a new region in this address space.

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -468,7 +468,11 @@ impl AddressSpace {
         Ok(region)
     }
 
-    pub fn ensure_mapped(&mut self, range: Range<VirtualAddress>, will_write: bool) -> Result<(), Error> {
+    pub fn ensure_mapped(
+        &mut self,
+        range: Range<VirtualAddress>,
+        will_write: bool,
+    ) -> Result<(), Error> {
         ensure!(
             range.start.is_aligned_to(arch::PAGE_SIZE),
             Error::MisalignedStart
@@ -483,7 +487,7 @@ impl AddressSpace {
         let mut bytes_remaining = range.size();
         let mut c = self.regions.find_mut(&range.start);
         while bytes_remaining > 0 {
-            let mut region = c.get_mut().unwrap();
+            let region = c.get_mut().unwrap();
             let clamped = range.clamp(region.range);
             region.ensure_mapped(&mut batch, clamped, will_write)?;
 

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -361,7 +361,7 @@ impl AddressSpace {
     ///                         - replace old frame with new frame
     ///                      - update MMU page table
     pub fn page_fault(&mut self, addr: VirtualAddress, flags: PageFaultFlags) -> Result<(), Error> {
-        assert!(flags.is_valid());
+        assert!(flags.is_valid(), "invalid page fault flags {flags:?}");
 
         // make sure addr is even a valid address for this address space
         match self.kind {

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -599,8 +599,7 @@ impl AddressSpace {
 
         let mut candidate_spot_count = 0;
 
-        debug_assert!(!self.regions.is_empty());
-        // // if the tree is empty, treat max_range as the gap
+        // if the tree is empty, treat max_range as the gap
         if self.regions.is_empty() {
             let aligned_gap = self.max_range.checked_align_in(layout.align()).unwrap();
             let spot_count = spots_in_range(layout, aligned_gap);

--- a/kernel/src/vm/address_space_region.rs
+++ b/kernel/src/vm/address_space_region.rs
@@ -90,6 +90,66 @@ impl AddressSpaceRegion {
         Ok(())
     }
 
+    pub fn ensure_mapped(
+        self: Pin<&mut Self>,
+        batch: &mut Batch,
+        range: Range<VirtualAddress>,
+        will_write: bool,
+    ) -> Result<(), Error> {
+        let vmo_relative_range = Range {
+            start: range.start.checked_sub_addr(self.range.start).unwrap(),
+            end: range.end.checked_sub_addr(self.range.start).unwrap(),
+        };
+        
+        match self.vmo.as_ref() {
+            Vmo::Wired(vmo) => {
+                let range_phys = vmo
+                    .lookup_contiguous(vmo_relative_range)
+                    .expect("contiguous lookup for wired VMOs should never fail");
+
+                batch.append(
+                    range.start,
+                    range_phys.start,
+                    range_phys.size(),
+                    self.permissions.into(),
+                )?;
+            }
+            Vmo::Paged(vmo) => {
+                if will_write {
+                    let mut vmo = vmo.write();
+
+                    for addr in range.iter().step_by(arch::PAGE_SIZE) {
+                        debug_assert!(addr.is_aligned_to(arch::PAGE_SIZE));
+                        let vmo_relative_offset = addr.checked_sub_addr(self.range.start).unwrap();
+                        let frame = vmo.require_owned_frame(vmo_relative_offset)?;
+                        batch.append(
+                            addr,
+                            frame.addr(),
+                            arch::PAGE_SIZE,
+                            self.permissions.into(),
+                        )?;
+                    }
+                } else {
+                    let vmo = vmo.read();
+
+                    for addr in range.iter().step_by(arch::PAGE_SIZE) {
+                        debug_assert!(addr.is_aligned_to(arch::PAGE_SIZE));
+                        let vmo_relative_offset = addr.checked_sub_addr(self.range.start).unwrap();
+                        let frame = vmo.require_read_frame(vmo_relative_offset)?;
+                        batch.append(
+                            addr,
+                            frame.addr(),
+                            arch::PAGE_SIZE,
+                            self.permissions.difference(Permissions::WRITE).into(),
+                        )?;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn page_fault(
         self: Pin<&mut Self>,
         batch: &mut Batch,

--- a/kernel/src/vm/address_space_region.rs
+++ b/kernel/src/vm/address_space_region.rs
@@ -100,7 +100,7 @@ impl AddressSpaceRegion {
             start: range.start.checked_sub_addr(self.range.start).unwrap(),
             end: range.end.checked_sub_addr(self.range.start).unwrap(),
         };
-        
+
         match self.vmo.as_ref() {
             Vmo::Wired(vmo) => {
                 let range_phys = vmo

--- a/kernel/src/vm/error.rs
+++ b/kernel/src/vm/error.rs
@@ -32,6 +32,7 @@ pub enum Error {
     Sbi(riscv::sbi::Error),
     KernelFaultInUserSpace(VirtualAddress),
     UserFaultInKernelSpace(VirtualAddress),
+    Trap(crate::trap_handler::Trap),
 }
 
 impl From<crate::vm::frame_alloc::AllocError> for Error {
@@ -66,7 +67,8 @@ impl Display for Error {
             #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))]
             Error::Sbi(err) => write!(f, "SBI call failed: {err}"),
             Error::KernelFaultInUserSpace(addr) => write!(f, "non-user address fault in user address space addr={addr:?}"),
-            Error::UserFaultInKernelSpace(addr) => write!(f, "non-kernel address fault in kernel address space addr={addr:?}")
+            Error::UserFaultInKernelSpace(addr) => write!(f, "non-kernel address fault in kernel address space addr={addr:?}"),
+            Error::Trap(trap) => write!(f, "operation failed with trap {trap:?}")
         }
     }
 }

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -184,7 +184,7 @@ impl fmt::Display for PageFaultFlags {
 
 impl PageFaultFlags {
     pub fn is_valid(self) -> bool {
-        self.contains(PageFaultFlags::LOAD) != self.contains(PageFaultFlags::STORE)
+        !self.contains(PageFaultFlags::LOAD | PageFaultFlags::STORE)
     }
 
     pub fn cause_is_read(self) -> bool {

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -21,7 +21,7 @@ use crate::arch;
 use crate::machine_info::MachineInfo;
 use crate::vm::flush::Flush;
 use crate::vm::frame_alloc::Frame;
-pub use address::{PhysicalAddress, VirtualAddress};
+pub use address::{AddressRangeExt, PhysicalAddress, VirtualAddress};
 pub use address_space::AddressSpace;
 use alloc::format;
 use alloc::string::ToString;

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -13,8 +13,8 @@ mod error;
 pub mod flush;
 pub mod frame_alloc;
 mod frame_list;
-mod mmap;
 mod trap_handler;
+mod user_mmap;
 mod vmo;
 
 use crate::arch;
@@ -30,11 +30,11 @@ use core::range::Range;
 use core::{fmt, slice};
 pub use error::Error;
 use loader_api::BootInfo;
-pub use mmap::MmapSlice;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use sync::{LazyLock, Mutex, OnceLock};
 pub use trap_handler::trap_handler;
+pub use user_mmap::UserMmap;
 use xmas_elf::program::Type;
 
 pub static KERNEL_ASPACE: OnceLock<Mutex<AddressSpace>> = OnceLock::new();
@@ -201,9 +201,14 @@ impl PageFaultFlags {
 bitflags::bitflags! {
     #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
     pub struct Permissions: u8 {
+        /// Allow reads from the memory region
         const READ = 1 << 0;
+        /// Allow writes to the memory region
         const WRITE = 1 << 1;
+        /// Allow code execution from the memory region
         const EXECUTE = 1 << 2;
+        /// Allow userspace to access the memory region
+        const USER = 1 << 3;
     }
 }
 

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -36,6 +36,9 @@ use sync::{LazyLock, Mutex, OnceLock};
 pub use trap_handler::trap_handler;
 pub use user_mmap::UserMmap;
 use xmas_elf::program::Type;
+pub use vmo::Vmo;
+pub use frame_list::FrameList;
+pub use address_space::Batch;
 
 pub static KERNEL_ASPACE: OnceLock<Mutex<AddressSpace>> = OnceLock::new();
 static THE_ZERO_FRAME: LazyLock<Frame> = LazyLock::new(|| {
@@ -71,18 +74,7 @@ pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) -> crate::Result<()> {
 
         Ok(Mutex::new(aspace))
     })?;
-
-    // let mut aspace = vm::AddressSpace::new_user(2, Some(ChaCha20Rng::from_seed(
-    //     minfo.rng_seed.unwrap()[0..32].try_into().unwrap(),
-    // ))).unwrap();
-    // unsafe { aspace.arch.activate(); }
-    // log::trace!("everything is fine?!");
-    //
-    // let layout = Layout::from_size_align(5 * arch::PAGE_SIZE, arch::PAGE_SIZE).unwrap();
-    // let vmo = Vmo::new_paged(iter::repeat_n(THE_ZERO_FRAME.clone(), 5));
-    // let range = aspace.map(layout, vmo, 0, Permissions::READ | Permissions::WRITE, None).unwrap().range;
-    // log::trace!("{region:?}");
-
+    
     Ok(())
 }
 

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -23,22 +23,22 @@ use crate::vm::flush::Flush;
 use crate::vm::frame_alloc::Frame;
 pub use address::{AddressRangeExt, PhysicalAddress, VirtualAddress};
 pub use address_space::AddressSpace;
+pub use address_space::Batch;
 use alloc::format;
 use alloc::string::ToString;
 use core::num::NonZeroUsize;
 use core::range::Range;
 use core::{fmt, slice};
 pub use error::Error;
+pub use frame_list::FrameList;
 use loader_api::BootInfo;
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use sync::{LazyLock, Mutex, OnceLock};
 pub use trap_handler::trap_handler;
 pub use user_mmap::UserMmap;
-use xmas_elf::program::Type;
 pub use vmo::Vmo;
-pub use frame_list::FrameList;
-pub use address_space::Batch;
+use xmas_elf::program::Type;
 
 pub static KERNEL_ASPACE: OnceLock<Mutex<AddressSpace>> = OnceLock::new();
 static THE_ZERO_FRAME: LazyLock<Frame> = LazyLock::new(|| {
@@ -74,7 +74,7 @@ pub fn init(boot_info: &BootInfo, minfo: &MachineInfo) -> crate::Result<()> {
 
         Ok(Mutex::new(aspace))
     })?;
-    
+
     Ok(())
 }
 

--- a/kernel/src/vm/user_mmap.rs
+++ b/kernel/src/vm/user_mmap.rs
@@ -8,7 +8,7 @@
 use crate::arch;
 use crate::arch::with_user_memory_access;
 use crate::vm::address::AddressRangeExt;
-use crate::vm::address_space::AddressSpaceKind;
+use crate::vm::address_space::{AddressSpaceKind, Batch};
 use crate::vm::address_space_region::AddressSpaceRegion;
 use crate::vm::vmo::Vmo;
 use crate::vm::{
@@ -20,6 +20,8 @@ use core::pin::Pin;
 use core::ptr::NonNull;
 use core::range::Range;
 use core::{iter, ptr, slice};
+use core::time::Duration;
+use crate::time::Instant;
 
 /// A userspace memory mapping.
 ///
@@ -27,7 +29,6 @@ use core::{iter, ptr, slice};
 /// specific needs such as copying from and to memory.
 #[derive(Debug)]
 pub struct UserMmap {
-    ptr: *mut AddressSpaceRegion,
     range: Range<VirtualAddress>,
 }
 
@@ -43,19 +44,20 @@ impl UserMmap {
     /// slices and permission changing methods will always fail.
     pub fn new_empty() -> Self {
         Self {
-            ptr: ptr::null_mut(),
             range: Range::default(),
         }
     }
 
     /// Creates a new read-write (`RW`) memory mapping in the given address space.
-    pub fn new_zeroed(aspace: &mut AddressSpace, len: usize) -> Result<Self, Error> {
+    pub fn new_zeroed(aspace: &mut AddressSpace, len: usize, align: usize) -> Result<Self, Error> {
         debug_assert!(
             matches!(aspace.kind(), AddressSpaceKind::User),
             "cannot create UserMmap in kernel address space"
         );
+        debug_assert!(align >= arch::PAGE_SIZE, "alignment must be at least a page");
 
-        let layout = Layout::from_size_align(len, arch::PAGE_SIZE).unwrap();
+        let layout = Layout::from_size_align(len, align).unwrap();
+
         let vmo = Vmo::new_paged(iter::repeat_n(
             THE_ZERO_FRAME.clone(),
             layout.size().div_ceil(arch::PAGE_SIZE),
@@ -69,10 +71,10 @@ impl UserMmap {
             None,
         )?;
 
+        log::trace!("new_zeroed: {len} {:?}", region.range);
+
         Ok(Self {
             range: region.range,
-            // Safety: we only use the ptr as an identifier in the WAVLTree
-            ptr: ptr::from_mut(unsafe { Pin::into_inner_unchecked(region) }),
         })
     }
 
@@ -82,22 +84,35 @@ impl UserMmap {
 
     pub fn copy_from_userspace(
         &self,
+        aspace: &mut AddressSpace,
         src_range: Range<usize>,
         dst: &mut [u8],
     ) -> Result<(), Error> {
-        self.with_user_slice(|src| dst.clone_from_slice(&src[src_range]))
+        self.with_user_slice(aspace, src_range, |src| dst.clone_from_slice(src))
     }
 
-    pub fn copy_to_userspace(&mut self, src: &[u8], dst_range: Range<usize>) -> Result<(), Error> {
-        self.with_user_slice_mut(|dst| {
-            dst[dst_range].copy_from_slice(src);
+    pub fn copy_to_userspace(
+        &mut self,
+        aspace: &mut AddressSpace,
+        src: &[u8],
+        dst_range: Range<usize>,
+    ) -> Result<(), Error> {
+        self.with_user_slice_mut(aspace, dst_range, |dst| {
+            dst.copy_from_slice(src);
         })
     }
 
-    pub fn with_user_slice<F>(&self, f: F) -> Result<(), Error>
+    pub fn with_user_slice<F>(
+        &self,
+        aspace: &mut AddressSpace,
+        range: Range<usize>,
+        f: F,
+    ) -> Result<(), Error>
     where
         F: FnOnce(&[u8]),
     {
+        self.ensure_mapped(aspace, range, false)?;
+
         #[expect(tail_expr_drop_order, reason = "")]
         crate::trap_handler::catch_traps(|| {
             // Safety: checked by caller and `catch_traps`
@@ -105,17 +120,26 @@ impl UserMmap {
                 with_user_memory_access(|| {
                     let slice =
                         slice::from_raw_parts(self.range.start.as_ptr(), self.range().size());
-                    f(slice);
+
+                    f(&slice[range]);
                 });
             }
         })
         .map_err(Error::Trap)
     }
 
-    pub fn with_user_slice_mut<F>(&mut self, f: F) -> Result<(), Error>
+    pub fn with_user_slice_mut<F>(
+        &mut self,
+        aspace: &mut AddressSpace,
+        range: Range<usize>,
+        f: F,
+    ) -> Result<(), Error>
     where
         F: FnOnce(&mut [u8]),
     {
+        self.ensure_mapped(aspace, range, true)?;
+        unsafe { aspace.arch.activate(); }
+
         #[expect(tail_expr_drop_order, reason = "")]
         crate::trap_handler::catch_traps(|| {
             // Safety: checked by caller and `catch_traps`
@@ -125,12 +149,11 @@ impl UserMmap {
                         self.range.start.as_mut_ptr(),
                         self.range().size(),
                     );
-                    f(slice);
+                    f(&mut slice[range]);
                 });
             }
         })
         .map_err(|trap| {
-            log::trace!("here");
             Error::Trap(trap)
         })
     }
@@ -166,6 +189,7 @@ impl UserMmap {
         aspace: &mut AddressSpace,
         _branch_protection: bool,
     ) -> Result<(), Error> {
+        log::trace!("UserMmap::make_executable: {:?}", self.range);
         self.protect(
             aspace,
             Permissions::READ | Permissions::EXECUTE | Permissions::USER,
@@ -174,6 +198,7 @@ impl UserMmap {
 
     /// Mark this memory mapping as read-only (`R`) essentially removing the write permission.
     pub fn make_readonly(&mut self, aspace: &mut AddressSpace) -> Result<(), Error> {
+        log::trace!("UserMmap::make_readonly: {:?}", self.range);
         self.protect(aspace, Permissions::READ | Permissions::USER)
     }
 
@@ -182,10 +207,9 @@ impl UserMmap {
         aspace: &mut AddressSpace,
         new_permissions: Permissions,
     ) -> Result<(), Error> {
-        if let Some(ptr) = NonNull::new(self.ptr) {
-            // Safety: constructors ensure ptr is valid
-            let mut c = unsafe { aspace.regions.cursor_mut_from_ptr(ptr) };
-            let mut region = c.get_mut().unwrap();
+        if !self.range.is_empty() {
+            let mut cursor = aspace.regions.find_mut(&self.range.start);
+            let mut region = cursor.get_mut().unwrap();
 
             region.permissions = new_permissions;
 
@@ -200,6 +224,26 @@ impl UserMmap {
                 )?;
             };
             flush.flush()?;
+        }
+
+        Ok(())
+    }
+
+    fn ensure_mapped(&self, aspace: &mut AddressSpace, range: Range<usize>, will_write: bool) -> Result<(), Error> {
+        if !self.range.is_empty() {
+            let mut cursor = aspace.regions.find_mut(&self.range.start);
+
+            let src_range = Range {
+                start: self.range.start.checked_add(range.start).unwrap(),
+                end: self.range.end.checked_add(range.start).unwrap(),
+            };
+
+            let mut batch = Batch::new(&mut aspace.arch);
+            cursor
+                .get_mut()
+                .unwrap()
+                .ensure_mapped(&mut batch, src_range, will_write)?;
+            batch.flush()?;
         }
 
         Ok(())

--- a/kernel/src/vm/user_mmap.rs
+++ b/kernel/src/vm/user_mmap.rs
@@ -166,12 +166,15 @@ impl UserMmap {
         aspace: &mut AddressSpace,
         _branch_protection: bool,
     ) -> Result<(), Error> {
-        self.protect(aspace, Permissions::READ | Permissions::EXECUTE)
+        self.protect(
+            aspace,
+            Permissions::READ | Permissions::EXECUTE | Permissions::USER,
+        )
     }
 
     /// Mark this memory mapping as read-only (`R`) essentially removing the write permission.
     pub fn make_readonly(&mut self, aspace: &mut AddressSpace) -> Result<(), Error> {
-        self.protect(aspace, Permissions::READ)
+        self.protect(aspace, Permissions::READ | Permissions::USER)
     }
 
     fn protect(

--- a/kernel/src/vm/vmo/paged.rs
+++ b/kernel/src/vm/vmo/paged.rs
@@ -28,7 +28,7 @@ impl PagedVmo {
     pub fn is_valid_offset(&self, offset: usize) -> bool {
         offset <= self.frames.size()
     }
-
+    
     pub fn require_owned_frame(&mut self, at_offset: usize) -> Result<&Frame, Error> {
         if let Some(old_frame) = self.frames.get(at_offset) {
             log::trace!("require_owned_frame for resident frame, allocating new...");
@@ -55,7 +55,7 @@ impl PagedVmo {
             let new_frame = self.frames.insert(at_offset, new_frame.clone());
             Ok(new_frame)
         } else {
-            todo!("TODO request bytes from source (later when we actually have sources)");
+            todo!("TODO request bytes from source (later when we actually have sources) requested_offset={at_offset};size={}", self.frames.size());
         }
     }
 
@@ -64,7 +64,7 @@ impl PagedVmo {
         if let Some(frame) = self.frames.get(at_offset) {
             Ok(frame)
         } else {
-            todo!("TODO request bytes from source (later when we actually have sources)");
+            todo!("TODO request bytes from source (later when we actually have sources) requested_offset={at_offset};size={}", self.frames.size());
         }
     }
 

--- a/kernel/src/vm/vmo/paged.rs
+++ b/kernel/src/vm/vmo/paged.rs
@@ -28,7 +28,7 @@ impl PagedVmo {
     pub fn is_valid_offset(&self, offset: usize) -> bool {
         offset <= self.frames.size()
     }
-    
+
     pub fn require_owned_frame(&mut self, at_offset: usize) -> Result<&Frame, Error> {
         if let Some(old_frame) = self.frames.get(at_offset) {
             log::trace!("require_owned_frame for resident frame, allocating new...");

--- a/kernel/src/wasm/cranelift/compiler.rs
+++ b/kernel/src/wasm/cranelift/compiler.rs
@@ -9,7 +9,7 @@ use crate::wasm::runtime::{StaticVMOffsets, VMCONTEXT_MAGIC};
 use crate::wasm::translate::{
     FunctionBodyData, ModuleTranslation, ModuleTypes, WasmFuncType, WasmValType,
 };
-use crate::wasm::trap::TRAP_INTERNAL_ASSERT;
+use crate::wasm::trap::{TRAP_EXIT, TRAP_INTERNAL_ASSERT};
 use crate::wasm::utils::{array_call_signature, value_type, wasm_call_signature};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
@@ -191,7 +191,8 @@ impl Compiler for CraneliftCompiler {
             values_vec_len,
         );
 
-        builder.ins().return_(&[]);
+        builder.ins().trap(TRAP_EXIT);
+        // builder.ins().return_(&[]);
         builder.finalize();
 
         compiler.finish(None)

--- a/kernel/src/wasm/errors.rs
+++ b/kernel/src/wasm/errors.rs
@@ -5,6 +5,7 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use core::fmt;
 use cranelift_codegen::CodegenError;
+use crate::vm::VirtualAddress;
 
 /// Convenience macro for creating an `Error::Unsupported` variant.
 #[macro_export]
@@ -47,9 +48,9 @@ pub enum Error {
     /// A WebAssembly trap occurred.
     Trap {
         /// The program counter where this trap originated.
-        pc: usize,
+        pc: VirtualAddress,
         /// The address of the inaccessible data or zero if trap wasn't caused by data access.
-        faulting_addr: usize,
+        faulting_addr: VirtualAddress,
         /// The trap that occurred.
         trap: Trap,
         /// A human-readable description of the trap.

--- a/kernel/src/wasm/errors.rs
+++ b/kernel/src/wasm/errors.rs
@@ -1,3 +1,4 @@
+use crate::vm::VirtualAddress;
 use crate::wasm::backtrace::RawWasmBacktrace;
 use crate::wasm::translate::EntityType;
 use crate::wasm::trap::Trap;
@@ -5,7 +6,6 @@ use alloc::format;
 use alloc::string::{String, ToString};
 use core::fmt;
 use cranelift_codegen::CodegenError;
-use crate::vm::VirtualAddress;
 
 /// Convenience macro for creating an `Error::Unsupported` variant.
 #[macro_export]

--- a/kernel/src/wasm/instance.rs
+++ b/kernel/src/wasm/instance.rs
@@ -29,16 +29,13 @@ impl Instance {
     /// compatibility with the `module` being instantiated.
     pub(crate) unsafe fn new_unchecked(
         store: &mut Store,
-        alloc: &dyn InstanceAllocator,
-        aspace: &mut AddressSpace,
         const_eval: &mut ConstExprEvaluator,
         module: Module,
         imports: Imports,
     ) -> crate::wasm::Result<Self> {
         // Safety: caller has to ensure safety
-        let instance = unsafe {
-            runtime::Instance::new_unchecked(alloc, aspace, const_eval, module, imports)?
-        };
+        let instance =
+            unsafe { runtime::Instance::new_unchecked(store, const_eval, module, imports)? };
         let handle = store.push_instance(instance);
         Ok(Self(handle))
     }

--- a/kernel/src/wasm/linker.rs
+++ b/kernel/src/wasm/linker.rs
@@ -115,8 +115,6 @@ impl Linker {
     pub fn instantiate(
         &self,
         store: &mut Store,
-        alloc: &dyn InstanceAllocator,
-        aspace: &mut AddressSpace,
         const_eval: &mut ConstExprEvaluator,
         module: &Module,
     ) -> crate::wasm::Result<Instance> {
@@ -148,9 +146,7 @@ impl Linker {
         }
 
         // Safety: we have typechecked the imports above.
-        unsafe {
-            Instance::new_unchecked(store, alloc, aspace, const_eval, module.clone(), imports)
-        }
+        unsafe { Instance::new_unchecked(store, const_eval, module.clone(), imports) }
     }
 
     fn insert(&mut self, key: ImportKey, item: Extern) -> crate::wasm::Result<()> {

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -148,9 +148,7 @@ pub fn test() {
         linker
             .define_instance(&mut store, "fib_cpp", instance)
             .unwrap();
-
     }
-        crate::allocator::print_usage();
 
     // instantiate the test module
     {
@@ -162,13 +160,12 @@ pub fn test() {
         )
         .unwrap();
 
-        crate::allocator::print_usage();
         let instance = linker
             .instantiate(&mut store, &mut const_eval, &module)
             .unwrap();
 
         instance.debug_vmctx(&store);
-        
+
         let func = instance.get_func(&mut store, "fib_test").unwrap();
         // TODO replace with checked
         // Safety: WIP

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -32,9 +32,9 @@ mod values;
 pub use errors::Error;
 use wasmparser::Validator;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
-use crate::vm::{AddressSpace, KERNEL_ASPACE};
+use crate::vm::{AddressSpace, ArchAddressSpace, VirtualAddress, KERNEL_ASPACE};
 use crate::wasm::instance_allocator::PlaceholderAllocatorDontUse;
-use crate::{enum_accessors, owned_enum_accessors};
+use crate::{arch, enum_accessors, owned_enum_accessors};
 pub use engine::Engine;
 pub use func::Func;
 pub use global::Global;
@@ -128,57 +128,47 @@ pub fn test() {
     let mut linker = Linker::new(&engine);
     let mut store = Store::new(&engine);
     let mut const_eval = ConstExprEvaluator::default();
-    let mut aspace = AddressSpace::new_user(2, None).unwrap();
+    // let mut aspace = AddressSpace::new_user(2, None).unwrap();
 
     // instantiate & define the fib_cpp module
     {
         let module = Module::from_bytes(
             &engine,
-            &mut aspace,
+            &mut store,
             &mut validator,
             include_bytes!("../../fib_cpp.wasm"),
         )
         .unwrap();
-        log::debug!("here");
 
         let instance = linker
-            .instantiate(
-                &mut store,
-                &PlaceholderAllocatorDontUse,
-                &mut aspace,
-                &mut const_eval,
-                &module,
-            )
+            .instantiate(&mut store, &mut const_eval, &module)
             .unwrap();
         instance.debug_vmctx(&store);
 
         linker
             .define_instance(&mut store, "fib_cpp", instance)
             .unwrap();
+
     }
+        crate::allocator::print_usage();
 
     // instantiate the test module
     {
         let module = Module::from_bytes(
             &engine,
-            &mut aspace,
+            &mut store,
             &mut validator,
-            include_bytes!("../../fib_cpp.wasm"),
+            include_bytes!("../../fib_test.wasm"),
         )
         .unwrap();
 
+        crate::allocator::print_usage();
         let instance = linker
-            .instantiate(
-                &mut store,
-                &PlaceholderAllocatorDontUse,
-                &mut aspace,
-                &mut const_eval,
-                &module,
-            )
+            .instantiate(&mut store, &mut const_eval, &module)
             .unwrap();
 
         instance.debug_vmctx(&store);
-
+        
         let func = instance.get_func(&mut store, "fib_test").unwrap();
         // TODO replace with checked
         // Safety: WIP

--- a/kernel/src/wasm/runtime/code_memory.rs
+++ b/kernel/src/wasm/runtime/code_memory.rs
@@ -1,4 +1,4 @@
-use crate::vm::{AddressSpace, UserMmap, KERNEL_ASPACE};
+use crate::vm::{AddressRangeExt, AddressSpace, UserMmap, VirtualAddress, KERNEL_ASPACE};
 use crate::wasm::compile::FunctionLoc;
 use crate::wasm::runtime::MmapVec;
 use crate::wasm::trap::Trap;
@@ -46,15 +46,16 @@ impl CodeMemory {
     }
 
     #[inline]
-    pub fn text(&self) -> &[u8] {
-        // Safety: The constructor has to ensure that `self.len` is valid.
-        unsafe { self.mmap.slice(Range::from(0..self.len)) }
+    pub fn text_range(&self) -> Range<VirtualAddress> {
+        let start = self.mmap.range().start;
+
+        Range::from(start..start.checked_add(self.len).unwrap())
     }
 
     pub fn resolve_function_loc(&self, func_loc: FunctionLoc) -> usize {
         let text_range = {
-            let r = self.text().as_ptr_range();
-            r.start as usize..r.end as usize
+            let r = self.text_range();
+            r.start.get()..r.end.get()
         };
 
         let addr = text_range.start + func_loc.start as usize;

--- a/kernel/src/wasm/runtime/code_memory.rs
+++ b/kernel/src/wasm/runtime/code_memory.rs
@@ -1,4 +1,4 @@
-use crate::vm::{AddressSpace, MmapSlice, KERNEL_ASPACE};
+use crate::vm::{AddressSpace, UserMmap, KERNEL_ASPACE};
 use crate::wasm::compile::FunctionLoc;
 use crate::wasm::runtime::MmapVec;
 use crate::wasm::trap::Trap;
@@ -8,7 +8,7 @@ use core::range::Range;
 
 #[derive(Debug)]
 pub struct CodeMemory {
-    mmap: MmapSlice,
+    mmap: UserMmap,
     len: usize,
     published: bool,
 

--- a/kernel/src/wasm/runtime/code_registry.rs
+++ b/kernel/src/wasm/runtime/code_registry.rs
@@ -35,12 +35,12 @@ pub fn lookup_code(pc: usize) -> Option<(Arc<CodeMemory>, usize)> {
 /// This is used by trap handling to determine which region of code a faulting
 /// address.
 pub fn register_code(code: &Arc<CodeMemory>) {
-    let text = code.text();
+    let text = code.text_range();
     if text.is_empty() {
         return;
     }
-    let start = text.as_ptr() as usize;
-    let end = start + text.len() - 1;
-    let prev = global_code().write().insert(end, (start, code.clone()));
+    let prev = global_code()
+        .write()
+        .insert(text.start.get(), (text.end.get(), code.clone()));
     assert!(prev.is_none());
 }

--- a/kernel/src/wasm/runtime/code_registry.rs
+++ b/kernel/src/wasm/runtime/code_registry.rs
@@ -41,6 +41,6 @@ pub fn register_code(code: &Arc<CodeMemory>) {
     }
     let prev = global_code()
         .write()
-        .insert(text.start.get(), (text.end.get(), code.clone()));
+        .insert(text.end.get(), (text.start.get(), code.clone()));
     assert!(prev.is_none());
 }

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -53,7 +53,7 @@ impl Instance {
         imports: Imports,
     ) -> crate::wasm::Result<Self> {
         let (mut vmctx, mut tables, mut memories) = store.alloc.allocate_module(&module)?;
-        
+
         log::trace!("initializing instance");
         unsafe {
             arch::with_user_memory_access(|| -> crate::wasm::Result<()> {

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -25,6 +25,7 @@ use crate::wasm::{Extern, Module};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::ptr::NonNull;
+use core::range::Range;
 use core::{fmt, mem, ptr, slice};
 use cranelift_entity::packed_option::ReservedValue;
 use cranelift_entity::{EntityRef, EntitySet, PrimaryMap};
@@ -613,8 +614,9 @@ unsafe fn initialize_memories(
         let offset = usize::try_from(offset.get_u64()).unwrap();
 
         if let Some(def_index) = module.translated().defined_memory_index(init.memory_index) {
-            memories[def_index].as_slice_mut()[offset..offset + init.data.len()]
-                .copy_from_slice(&init.data);
+            memories[def_index].with_user_slice_mut(|slice| {
+                slice[offset..offset + init.data.len()].copy_from_slice(&init.data);
+            });
         } else {
             todo!("initializing imported table")
         }

--- a/kernel/src/wasm/runtime/instance_allocator.rs
+++ b/kernel/src/wasm/runtime/instance_allocator.rs
@@ -204,7 +204,7 @@ pub trait InstanceAllocator {
             module.translated().num_memories() - module.translated().num_imported_memories();
         let mut memories =
             PrimaryMap::with_capacity(usize::try_from(num_defined_memories).unwrap());
-        
+
         // Safety: TODO
         match (|| unsafe {
             self.allocate_tables(module.translated(), &mut tables)?;

--- a/kernel/src/wasm/runtime/memory.rs
+++ b/kernel/src/wasm/runtime/memory.rs
@@ -47,9 +47,11 @@ impl Memory {
         })
     }
 
-    pub(crate) fn as_slice_mut(&mut self) -> &mut [u8] {
-        // Safety: The constructor has to ensure that `self.len` is valid.
-        unsafe { self.mmap.slice_mut(Range::from(0..self.len)) }
+    pub fn with_user_slice_mut<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut [u8]),
+    {
+        self.mmap.with_user_slice_mut(f).unwrap();
     }
 
     pub(crate) fn as_vmmemory_definition(&mut self) -> VMMemoryDefinition {

--- a/kernel/src/wasm/runtime/memory.rs
+++ b/kernel/src/wasm/runtime/memory.rs
@@ -1,4 +1,4 @@
-use crate::vm::{AddressSpace, MmapSlice};
+use crate::vm::{AddressSpace, UserMmap};
 use crate::wasm::runtime::VMMemoryDefinition;
 use crate::wasm::translate::MemoryDesc;
 use crate::wasm::utils::round_usize_up_to_host_pages;
@@ -8,7 +8,7 @@ use core::range::Range;
 #[derive(Debug)]
 pub struct Memory {
     /// The underlying allocation backing this memory
-    mmap: MmapSlice,
+    mmap: UserMmap,
     /// The current length of this Wasm memory, in bytes.
     len: usize,
     /// The optional maximum accessible size, in bytes, for this linear memory.
@@ -39,7 +39,7 @@ impl Memory {
         let request_bytes = allocation_bytes + offset_guard_bytes;
 
         Ok(Self {
-            mmap: MmapSlice::new_zeroed(aspace, request_bytes).map_err(|_| Error::MmapFailed)?,
+            mmap: UserMmap::new_zeroed(aspace, request_bytes).map_err(|_| Error::MmapFailed)?,
             len: actual_minimum_bytes,
             maximum: actual_maximum_bytes,
             page_size_log2: desc.page_size_log2,

--- a/kernel/src/wasm/runtime/memory.rs
+++ b/kernel/src/wasm/runtime/memory.rs
@@ -24,8 +24,9 @@ pub struct Memory {
 }
 
 impl Memory {
+    #[expect(clippy::unnecessary_wraps, reason = "TODO")]
     pub fn try_new(
-        aspace: &mut AddressSpace,
+        _aspace: &mut AddressSpace,
         desc: &MemoryDesc,
         actual_minimum_bytes: usize,
         actual_maximum_bytes: Option<usize>,
@@ -34,9 +35,9 @@ impl Memory {
         // Ensure that our guard regions are multiples of the host page size.
         let offset_guard_bytes = round_usize_up_to_host_pages(offset_guard_bytes);
 
-        let bound_bytes = round_usize_up_to_host_pages(MEMORY_MAX);
-        let allocation_bytes = bound_bytes.min(actual_maximum_bytes.unwrap_or(usize::MAX));
-        let request_bytes = allocation_bytes + offset_guard_bytes;
+        // let bound_bytes = round_usize_up_to_host_pages(MEMORY_MAX);
+        // let allocation_bytes = bound_bytes.min(actual_maximum_bytes.unwrap_or(usize::MAX));
+        // let request_bytes = allocation_bytes + offset_guard_bytes;
 
         // let mmap = UserMmap::new_zeroed(aspace, request_bytes, 2 * 1048576).map_err(|_| Error::MmapFailed)?;
 

--- a/kernel/src/wasm/runtime/memory.rs
+++ b/kernel/src/wasm/runtime/memory.rs
@@ -38,8 +38,10 @@ impl Memory {
         let allocation_bytes = bound_bytes.min(actual_maximum_bytes.unwrap_or(usize::MAX));
         let request_bytes = allocation_bytes + offset_guard_bytes;
 
+        // let mmap = UserMmap::new_zeroed(aspace, request_bytes, 2 * 1048576).map_err(|_| Error::MmapFailed)?;
+
         Ok(Self {
-            mmap: UserMmap::new_zeroed(aspace, request_bytes).map_err(|_| Error::MmapFailed)?,
+            mmap: UserMmap::new_empty(),
             len: actual_minimum_bytes,
             maximum: actual_maximum_bytes,
             page_size_log2: desc.page_size_log2,
@@ -47,11 +49,11 @@ impl Memory {
         })
     }
 
-    pub fn with_user_slice_mut<F>(&mut self, f: F)
+    pub fn with_user_slice_mut<F>(&mut self, aspace: &mut AddressSpace, range: Range<usize>, f: F)
     where
         F: FnOnce(&mut [u8]),
     {
-        self.mmap.with_user_slice_mut(f).unwrap();
+        self.mmap.with_user_slice_mut(aspace, range, f).unwrap();
     }
 
     pub(crate) fn as_vmmemory_definition(&mut self) -> VMMemoryDefinition {

--- a/kernel/src/wasm/runtime/mmap_vec.rs
+++ b/kernel/src/wasm/runtime/mmap_vec.rs
@@ -1,11 +1,11 @@
-use core::cmp::max;
+use crate::arch;
 use crate::vm::{AddressSpace, UserMmap};
 use crate::wasm::Error;
+use core::cmp::max;
 use core::marker::PhantomData;
 use core::ops::Deref;
 use core::range::Range;
 use core::slice;
-use crate::arch;
 
 #[derive(Debug)]
 pub struct MmapVec<T> {
@@ -25,7 +25,8 @@ impl<T> MmapVec<T> {
 
     pub fn new_zeroed(aspace: &mut AddressSpace, capacity: usize) -> crate::wasm::Result<Self> {
         Ok(Self {
-            mmap: UserMmap::new_zeroed(aspace, capacity, max(align_of::<T>(), arch::PAGE_SIZE)).map_err(|_| Error::MmapFailed)?,
+            mmap: UserMmap::new_zeroed(aspace, capacity, max(align_of::<T>(), arch::PAGE_SIZE))
+                .map_err(|_| Error::MmapFailed)?,
             len: 0,
             _m: PhantomData,
         })
@@ -48,7 +49,7 @@ impl<T> MmapVec<T> {
     pub fn capacity(&self) -> usize {
         self.mmap.len() / size_of::<T>()
     }
-    
+
     pub fn len(&self) -> usize {
         self.len
     }
@@ -90,7 +91,7 @@ impl<T> MmapVec<T> {
         T: Clone,
     {
         assert!(self.len() + other.len() <= self.capacity());
-        
+
         // "Transmute" the slice to a byte slice
         // Safety: we're just converting the slice to a byte slice of the same length
         let src = unsafe { slice::from_raw_parts(other.as_ptr().cast::<u8>(), size_of_val(other)) };
@@ -109,7 +110,7 @@ impl<T> MmapVec<T> {
         T: Clone,
     {
         assert!(self.len() + count <= self.capacity());
-        
+
         self.mmap
             .with_user_slice_mut(aspace, Range::from(self.len..self.len + count), |dst| {
                 // "Transmute" the slice to a byte slice

--- a/kernel/src/wasm/runtime/mmap_vec.rs
+++ b/kernel/src/wasm/runtime/mmap_vec.rs
@@ -1,4 +1,4 @@
-use crate::vm::{AddressSpace, MmapSlice};
+use crate::vm::{AddressSpace, UserMmap};
 use crate::wasm::Error;
 use core::marker::PhantomData;
 use core::ops::Deref;
@@ -6,7 +6,7 @@ use core::slice;
 
 #[derive(Debug)]
 pub struct MmapVec<T> {
-    mmap: MmapSlice,
+    mmap: UserMmap,
     len: usize,
     _m: PhantomData<T>,
 }
@@ -14,7 +14,7 @@ pub struct MmapVec<T> {
 impl<T> MmapVec<T> {
     pub fn new_empty() -> Self {
         Self {
-            mmap: MmapSlice::new_empty(),
+            mmap: UserMmap::new_empty(),
             len: 0,
             _m: PhantomData,
         }
@@ -22,7 +22,7 @@ impl<T> MmapVec<T> {
 
     pub fn new_zeroed(aspace: &mut AddressSpace, len: usize) -> crate::wasm::Result<Self> {
         Ok(Self {
-            mmap: MmapSlice::new_zeroed(aspace, len).map_err(|_| Error::MmapFailed)?,
+            mmap: UserMmap::new_zeroed(aspace, len).map_err(|_| Error::MmapFailed)?,
             len: 0,
             _m: PhantomData,
         })
@@ -108,7 +108,7 @@ impl<T> MmapVec<T> {
         }
     }
 
-    pub(crate) fn into_parts(self) -> (MmapSlice, usize) {
+    pub(crate) fn into_parts(self) -> (UserMmap, usize) {
         (self.mmap, self.len)
     }
 }

--- a/kernel/src/wasm/runtime/owned_vmcontext.rs
+++ b/kernel/src/wasm/runtime/owned_vmcontext.rs
@@ -1,22 +1,58 @@
-use crate::vm::AddressSpace;
+use alloc::string::ToString;
+use crate::arch;
+use crate::vm::{frame_alloc, AddressRangeExt, AddressSpace, ArchAddressSpace, Batch, FrameList, VirtualAddress, Vmo};
 use crate::wasm::runtime::{MmapVec, VMContext, VMOffsets};
+use core::alloc::Layout;
+use core::num::NonZeroUsize;
+use core::range::Range;
 
 #[derive(Debug)]
-pub struct OwnedVMContext(MmapVec<u8>);
+pub struct OwnedVMContext {
+    frames: FrameList,
+    range: Range<VirtualAddress>,
+}
 
 impl OwnedVMContext {
+    #[expect(tail_expr_drop_order, reason = "")]
     pub fn try_new(
         aspace: &mut AddressSpace,
         offsets: &VMOffsets,
     ) -> crate::wasm::Result<OwnedVMContext> {
-        let vec = MmapVec::new_zeroed(aspace, offsets.size() as usize)?;
-        Ok(Self(vec))
+        let layout = Layout::from_size_align(offsets.size() as usize, arch::PAGE_SIZE).unwrap();
+        let frames = frame_alloc::alloc_contiguous(layout.pad_to_align()).unwrap();
+
+        log::trace!("{frames:?}");
+        let phys_range = {
+            let start = frames.first().unwrap().addr();
+            Range::from(start..start.checked_add(layout.pad_to_align().size()).unwrap())
+        };
+        let vmo = Vmo::new_wired(phys_range);
+
+        let virt_range = aspace
+            .map(
+                layout,
+                vmo,
+                0,
+                crate::vm::Permissions::READ | crate::vm::Permissions::WRITE,
+                Some("VMContext".to_string()),
+            )
+            .unwrap().range;
+        aspace.ensure_mapped(virt_range, true).unwrap();
+        
+        // let mut batch = Batch::new(&mut aspace.arch);
+        // region.ensure_mapped(&mut batch, virt_range, true).unwrap();
+        // batch.flush().unwrap();
+        
+        Ok(Self {
+            frames,
+            range: virt_range,
+        })
     }
     pub fn as_ptr(&self) -> *const VMContext {
-        self.0.as_ptr().cast()
+        self.range.start.as_ptr().cast()
     }
     pub fn as_mut_ptr(&mut self) -> *mut VMContext {
-        self.0.as_mut_ptr().cast()
+        self.range.start.as_mut_ptr().cast()
     }
     pub unsafe fn plus_offset<T>(&self, offset: u32) -> *const T {
         // Safety: caller has to ensure offset is valid

--- a/kernel/src/wasm/runtime/owned_vmcontext.rs
+++ b/kernel/src/wasm/runtime/owned_vmcontext.rs
@@ -1,7 +1,10 @@
-use alloc::string::ToString;
 use crate::arch;
-use crate::vm::{frame_alloc, AddressRangeExt, AddressSpace, ArchAddressSpace, Batch, FrameList, VirtualAddress, Vmo};
+use crate::vm::{
+    frame_alloc, AddressRangeExt, AddressSpace, ArchAddressSpace, Batch, FrameList, VirtualAddress,
+    Vmo,
+};
 use crate::wasm::runtime::{MmapVec, VMContext, VMOffsets};
+use alloc::string::ToString;
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
 use core::range::Range;
@@ -14,6 +17,7 @@ pub struct OwnedVMContext {
 
 impl OwnedVMContext {
     #[expect(tail_expr_drop_order, reason = "")]
+    #[expect(clippy::unnecessary_wraps, reason = "TODO")]
     pub fn try_new(
         aspace: &mut AddressSpace,
         offsets: &VMOffsets,
@@ -36,13 +40,14 @@ impl OwnedVMContext {
                 crate::vm::Permissions::READ | crate::vm::Permissions::WRITE,
                 Some("VMContext".to_string()),
             )
-            .unwrap().range;
+            .unwrap()
+            .range;
         aspace.ensure_mapped(virt_range, true).unwrap();
-        
+
         // let mut batch = Batch::new(&mut aspace.arch);
         // region.ensure_mapped(&mut batch, virt_range, true).unwrap();
         // batch.flush().unwrap();
-        
+
         Ok(Self {
             frames,
             range: virt_range,

--- a/kernel/src/wasm/runtime/table.rs
+++ b/kernel/src/wasm/runtime/table.rs
@@ -25,7 +25,7 @@ impl Table {
             MmapVec::new_empty()
         } else {
             let mut elements = MmapVec::new_zeroed(aspace, reserve_size)?;
-            elements.extend_with(usize::try_from(desc.minimum).unwrap(), None);
+            elements.extend_with(aspace, usize::try_from(desc.minimum).unwrap(), None);
             elements
         };
 

--- a/kernel/src/wasm/store.rs
+++ b/kernel/src/wasm/store.rs
@@ -1,3 +1,4 @@
+use crate::wasm::instance_allocator::PlaceholderAllocatorDontUse;
 use crate::wasm::runtime::{VMContext, VMOpaqueContext, VMVal};
 use crate::wasm::{runtime, Engine};
 use alloc::vec::Vec;
@@ -17,6 +18,8 @@ pub struct Store {
     wasm_vmval_storage: Vec<VMVal>,
 
     vmctx2instance: HashMap<*mut VMOpaqueContext, Stored<runtime::Instance>>,
+
+    pub(super) alloc: PlaceholderAllocatorDontUse,
 }
 
 impl Store {
@@ -32,6 +35,8 @@ impl Store {
             wasm_vmval_storage: Vec::new(),
 
             vmctx2instance: HashMap::new(),
+
+            alloc: PlaceholderAllocatorDontUse::default(),
         }
     }
 

--- a/kernel/src/wasm/trap.rs
+++ b/kernel/src/wasm/trap.rs
@@ -18,8 +18,7 @@ pub const TRAP_NULL_REFERENCE: TrapCode =
     TrapCode::unwrap_user(Trap::NullReference as u8 + TRAP_OFFSET);
 pub const TRAP_I31_NULL_REFERENCE: TrapCode =
     TrapCode::unwrap_user(Trap::NullI31Ref as u8 + TRAP_OFFSET);
-pub const TRAP_EXIT: TrapCode =
-    TrapCode::unwrap_user(Trap::Exit as u8 + TRAP_OFFSET);
+pub const TRAP_EXIT: TrapCode = TrapCode::unwrap_user(Trap::Exit as u8 + TRAP_OFFSET);
 
 #[derive(Debug, Copy, Clone)]
 pub enum Trap {
@@ -50,7 +49,7 @@ pub enum Trap {
     IntegerDivisionByZero,
     /// Failed float-to-int conversion.
     BadConversionToInteger,
-    
+
     Exit,
 }
 
@@ -71,7 +70,7 @@ impl fmt::Display for Trap {
             Trap::IntegerOverflow => f.write_str("integer overflow"),
             Trap::IntegerDivisionByZero => f.write_str("integer divide by zero"),
             Trap::BadConversionToInteger => f.write_str("invalid conversion to integer"),
-            
+
             Trap::Exit => f.write_str("exit"),
         }
     }
@@ -96,9 +95,9 @@ impl Trap {
             TRAP_UNREACHABLE => Some(Trap::UnreachableCodeReached),
             TRAP_NULL_REFERENCE => Some(Trap::NullReference),
             TRAP_I31_NULL_REFERENCE => Some(Trap::NullI31Ref),
-            
+
             TRAP_EXIT => Some(Trap::Exit),
-            
+
             c => {
                 log::warn!("unknown trap code {c}");
                 None
@@ -124,7 +123,7 @@ impl From<Trap> for u8 {
             Trap::IntegerOverflow => 10,
             Trap::IntegerDivisionByZero => 11,
             Trap::BadConversionToInteger => 12,
-            
+
             Trap::Exit => 13,
         }
     }
@@ -149,9 +148,9 @@ impl TryFrom<u8> for Trap {
             10 => Ok(Self::IntegerOverflow),
             11 => Ok(Self::IntegerDivisionByZero),
             12 => Ok(Self::BadConversionToInteger),
-            
+
             13 => Ok(Self::Exit),
-            
+
             _ => Err(()),
         }
     }

--- a/kernel/src/wasm/trap.rs
+++ b/kernel/src/wasm/trap.rs
@@ -18,6 +18,8 @@ pub const TRAP_NULL_REFERENCE: TrapCode =
     TrapCode::unwrap_user(Trap::NullReference as u8 + TRAP_OFFSET);
 pub const TRAP_I31_NULL_REFERENCE: TrapCode =
     TrapCode::unwrap_user(Trap::NullI31Ref as u8 + TRAP_OFFSET);
+pub const TRAP_EXIT: TrapCode =
+    TrapCode::unwrap_user(Trap::Exit as u8 + TRAP_OFFSET);
 
 #[derive(Debug, Copy, Clone)]
 pub enum Trap {
@@ -48,6 +50,8 @@ pub enum Trap {
     IntegerDivisionByZero,
     /// Failed float-to-int conversion.
     BadConversionToInteger,
+    
+    Exit,
 }
 
 impl fmt::Display for Trap {
@@ -67,6 +71,8 @@ impl fmt::Display for Trap {
             Trap::IntegerOverflow => f.write_str("integer overflow"),
             Trap::IntegerDivisionByZero => f.write_str("integer divide by zero"),
             Trap::BadConversionToInteger => f.write_str("invalid conversion to integer"),
+            
+            Trap::Exit => f.write_str("exit"),
         }
     }
 }
@@ -90,6 +96,9 @@ impl Trap {
             TRAP_UNREACHABLE => Some(Trap::UnreachableCodeReached),
             TRAP_NULL_REFERENCE => Some(Trap::NullReference),
             TRAP_I31_NULL_REFERENCE => Some(Trap::NullI31Ref),
+            
+            TRAP_EXIT => Some(Trap::Exit),
+            
             c => {
                 log::warn!("unknown trap code {c}");
                 None
@@ -115,6 +124,8 @@ impl From<Trap> for u8 {
             Trap::IntegerOverflow => 10,
             Trap::IntegerDivisionByZero => 11,
             Trap::BadConversionToInteger => 12,
+            
+            Trap::Exit => 13,
         }
     }
 }
@@ -138,6 +149,9 @@ impl TryFrom<u8> for Trap {
             10 => Ok(Self::IntegerOverflow),
             11 => Ok(Self::IntegerDivisionByZero),
             12 => Ok(Self::BadConversionToInteger),
+            
+            13 => Ok(Self::Exit),
+            
             _ => Err(()),
         }
     }

--- a/libs/riscv/src/register/satp.rs
+++ b/libs/riscv/src/register/satp.rs
@@ -7,7 +7,7 @@
 
 //! Supervisor Address Translation and Protection Register
 
-use super::{read_csr_as, set};
+use super::{read_csr_as, write_csr};
 use crate::Error;
 use core::fmt;
 
@@ -18,7 +18,7 @@ pub struct Satp {
 }
 
 read_csr_as!(Satp, 0x180);
-set!(0x180);
+write_csr!(0x180);
 
 /// Sets the register to corresponding page table mode, physical page number and address space id.
 ///
@@ -83,7 +83,7 @@ pub unsafe fn try_set(mode: Mode, asid: u16, ppn: usize) -> crate::Result<()> {
     } else {
         let bits = (mode as usize) << 60 | ((asid as usize) << 44) | ppn;
         unsafe {
-            _set(bits);
+            _write(bits);
         }
         Ok(())
     }

--- a/libs/riscv/src/register/scause.rs
+++ b/libs/riscv/src/register/scause.rs
@@ -7,7 +7,7 @@
 
 //! Supervisor Cause Register
 
-use super::{read_csr_as, set};
+use super::{read_csr_as, write_csr};
 use core::fmt;
 use core::fmt::Formatter;
 
@@ -18,14 +18,14 @@ pub struct Scause {
 }
 
 read_csr_as!(Scause, 0x142);
-set!(0x142);
+write_csr!(0x142);
 
 pub unsafe fn set(trap: Trap) {
     match trap {
         Trap::Interrupt(interrupt) => unsafe {
-            _set(1 << (usize::BITS as usize - 1) | interrupt as usize);
+            _write(1 << (usize::BITS as usize - 1) | interrupt as usize);
         },
-        Trap::Exception(exception) => unsafe { _set(exception as usize) },
+        Trap::Exception(exception) => unsafe { _write(exception as usize) },
     }
 }
 

--- a/libs/riscv/src/register/scounteren.rs
+++ b/libs/riscv/src/register/scounteren.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::register::{clear, read_csr_as, set};
-use crate::{set_clear_csr, Error};
+use crate::register::{clear_csr, read_csr_as, set_clear_csr_field, set_csr};
+use crate::Error;
 
 /// Scounteren register
 #[derive(Clone, Copy)]
@@ -15,18 +15,18 @@ pub struct Scounteren {
 }
 
 read_csr_as!(Scounteren, 0x106);
-set!(0x106);
-clear!(0x106);
+set_csr!(0x106);
+clear_csr!(0x106);
 
-set_clear_csr!(
+set_clear_csr_field!(
 /// User cycle Enable
     , set_cy, clear_cy, 1 << 0_i32);
 
-set_clear_csr!(
+set_clear_csr_field!(
 /// User time Enable
     , set_tm, clear_tm, 1 << 1_i32);
 
-set_clear_csr!(
+set_clear_csr_field!(
 /// User instret Enable
     , set_ir, clear_ir, 1 << 2_i32);
 

--- a/libs/riscv/src/register/sepc.rs
+++ b/libs/riscv/src/register/sepc.rs
@@ -7,7 +7,7 @@
 
 //! Supervisor Exception Program Counter Register
 
-use super::{read_csr_as_usize, set_csr_as_usize};
+use super::{read_csr_as_usize, write_csr_as_usize};
 
 read_csr_as_usize!(0x141);
-set_csr_as_usize!(0x141);
+write_csr_as_usize!(0x141);

--- a/libs/riscv/src/register/sie.rs
+++ b/libs/riscv/src/register/sie.rs
@@ -7,7 +7,7 @@
 
 //! Supervisor Interrupt Enable Register
 
-use super::{clear, read_csr_as, set};
+use super::{clear_csr, read_csr_as, set_csr};
 use core::fmt;
 use core::fmt::Formatter;
 
@@ -18,8 +18,8 @@ pub struct Sie {
 }
 
 read_csr_as!(Sie, 0x104);
-set!(0x104);
-clear!(0x104);
+set_csr!(0x104);
+clear_csr!(0x104);
 
 pub unsafe fn set_ssie() {
     unsafe {

--- a/libs/riscv/src/register/sscratch.rs
+++ b/libs/riscv/src/register/sscratch.rs
@@ -7,7 +7,7 @@
 
 //! sscratch register
 
-use crate::register::{read_csr_as_usize, set_csr_as_usize};
+use crate::register::{read_csr_as_usize, write_csr_as_usize};
 
 read_csr_as_usize!(0x140);
-set_csr_as_usize!(0x140);
+write_csr_as_usize!(0x140);

--- a/libs/riscv/src/register/sstatus.rs
+++ b/libs/riscv/src/register/sstatus.rs
@@ -7,7 +7,8 @@
 
 //! Supervisor Status Register
 
-use super::{clear, read_csr_as, set};
+use super::{clear_csr, read_csr_as, set_clear_csr_field, set_csr};
+use crate::set_csr_field;
 use core::fmt;
 use core::fmt::Formatter;
 
@@ -17,37 +18,35 @@ pub struct Sstatus {
     bits: usize,
 }
 
+set_csr!(0x100);
+clear_csr!(0x100);
+
 read_csr_as!(Sstatus, 0x100);
-set!(0x100);
-clear!(0x100);
-
-/// Supervisor Interrupt Enable
-pub unsafe fn set_sie() {
-    unsafe {
-        _set(1 << 1);
-    }
-}
-
-/// Supervisor Interrupt Enable
-pub unsafe fn clear_sie() {
-    unsafe {
-        _clear(1 << 1);
-    }
-}
-
-/// Supervisor Previous Interrupt Enable
-pub unsafe fn set_spie() {
-    unsafe {
-        _set(1 << 5);
-    }
-}
+set_clear_csr_field!(
+    /// User Interrupt Enable
+    , set_uie, clear_uie, 1 << 0_i32);
+set_clear_csr_field!(
+    /// Supervisor Interrupt Enable
+    , set_sie, clear_sie, 1 << 1_i32);
+set_csr_field!(
+    /// User Previous Interrupt Enable
+    , set_upie, 1 << 4_i32);
+set_csr_field!(
+    /// Supervisor Previous Interrupt Enable
+    , set_spie, 1 << 5_i32);
+set_clear_csr_field!(
+    /// Permit Supervisor User Memory access
+    , set_sum, clear_sum, 1 << 18_i32);
+set_clear_csr_field!(
+    /// Make eXecutable Readable
+    , set_mxr, clear_mxr, 1 << 19_i32);
 
 /// Supervisor Previous Privilege Mode
 #[inline]
 pub unsafe fn set_spp(spp: SPP) {
     match spp {
-        SPP::Supervisor => unsafe { _set(1 << 8) },
-        SPP::User => unsafe { _clear(1 << 8) },
+        SPP::Supervisor => unsafe { _set(1 << 8_i32) },
+        SPP::User => unsafe { _clear(1 << 8_i32) },
     }
 }
 
@@ -58,20 +57,6 @@ pub unsafe fn set_fs(fs: FS) {
     value |= (fs as usize) << 13_i32;
     unsafe {
         _set(value);
-    }
-}
-
-/// Permit Supervisor User Memory access
-pub unsafe fn set_sum() {
-    unsafe {
-        _set(1 << 18);
-    }
-}
-
-/// Permit Supervisor User Memory access
-pub unsafe fn clear_sum() {
-    unsafe {
-        _clear(1 << 18);
     }
 }
 

--- a/libs/riscv/src/register/stval.rs
+++ b/libs/riscv/src/register/stval.rs
@@ -7,7 +7,7 @@
 
 //! Supervisor Trap Value Register
 
-use super::{read_csr_as_usize, set_csr_as_usize};
+use super::{read_csr_as_usize, write_csr_as_usize};
 
 read_csr_as_usize!(0x143);
-set_csr_as_usize!(0x143);
+write_csr_as_usize!(0x143);

--- a/libs/riscv/src/register/stvec.rs
+++ b/libs/riscv/src/register/stvec.rs
@@ -7,7 +7,7 @@
 
 //! Supervisor Trap Vector Base Address Register
 
-use super::{read_csr_as, set};
+use super::{read_csr_as, set_csr};
 use core::fmt;
 use core::fmt::Formatter;
 
@@ -16,7 +16,7 @@ pub struct Stvec {
     bits: usize,
 }
 read_csr_as!(Stvec, 0x105);
-set!(0x105);
+set_csr!(0x105);
 
 pub unsafe fn write(base: usize, mode: Mode) {
     unsafe {

--- a/libs/wavltree/src/lib.rs
+++ b/libs/wavltree/src/lib.rs
@@ -667,7 +667,7 @@ where
     /// Caller has to ensure the pointer points to a valid node in the tree.
     #[inline]
     pub unsafe fn cursor_mut_from_ptr(&mut self, ptr: NonNull<T>) -> CursorMut<'_, T> {
-        debug_assert!(unsafe { T::links(ptr).as_ref() }.is_linked());
+        debug_assert!(unsafe { T::links(ptr).as_ref() }.is_linked(), "ptr {ptr:?} is not a linked element");
         CursorMut {
             current: Some(ptr),
             _tree: self,

--- a/libs/wavltree/src/lib.rs
+++ b/libs/wavltree/src/lib.rs
@@ -667,7 +667,10 @@ where
     /// Caller has to ensure the pointer points to a valid node in the tree.
     #[inline]
     pub unsafe fn cursor_mut_from_ptr(&mut self, ptr: NonNull<T>) -> CursorMut<'_, T> {
-        debug_assert!(unsafe { T::links(ptr).as_ref() }.is_linked(), "ptr {ptr:?} is not a linked element");
+        debug_assert!(
+            unsafe { T::links(ptr).as_ref() }.is_linked(),
+            "ptr {ptr:?} is not a linked element"
+        );
         CursorMut {
             current: Some(ptr),
             _tree: self,


### PR DESCRIPTION
The basic features of userspace `AddressSpaces` have been present for a while now, but while integrating the WASM runtime I discovered that actually the APIs aren't quite there yet to support the necessary features.

The implementation of usercopy primitives was a big step and this PR continues this by evolving the `MmapSlice` struct.