### PR TITLE
fix: panics in trap handler

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-02-20"
+channel = "nightly-2025-02-21"
 components = ["rustfmt", "clippy", "rust-src", "llvm-tools"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
This allows panicking in the trap handler, which while not desired is a good debugging feature to have