### PR TITLE
fix: don't share the zero frame for write

### DIFF
--- a/kernel/src/vm/provider.rs
+++ b/kernel/src/vm/provider.rs
@@ -14,7 +14,7 @@ use sync::LazyLock;
 
 pub trait Provider: Debug {
     // TODO make async
-    fn get_frame(&self, at_offset: usize) -> Result<Frame, Error>;
+    fn get_frame(&self, at_offset: usize, will_read: bool) -> Result<Frame, Error>;
     // TODO make async
     fn get_frames(&self, at_offset: usize, len: NonZeroUsize) -> Result<FrameList, Error>;
     fn free_frame(&self, frame: Frame);
@@ -38,8 +38,12 @@ impl TheZeroFrame {
 }
 
 impl Provider for TheZeroFrame {
-    fn get_frame(&self, _at_offset: usize) -> Result<Frame, Error> {
-        Ok(self.0.clone())
+    fn get_frame(&self, _at_offset: usize, will_read: bool) -> Result<Frame, Error> {
+        if will_read {
+            frame_alloc::alloc_one_zeroed().map_err(Into::into)
+        } else {
+            Ok(self.0.clone())
+        }
     }
 
     fn get_frames(&self, _at_offset: usize, len: NonZeroUsize) -> Result<FrameList, Error> {

--- a/kernel/src/vm/vmo.rs
+++ b/kernel/src/vm/vmo.rs
@@ -114,7 +114,8 @@ impl PagedVmo {
             let new_frame = self.frames.insert(at_offset, new_frame.clone());
             Ok(new_frame)
         } else {
-            let new_frame = self.provider.get_frame(at_offset)?;
+            let new_frame = self.provider.get_frame(at_offset, true)?;
+            debug_assert!(new_frame.is_unique());
             let new_frame = self.frames.insert(at_offset, new_frame);
             Ok(new_frame)
         }
@@ -124,7 +125,7 @@ impl PagedVmo {
         let frame = match self.frames.entry(at_offset) {
             Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => {
-                let new_frame = self.provider.get_frame(at_offset)?;
+                let new_frame = self.provider.get_frame(at_offset, false)?;
                 entry.insert(new_frame)
             }
         };


### PR DESCRIPTION
This fixes a stupid bug where THE ZERO FRAME provider would always return the zero frame even for write mappings. This of course isn't great and led to all memory mappings being mapped to the same Frame which obviously meant horrific data corruption.