### PR TITLE
fix: add callback `executor::run` to spawn hart-local tasks

### DIFF
--- a/kernel/src/executor/mod.rs
+++ b/kernel/src/executor/mod.rs
@@ -84,6 +84,7 @@ use core::future::Future;
 use rand::RngCore;
 use sync::OnceLock;
 pub use task::JoinHandle;
+use crate::executor::task::TaskRef;
 
 static EXECUTOR: OnceLock<Executor> = OnceLock::new();
 
@@ -116,9 +117,13 @@ pub fn init(num_cores: usize, rng: &mut impl RngCore, shutdown_on_idle: bool) ->
 /// Run the async runtime loop on the calling hart.
 ///
 /// This function will not return until the runtime is shut down.
-#[cold]
-pub fn run(rt: &'static Executor, hartid: usize) -> Result<(), ()> {
-    scheduler::multi_thread::worker::run(&rt.scheduler, hartid)
+#[inline]
+pub fn run(
+    rt: &'static Executor,
+    hartid: usize,
+    initial: impl FnOnce()
+) -> Result<(), ()> {
+    scheduler::multi_thread::worker::run(&rt.scheduler, hartid, initial)
 }
 
 impl Executor {

--- a/kernel/src/executor/mod.rs
+++ b/kernel/src/executor/mod.rs
@@ -84,7 +84,6 @@ use core::future::Future;
 use rand::RngCore;
 use sync::OnceLock;
 pub use task::JoinHandle;
-use crate::executor::task::TaskRef;
 
 static EXECUTOR: OnceLock<Executor> = OnceLock::new();
 
@@ -118,11 +117,7 @@ pub fn init(num_cores: usize, rng: &mut impl RngCore, shutdown_on_idle: bool) ->
 ///
 /// This function will not return until the runtime is shut down.
 #[inline]
-pub fn run(
-    rt: &'static Executor,
-    hartid: usize,
-    initial: impl FnOnce()
-) -> Result<(), ()> {
+pub fn run(rt: &'static Executor, hartid: usize, initial: impl FnOnce()) -> Result<(), ()> {
     scheduler::multi_thread::worker::run(&rt.scheduler, hartid, initial)
 }
 

--- a/kernel/src/executor/scheduler/multi_thread/idle.rs
+++ b/kernel/src/executor/scheduler/multi_thread/idle.rs
@@ -261,14 +261,16 @@ impl Idle {
             let core = self.try_acquire_available_core(&mut synced.idle).unwrap();
 
             synced.assigned_cores[worker] = Some(core);
+            log::trace!("waking sleeping worker {worker} for shutdown...");
             shared.condvars[worker].notify_one(&shared.parking_spot);
         }
 
         debug_assert!(self.idle_map.matches(&synced.idle.available_cores));
 
         // Wake up any other workers
-        while let Some(index) = synced.idle.sleepers.pop() {
-            shared.condvars[index].notify_one(&shared.parking_spot);
+        while let Some(worker) = synced.idle.sleepers.pop() {
+            log::trace!("waking worker {worker} for shutdown...");
+            shared.condvars[worker].notify_one(&shared.parking_spot);
         }
     }
 

--- a/kernel/src/executor/scheduler/multi_thread/worker.rs
+++ b/kernel/src/executor/scheduler/multi_thread/worker.rs
@@ -76,6 +76,7 @@ use crate::{arch, counter};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
+use core::future::Future;
 use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use core::task::Waker;
 use core::time::Duration;
@@ -197,7 +198,11 @@ pub(super) struct Context {
 }
 
 #[cold]
-pub fn run(handle: &'static Handle, hartid: usize) -> Result<(), ()> {
+pub fn run(
+    handle: &'static Handle,
+    hartid: usize,
+    initial: impl FnOnce()
+) -> Result<(), ()> {
     let mut worker = Worker {
         is_shutdown: false,
         hartid,
@@ -229,10 +234,12 @@ pub fn run(handle: &'static Handle, hartid: usize) -> Result<(), ()> {
             worker.wait_for_core(cx, synced)?
         }
     };
-
+    
     if let Some(task) = maybe_task {
         core = worker.run_task(cx, core, task)?;
     }
+    
+    initial();
 
     // once we have acquired a core, we can start the scheduling loop
     while !worker.is_shutdown {
@@ -347,7 +354,9 @@ impl Worker {
                 return Err(());
             }
 
+            log::trace!("[wait_for_core] parking hart..");
             cx.shared().condvars[self.hartid].wait(&cx.shared().parking_spot, &mut synced);
+            log::trace!("[wait_for_core] unparked hart");
         };
 
         self.reset_acquired_core(cx, &mut core);
@@ -658,6 +667,7 @@ impl Worker {
 
         // Notify any workers
         for worker in self.workers_to_notify.drain(..) {
+            log::trace!("notifying worker {worker} in local notify queue...");
             cx.shared().condvars[worker].notify_one(&cx.shared().parking_spot);
         }
 
@@ -771,11 +781,13 @@ impl Shared {
         self.run_queue.enqueue(task);
 
         let synced = self.synced.lock();
+        log::trace!("calling notify_remote as part of schedule_remote...");
         self.idle.notify_remote(synced, self);
     }
 
     fn notify_parked_local(&self) {
         NUM_NOTIFY_LOCAL.increment(1);
+        log::trace!("calling notify_local as part of schedule_local...");
         self.idle.notify_local(self);
     }
 

--- a/kernel/src/executor/scheduler/multi_thread/worker.rs
+++ b/kernel/src/executor/scheduler/multi_thread/worker.rs
@@ -76,7 +76,6 @@ use crate::{arch, counter};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
-use core::future::Future;
 use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use core::task::Waker;
 use core::time::Duration;
@@ -198,11 +197,7 @@ pub(super) struct Context {
 }
 
 #[cold]
-pub fn run(
-    handle: &'static Handle,
-    hartid: usize,
-    initial: impl FnOnce()
-) -> Result<(), ()> {
+pub fn run(handle: &'static Handle, hartid: usize, initial: impl FnOnce()) -> Result<(), ()> {
     let mut worker = Worker {
         is_shutdown: false,
         hartid,
@@ -234,11 +229,11 @@ pub fn run(
             worker.wait_for_core(cx, synced)?
         }
     };
-    
+
     if let Some(task) = maybe_task {
         core = worker.run_task(cx, core, task)?;
     }
-    
+
     initial();
 
     // once we have acquired a core, we can start the scheduling loop

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -128,7 +128,7 @@ fn _start(hartid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
 
         // initialize the virtual memory subsystem
         vm::init(boot_info, &mut rng).unwrap();
-        
+
         // initialize the executor
 
         // if we're executing tests we don't want idle harts to park indefinitely, instead the
@@ -151,7 +151,7 @@ fn _start(hartid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
         Instant::now().duration_since(Instant::ZERO),
         Instant::from_ticks(boot_ticks).elapsed()
     );
-    
+
     let _ = executor::run(executor::current(), hartid, || {
         executor::current().spawn(async move {
             log::info!("Hello from hart {}", hartid);

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -128,7 +128,7 @@ fn _start(hartid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
 
         // initialize the virtual memory subsystem
         vm::init(boot_info, &mut rng).unwrap();
-
+        
         // initialize the executor
 
         // if we're executing tests we don't want idle harts to park indefinitely, instead the
@@ -151,12 +151,12 @@ fn _start(hartid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
         Instant::now().duration_since(Instant::ZERO),
         Instant::from_ticks(boot_ticks).elapsed()
     );
-
-    executor::current().spawn(async move {
-        log::info!("Hello from hart {}", hartid);
+    
+    let _ = executor::run(executor::current(), hartid, || {
+        executor::current().spawn(async move {
+            log::info!("Hello from hart {}", hartid);
+        });
     });
-
-    let _ = executor::run(executor::current(), hartid);
 
     // wasm::test();
 

--- a/kernel/src/util/parking_spot.rs
+++ b/kernel/src/util/parking_spot.rs
@@ -169,17 +169,17 @@ impl ParkingSpot {
                     // This will put the hart into a "wait for interrupt" mode where it will wait until
                     // either the timeout interrupt arrives or it receives an interrupt from another hart.
                     drop(inner);
-                    log::trace!("parking for {timeout:?}...");
+                    // log::trace!("parking for {timeout:?}...");
                     arch::hart_park_timeout(timeout);
-                    log::trace!("unparked!");
+                    // log::trace!("unparked!");
                     inner = self.inner.lock();
                 } else {
                     // Suspend the calling hart for an indefinite amount of time.
                     // It will only wake up if it receives an interrupt from another hart.
                     drop(inner);
-                    log::trace!("parking indefinitely...");
+                    // log::trace!("parking indefinitely...");
                     arch::hart_park();
-                    log::trace!("unparked!");
+                    // log::trace!("unparked!");
                     inner = self.inner.lock();
                 }
 


### PR DESCRIPTION
This PR fixes a "bug" where the initial test task for each HART would be scheduled through the global run queue and therefore distributed randomly among the workers. This is usually what we want (therefore "bug" in quotes) but not in this specific case where we want each hart to run their own task.

The long-term proper solution would be to a add CPU affinity to tasks, but this PR adds a callback after the worker was initialized so we can spawn the task then.
