### PR TITLE
refactor: move backtracing logic into `kernel`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,19 +70,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "backtrace"
-version = "0.1.0"
-dependencies = [
- "addr2line",
- "arrayvec",
- "fallible-iterator",
- "gimli",
- "rustc-demangle",
- "unwind2",
- "xmas-elf",
-]
-
-[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,8 +449,8 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "addr2line",
  "arrayvec",
- "backtrace",
  "bitflags",
  "bumpalo",
  "cfg-if",
@@ -487,6 +474,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "riscv",
+ "rustc-demangle",
  "smallvec",
  "static_assertions",
  "sync",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "backtrace"
+version = "0.1.0"
+dependencies = [
+ "addr2line",
+ "arrayvec",
+ "fallible-iterator",
+ "gimli",
+ "rustc-demangle",
+ "unwind2",
+ "xmas-elf",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,6 @@ missing_errors_doc = "deny"
 
 [workspace.dependencies]
 addr2line = { path = "libs/addr2line" }
-backtrace = { path = "libs/backtrace" }
 leb128 = { path = "libs/leb128" }
 linked-list = { path = "libs/linked-list" }
 mpsc-queue = { path = "libs/mpsc-queue" }

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -18,13 +18,14 @@ cpu-local.workspace = true
 sync = { workspace = true, features = ["thread-local", "lock_api"] }
 linked-list.workspace = true
 unwind2.workspace = true
-backtrace.workspace = true
 wavltree = { workspace = true, features = ["dot"] }
 mpsc-queue.workspace = true
 fdt.workspace = true
 ksharded-slab.workspace = true
 ktest.workspace = true
+addr2line.workspace = true
 
+rustc-demangle.workspace = true
 log.workspace = true
 cfg-if.workspace = true
 talc.workspace = true

--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -1,0 +1,192 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+mod symbolize;
+
+use arrayvec::ArrayVec;
+use core::fmt::Formatter;
+use core::{fmt, slice};
+use fallible_iterator::FallibleIterator;
+use loader_api::BootInfo;
+use symbolize::SymbolizeContext;
+use sync::{LazyLock, OnceLock};
+use unwind2::FrameIter;
+
+static ELF_INFO: OnceLock<ElfInfo> = OnceLock::new();
+static SYMBOLIZE_CONTEXT: LazyLock<Option<SymbolizeContext>> = LazyLock::new(|| {
+    tracing::debug!("Setting up symbolize context...");
+    let state = ELF_INFO.get()?;
+
+    let elf = xmas_elf::ElfFile::new(state.elf).unwrap();
+    Some(SymbolizeContext::new(elf, state.kernel_virt_base).unwrap())
+});
+
+struct ElfInfo {
+    kernel_virt_base: u64,
+    elf: &'static [u8],
+}
+
+#[cold]
+pub fn init(boot_info: &BootInfo) {
+    ELF_INFO.get_or_init(|| ElfInfo {
+        kernel_virt_base: boot_info.kernel_virt.start as u64,
+        // Safety: we have to trust the loaders BootInfo here
+        elf: unsafe {
+            let base = boot_info
+                .physical_address_offset
+                .checked_add(boot_info.kernel_phys.start)
+                .unwrap() as *const u8;
+
+            slice::from_raw_parts(
+                base,
+                boot_info
+                    .kernel_phys
+                    .end
+                    .checked_sub(boot_info.kernel_phys.start)
+                    .unwrap(),
+            )
+        },
+    });
+}
+
+#[derive(Clone)]
+pub struct Backtrace<'a, const MAX_FRAMES: usize> {
+    symbolize_ctx: Option<&'a SymbolizeContext<'static>>,
+    pub frames: ArrayVec<usize, MAX_FRAMES>,
+    pub frames_omitted: usize,
+}
+
+impl<'a, const MAX_FRAMES: usize> Backtrace<'a, MAX_FRAMES> {
+    /// Captures a backtrace at the callsite of this function, returning an owned representation.
+    ///
+    /// The returned object is almost entirely self-contained. It can be cloned, or send to other threads.
+    ///
+    /// Note that this step is quite cheap, contrary to the `Backtrace` implementation in the standard
+    /// library this resolves the symbols (the expensive step) lazily, so this struct can be constructed
+    /// in performance sensitive codepaths and only later resolved.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`unwind2::Error`] if walking the stack fails.
+    #[inline]
+    pub fn capture() -> Result<Self, unwind2::Error> {
+        Self::new_inner(FrameIter::new())
+    }
+
+    /// Constructs a backtrace from the provided register context, returning an owned representation.
+    ///
+    /// The returned object is almost entirely self-contained. It can be cloned, or send to other threads.
+    ///
+    /// Note that this step is quite cheap, contrary to the `Backtrace` implementation in the standard
+    /// library this resolves the symbols (the expensive step) lazily, so this struct can be constructed
+    /// in performance sensitive codepaths and only later resolved.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`unwind2::Error`] if walking the stack fails.
+    #[inline]
+    pub fn from_registers(regs: unwind2::Registers, ip: usize) -> Result<Self, unwind2::Error> {
+        let iter = FrameIter::from_registers(regs, ip);
+        Self::new_inner(iter)
+    }
+
+    fn new_inner(mut iter: FrameIter) -> Result<Self, unwind2::Error> {
+        let mut frames = ArrayVec::new();
+        let mut frames_omitted: usize = 0;
+
+        while let Some(frame) = iter.next()? {
+            if frames.try_push(frame.ip()).is_err() {
+                frames_omitted += 1;
+            }
+        }
+
+        Ok(Self {
+            symbolize_ctx: SYMBOLIZE_CONTEXT.as_ref(),
+            frames,
+            frames_omitted,
+        })
+    }
+}
+
+impl<const MAX_FRAMES: usize> fmt::Display for Backtrace<'_, MAX_FRAMES> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "stack backtrace:")?;
+
+        let mut frame_idx: i32 = 0;
+        for ip in &self.frames {
+            // if the symbolication state isn't setup, yet we can't print symbols the addresses will have
+            // to suffice...
+            if let Some(symbolize_ctx) = self.symbolize_ctx {
+                let mut syms = symbolize_ctx.resolve_unsynchronized(*ip as u64).unwrap();
+
+                write!(f, "{frame_idx}: {address:#x}    -", address = ip)?;
+                while let Some(sym) = syms.next().unwrap() {
+                    if let Some(name) = sym.name() {
+                        writeln!(f, "      {name}")?;
+                    } else {
+                        writeln!(f, "      <unknown>")?;
+                    }
+                    if let Some(filename) = sym.filename() {
+                        write!(f, "      at {filename}")?;
+                        if let Some(lineno) = sym.lineno() {
+                            write!(f, ":{lineno}")?;
+                        } else {
+                            write!(f, "??")?;
+                        }
+                        if let Some(colno) = sym.colno() {
+                            writeln!(f, ":{colno}")?;
+                        } else {
+                            writeln!(f, "??")?;
+                        }
+                    }
+                }
+            } else {
+                writeln!(f, "{frame_idx}: {address:#x}", address = ip)?;
+            }
+
+            frame_idx += 1i32;
+        }
+
+        if self.symbolize_ctx.is_none() {
+            let _ = writeln!(f, "note: backtrace subsystem wasn't initialized, no symbols were printed.");
+        }
+
+        Ok(())
+    }
+}
+
+/// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`. Note that
+/// this is only inline(never) when backtraces in std are enabled, otherwise
+/// it's fine to optimize away.
+#[inline(never)]
+pub fn __rust_begin_short_backtrace<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let result = f();
+
+    // prevent this frame from being tail-call optimised away
+    core::hint::black_box(());
+
+    result
+}
+
+/// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`. Note that
+/// this is only inline(never) when backtraces in std are enabled, otherwise
+/// it's fine to optimize away.
+#[inline(never)]
+pub fn __rust_end_short_backtrace<F, T>(f: F) -> T
+where
+    F: FnOnce() -> T,
+{
+    let result = f();
+
+    // prevent this frame from being tail-call optimised away
+    core::hint::black_box(());
+
+    result
+}

--- a/kernel/src/backtrace/symbolize.rs
+++ b/kernel/src/backtrace/symbolize.rs
@@ -192,6 +192,7 @@ impl<'a> SymbolizeContext<'a> {
         })?;
         let addr2line = addr2line::Context::from_dwarf(dwarf)?;
 
+        #[expect(tail_expr_drop_order, reason = "")]
         Ok(Self {
             addr2line,
             elf,
@@ -225,6 +226,7 @@ impl<'a> SymbolizeContext<'a> {
             })
             .unwrap();
 
+        #[expect(tail_expr_drop_order, reason = "")]
         Ok(SymbolsIter {
             addr: probe,
             elf: &self.elf,

--- a/kernel/src/backtrace/symbolize.rs
+++ b/kernel/src/backtrace/symbolize.rs
@@ -1,0 +1,236 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use core::ffi::c_void;
+use core::{fmt, str};
+use fallible_iterator::FallibleIterator;
+use gimli::{EndianSlice, NativeEndian};
+use rustc_demangle::{try_demangle, Demangle};
+use xmas_elf::sections::SectionData;
+use xmas_elf::symbol_table::Entry;
+
+pub enum Symbol<'a> {
+    /// We were able to locate frame information for this symbol, and
+    /// `addr2line`'s frame internally has all the nitty gritty details.
+    Frame {
+        addr: *mut c_void,
+        location: Option<addr2line::Location<'a>>,
+        name: Option<&'a str>,
+    },
+    /// Couldn't find debug information, but we found it in the symbol table of
+    /// the elf executable.
+    Symtab { name: &'a str },
+}
+
+impl Symbol<'_> {
+    pub fn name(&self) -> Option<SymbolName<'_>> {
+        match self {
+            Symbol::Frame { name, .. } => {
+                let name = name.as_ref()?;
+                Some(SymbolName::new(name))
+            }
+            Symbol::Symtab { name, .. } => Some(SymbolName::new(name)),
+        }
+    }
+
+    pub fn addr(&self) -> Option<*mut c_void> {
+        match self {
+            Symbol::Frame { addr, .. } => Some(*addr),
+            Symbol::Symtab { .. } => None,
+        }
+    }
+
+    pub fn filename(&self) -> Option<&str> {
+        match self {
+            Symbol::Frame { location, .. } => {
+                let file = location.as_ref()?.file?;
+                Some(file)
+            }
+            Symbol::Symtab { .. } => None,
+        }
+    }
+
+    pub fn lineno(&self) -> Option<u32> {
+        match self {
+            Symbol::Frame { location, .. } => location.as_ref()?.line,
+            Symbol::Symtab { .. } => None,
+        }
+    }
+
+    pub fn colno(&self) -> Option<u32> {
+        match self {
+            Symbol::Frame { location, .. } => location.as_ref()?.column,
+            Symbol::Symtab { .. } => None,
+        }
+    }
+}
+
+impl fmt::Debug for Symbol<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = f.debug_struct("Symbol");
+        d.field("name", &self.name());
+        d.field("addr", &self.addr());
+        d.field("filename", &self.filename());
+        d.field("lineno", &self.lineno());
+        d.field("colno", &self.colno());
+        d.finish()
+    }
+}
+
+pub struct SymbolName<'a> {
+    raw: &'a str,
+    demangled: Option<Demangle<'a>>,
+}
+
+impl<'a> SymbolName<'a> {
+    pub fn new(raw: &'a str) -> SymbolName<'a> {
+        let demangled = try_demangle(raw).ok();
+
+        Self { raw, demangled }
+    }
+
+    pub fn as_raw_str(&self) -> &'a str {
+        self.demangled
+            .as_ref()
+            .map(|s| s.as_str())
+            .unwrap_or(self.raw)
+    }
+}
+
+impl fmt::Display for SymbolName<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref s) = self.demangled {
+            return s.fmt(f);
+        }
+
+        f.write_str(self.raw)
+    }
+}
+
+impl fmt::Debug for SymbolName<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref s) = self.demangled {
+            return s.fmt(f);
+        }
+
+        f.write_str(self.raw)
+    }
+}
+
+pub struct SymbolsIter<'a, 'ctx> {
+    addr: u64,
+    elf: &'ctx xmas_elf::ElfFile<'a>,
+    symtab: &'ctx [xmas_elf::symbol_table::Entry64],
+    iter: addr2line::FrameIter<'ctx, EndianSlice<'a, NativeEndian>>,
+    anything: bool,
+}
+
+impl<'ctx> SymbolsIter<'_, 'ctx> {
+    fn search_symtab(&self) -> Option<&'ctx str> {
+        self.symtab
+            .iter()
+            .find(|sym| sym.value() == self.addr)
+            .map(|sym| sym.get_name(self.elf).unwrap())
+    }
+}
+
+impl<'ctx> FallibleIterator for SymbolsIter<'_, 'ctx> {
+    type Item = Symbol<'ctx>;
+    type Error = gimli::Error;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        if let Some(frame) = self.iter.next()? {
+            self.anything = true;
+
+            let name = if let Some(func) = frame.function {
+                str::from_utf8(func.name.slice()).ok()
+            } else {
+                self.search_symtab()
+            };
+
+            Ok(Some(Symbol::Frame {
+                addr: self.addr as *mut c_void,
+                location: frame.location,
+                name,
+            }))
+        } else if !self.anything {
+            self.anything = true;
+            // the iterator didn't produce any frames, so let's try the symbol table
+            if let Some(name) = self.search_symtab() {
+                Ok(Some(Symbol::Symtab { name }))
+            } else {
+                Ok(None)
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Context necessary to resolve an address to its symbol name and source location.
+pub struct SymbolizeContext<'a> {
+    addr2line: addr2line::Context<EndianSlice<'a, NativeEndian>>,
+    elf: xmas_elf::ElfFile<'a>,
+    adjust_vma: u64,
+}
+
+impl<'a> SymbolizeContext<'a> {
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF fails.
+    pub fn new(elf: xmas_elf::ElfFile<'a>, adjust_vma: u64) -> gimli::Result<Self> {
+        let dwarf = gimli::Dwarf::load(|section_id| -> gimli::Result<_> {
+            let data = match elf.find_section_by_name(section_id.name()) {
+                Some(section) => section.raw_data(&elf),
+                None => &[],
+            };
+            Ok(EndianSlice::new(data, NativeEndian))
+        })?;
+        let addr2line = addr2line::Context::from_dwarf(dwarf)?;
+
+        Ok(Self {
+            addr2line,
+            elf,
+            adjust_vma,
+        })
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if the given address doesn't correspond to a symbol or parsing the DWARF info
+    /// fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the ELF file doesn't contain a symbol table.
+    pub fn resolve_unsynchronized(&self, probe: u64) -> gimli::Result<SymbolsIter<'a, '_>> {
+        let probe = probe - self.adjust_vma;
+        let iter = self.addr2line.find_frames(probe).skip_all_loads()?;
+
+        let symtab = self
+            .elf
+            .section_iter()
+            .find_map(|section| {
+                section
+                    .get_data(&self.elf)
+                    .ok()
+                    .and_then(|data| match data {
+                        SectionData::SymbolTable64(symtab) => Some(symtab),
+                        _ => None,
+                    })
+            })
+            .unwrap();
+
+        Ok(SymbolsIter {
+            addr: probe,
+            elf: &self.elf,
+            symtab,
+            iter,
+            anything: false,
+        })
+    }
+}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -29,6 +29,7 @@ extern crate alloc;
 
 mod allocator;
 mod arch;
+mod backtrace;
 mod cmdline;
 mod cpu_local;
 mod device_tree;
@@ -46,7 +47,6 @@ mod traps;
 mod util;
 mod vm;
 mod wasm;
-mod backtrace;
 
 use crate::device_tree::device_tree;
 use crate::error::Error;
@@ -62,7 +62,6 @@ use cpu_local::cpu_local;
 use loader_api::{BootInfo, LoaderConfig, MemoryRegionKind};
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use backtrace::Backtrace;
 use sync::Once;
 use vm::frame_alloc;
 use vm::PhysicalAddress;
@@ -149,7 +148,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
 
         // fully initialize the tracing subsystem now that we can allocate
         tracing::init(cmdline.log);
-        
+
         // perform global, architecture-specific initialization
         arch::init_early();
 

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -5,54 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
+use crate::{arch, backtrace};
+use crate::backtrace::Backtrace;
 use crate::panic::panic_count::MustAbort;
 use alloc::boxed::Box;
 use alloc::string::String;
-use backtrace::{Backtrace, SymbolizeContext};
 use core::any::Any;
 use core::panic::{PanicPayload, UnwindSafe};
 use core::{fmt, mem, slice};
 use loader_api::BootInfo;
 use sync::{LazyLock, OnceLock};
-
-static GLOBAL_PANIC_STATE: OnceLock<GlobalPanicState> = OnceLock::new();
-
-struct GlobalPanicState {
-    kernel_virt_base: u64,
-    elf: &'static [u8],
-}
-
-#[cold]
-pub fn init(boot_info: &BootInfo) {
-    GLOBAL_PANIC_STATE.get_or_init(|| GlobalPanicState {
-        kernel_virt_base: boot_info.kernel_virt.start as u64,
-        // Safety: we have to trust the loaders BootInfo here
-        elf: unsafe {
-            let base = boot_info
-                .physical_address_offset
-                .checked_add(boot_info.kernel_phys.start)
-                .unwrap() as *const u8;
-
-            slice::from_raw_parts(
-                base,
-                boot_info
-                    .kernel_phys
-                    .end
-                    .checked_sub(boot_info.kernel_phys.start)
-                    .unwrap(),
-            )
-        },
-    });
-}
-
-static SYMBOLIZE_CONTEXT: LazyLock<Option<SymbolizeContext>> = LazyLock::new(|| {
-    tracing::debug!("Setting up symbolize context...");
-    let state = GLOBAL_PANIC_STATE.get()?;
-
-    let elf = xmas_elf::ElfFile::new(state.elf).unwrap();
-    Some(SymbolizeContext::new(elf, state.kernel_virt_base).unwrap())
-});
 
 /// Determines whether the current thread is unwinding because of panic.
 #[inline]
@@ -69,7 +31,6 @@ pub fn catch_unwind<F, R>(f: F) -> Result<R, Box<dyn Any + Send + 'static>>
 where
     F: FnOnce() -> R + UnwindSafe,
 {
-    #[expect(tail_expr_drop_order, reason = "")]
     unwind2::catch_unwind(f).inspect_err(|_| {
         panic_count::decrease(); // decrease the panic count, since we caught it
     })
@@ -108,24 +69,19 @@ fn begin_panic_handler(info: &core::panic::PanicInfo<'_>) -> ! {
 
         tracing::error!("cpu panicked at {loc}:\n{msg}");
 
-        if let Some(ctx) = SYMBOLIZE_CONTEXT.as_ref() {
-            // FIXME 32 seems adequate for unoptimized builds where the callstack can get quite deep
-            //  but (at least at the moment) is absolute overkill for optimized builds. Sadly there
-            //  is no good way to do conditional compilation based on the opt-level.
-            const MAX_BACKTRACE_FRAMES: usize = 32;
+        // FIXME 32 seems adequate for unoptimized builds where the callstack can get quite deep
+        //  but (at least at the moment) is absolute overkill for optimized builds. Sadly there
+        //  is no good way to do conditional compilation based on the opt-level.
+        const MAX_BACKTRACE_FRAMES: usize = 32;
 
-            let backtrace = Backtrace::<MAX_BACKTRACE_FRAMES>::capture(ctx).unwrap();
-            tracing::error!("{backtrace}");
-            if backtrace.frames_omitted > 0 {
-                let total_frames = backtrace.frames.len() + backtrace.frames_omitted;
-                let omitted_frames = backtrace.frames_omitted;
+        let backtrace = Backtrace::<MAX_BACKTRACE_FRAMES>::capture().unwrap();
+        tracing::error!("{backtrace}");
+        
+        if backtrace.frames_omitted > 0 {
+            let total_frames = backtrace.frames.len() + backtrace.frames_omitted;
+            let omitted_frames = backtrace.frames_omitted;
 
-                tracing::warn!("Stack trace was {total_frames} frames, but backtrace buffer capacity was {MAX_BACKTRACE_FRAMES}. Omitted {omitted_frames} frames. Consider increasing `MAX_BACKTRACE_FRAMES` to at least {total_frames} to capture the entire trace.");
-            }
-        } else {
-            tracing::error!(
-                "Backtrace unavailable. Panic happened before panic subsystem initialization."
-            );
+            tracing::warn!("Stack trace was {total_frames} frames, but backtrace buffer capacity was {MAX_BACKTRACE_FRAMES}. Omitted {omitted_frames} frames. Consider increasing `MAX_BACKTRACE_FRAMES` to at least {total_frames} to capture the entire trace.");
         }
 
         panic_count::finished_panic_hook();
@@ -171,7 +127,7 @@ fn construct_panic_payload(info: &core::panic::PanicInfo) -> Box<dyn Any + Send>
             // Lazily, the first time this gets called, run the actual string formatting.
             self.string.get_or_insert_with(|| {
                 let mut s = String::new();
-                let mut fmt = fmt::Formatter::new(&mut s);
+                let mut fmt = fmt::Formatter::new(&mut s, fmt::FormattingOptions::new());
                 let _err = fmt::Display::fmt(&inner, &mut fmt);
                 s
             })


### PR DESCRIPTION
This moves the `backtrace` crate into the kernel since it wasn't useful outside of it anyway and this streamlines the API.