### PR TITLE
fix: eagerly capture frames in `Backtrace::capture`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ name = "backtrace"
 version = "0.1.0"
 dependencies = [
  "addr2line",
+ "arrayvec",
  "fallible-iterator",
  "gimli",
  "rustc-demangle",

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -92,6 +92,25 @@ static LOADER_CONFIG: LoaderConfig = {
 
 #[unsafe(no_mangle)]
 fn _start(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
+    let res = panic::catch_unwind(|| {
+        backtrace::__rust_begin_short_backtrace(|| kmain(cpuid, boot_info, boot_ticks));
+    });
+
+    // Run thread-local destructors
+    // Safety: after this point thread-locals cannot be accessed anymore anyway
+    unsafe {
+        cpu_local::destructors::run();
+    }
+
+    match res {
+        Ok(_) => arch::exit(0),
+        // If the panic propagates up to this catch here there is nothing we can do, this is a terminal
+        // failure.
+        Err(_) => arch::abort("unrecoverable kernel panic"),
+    }
+}
+
+fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
     CPUID.set(cpuid);
 
     // perform EARLY per-cpu, architecture-specific initialization
@@ -206,14 +225,6 @@ fn _start(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
     // - [all][global] `topology::init()` initialize the system topology
     // - `kernel_shell_init()`
     // - `userboot_init()`
-
-    // Run thread-local destructors
-    // Safety: after this point thread-locals cannot be accessed anymore anyway
-    unsafe {
-        cpu_local::destructors::run();
-    }
-
-    arch::exit(0);
 }
 
 /// Builds a list of memory regions from the boot info that are usable for allocation.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -92,6 +92,9 @@ static LOADER_CONFIG: LoaderConfig = {
 
 #[unsafe(no_mangle)]
 fn _start(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
+    // Unwinding expects at least one landing pad in the callstack, but capturing all unwinds that
+    // bubble up to this point is also a good idea since we can perform some last cleanup and
+    // print an error message.
     let res = panic::catch_unwind(|| {
         backtrace::__rust_begin_short_backtrace(|| kmain(cpuid, boot_info, boot_ticks));
     });

--- a/libs/backtrace/Cargo.toml
+++ b/libs/backtrace/Cargo.toml
@@ -15,3 +15,4 @@ addr2line.workspace = true
 xmas-elf.workspace = true
 rustc-demangle.workspace = true
 fallible-iterator.workspace = true
+arrayvec.workspace = true


### PR DESCRIPTION
This fixes #300 by eagerly capturing all frames when constructing a backtrace. This change also brings back the wrapping of the kernel main function in `catch_unwind` to fix unwinding code