### PR TITLE
fix: correctly return from `JoinHandle` when task fails

### DIFF
--- a/kernel/src/task/join_handle.rs
+++ b/kernel/src/task/join_handle.rs
@@ -31,6 +31,21 @@ enum JoinHandleState {
     Error(JoinErrorKind),
 }
 
+pub struct JoinError<T> {
+    kind: JoinErrorKind,
+    id: Id,
+    output: Option<T>,
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum JoinErrorKind {
+    Cancelled { completed: bool },
+    Panic(Box<dyn Any + Send + 'static>),
+}
+
+// === impl JoinHandle ===
+
 impl<T> UnwindSafe for JoinHandle<T> {}
 
 impl<T> RefUnwindSafe for JoinHandle<T> {}
@@ -204,18 +219,7 @@ impl<T> JoinHandle<T> {
     }
 }
 
-pub struct JoinError<T> {
-    kind: JoinErrorKind,
-    id: Id,
-    output: Option<T>,
-}
-
-#[derive(Debug)]
-#[non_exhaustive]
-pub enum JoinErrorKind {
-    Cancelled { completed: bool },
-    Panic(Box<dyn Any + Send + 'static>),
-}
+// === impl JoinError ===
 
 impl JoinError<()> {
     pub(super) fn cancelled(completed: bool, id: Id) -> Self {


### PR DESCRIPTION
This PR fixes a bug in the `JoinHandle` Future code that would swallow failures from awaited tasks, such as panics and cancellations and always report `Ok(())`