### PR TITLE
fix: user aspace max range

### DIFF
--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -17,8 +17,8 @@ use core::arch::asm;
 use riscv::sstatus::FS;
 use riscv::{interrupt, scounteren, sie, sstatus};
 pub use vm::{
-    AddressSpace, CANONICAL_ADDRESS_MASK, DEFAULT_ASID, KERNEL_ASPACE_BASE, PAGE_SHIFT, PAGE_SIZE,
-    USER_ASPACE_BASE, invalidate_range, is_kernel_address,
+    invalidate_range, is_kernel_address, AddressSpace, CANONICAL_ADDRESS_MASK, DEFAULT_ASID,
+    KERNEL_ASPACE_RANGE, USER_ASPACE_RANGE, PAGE_SHIFT, PAGE_SIZE,
 };
 
 /// Global RISC-V specific initialization.

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -17,8 +17,8 @@ use core::arch::asm;
 use riscv::sstatus::FS;
 use riscv::{interrupt, scounteren, sie, sstatus};
 pub use vm::{
-    invalidate_range, is_kernel_address, AddressSpace, CANONICAL_ADDRESS_MASK, DEFAULT_ASID,
-    KERNEL_ASPACE_RANGE, USER_ASPACE_RANGE, PAGE_SHIFT, PAGE_SIZE,
+    AddressSpace, CANONICAL_ADDRESS_MASK, DEFAULT_ASID, KERNEL_ASPACE_RANGE, PAGE_SHIFT, PAGE_SIZE,
+    USER_ASPACE_RANGE, invalidate_range, is_kernel_address,
 };
 
 /// Global RISC-V specific initialization.

--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -6,16 +6,16 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::arch::{mb, wmb};
-use crate::vm::Error;
 use crate::vm::flush::Flush;
 use crate::vm::frame_alloc::Frame;
-use crate::vm::{PhysicalAddress, VirtualAddress, frame_alloc};
+use crate::vm::Error;
+use crate::vm::{frame_alloc, PhysicalAddress, VirtualAddress};
 use alloc::vec;
 use alloc::vec::Vec;
 use bitflags::bitflags;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
-use core::range::Range;
+use core::range::{Range, RangeInclusive};
 use core::{fmt, slice};
 use riscv::satp;
 use riscv::sbi::rfence::sfence_vma_asid;
@@ -23,21 +23,28 @@ use static_assertions::const_assert_eq;
 
 pub const DEFAULT_ASID: u16 = 0;
 
-/// Virtual address where the kernel address space starts.
-///
-///
-pub const KERNEL_ASPACE_BASE: VirtualAddress = VirtualAddress::new(0xffffffc000000000).unwrap();
-pub const KERNEL_ASPACE_SIZE: usize = 1 << VIRT_ADDR_BITS;
-const_assert_eq!(KERNEL_ASPACE_BASE.get(), CANONICAL_ADDRESS_MASK);
-const_assert_eq!(KERNEL_ASPACE_SIZE - 1, !CANONICAL_ADDRESS_MASK);
+pub const KERNEL_ASPACE_RANGE: RangeInclusive<VirtualAddress> = RangeInclusive {
+    start: VirtualAddress::new(0xffffffc000000000).unwrap(),
+    end: VirtualAddress::MAX,
+};
+const_assert_eq!(KERNEL_ASPACE_RANGE.start.get(), CANONICAL_ADDRESS_MASK);
+const_assert_eq!(
+    KERNEL_ASPACE_RANGE
+        .end
+        .checked_sub_addr(KERNEL_ASPACE_RANGE.start)
+        .unwrap(),
+    !CANONICAL_ADDRESS_MASK
+);
 
 /// Virtual address where the user address space starts.
 ///
 /// The first 2MiB are reserved for catching null pointer dereferences, but this might
 /// change in the future if we decide that the null-checking performed by the WASM runtime
 /// is sufficiently robust.
-pub const USER_ASPACE_BASE: VirtualAddress = VirtualAddress::new(0x0000000000200000).unwrap();
-pub const USER_ASPACE_SIZE: usize = (1 << VIRT_ADDR_BITS) - USER_ASPACE_BASE.get();
+pub const USER_ASPACE_RANGE: RangeInclusive<VirtualAddress> = RangeInclusive {
+    start: VirtualAddress::new(0x0000000000200000).unwrap(),
+    end: VirtualAddress::new((1 << VIRT_ADDR_BITS) - 1).unwrap(),
+};
 
 pub const PAGE_SIZE: usize = 4096;
 pub const PAGE_SHIFT: usize = (PAGE_SIZE - 1).count_ones() as usize;
@@ -90,8 +97,7 @@ pub fn init() {
 
 /// Return whether the given virtual address is in the kernel address space.
 pub const fn is_kernel_address(virt: VirtualAddress) -> bool {
-    virt.get() >= KERNEL_ASPACE_BASE.get()
-        && virt.checked_sub_addr(KERNEL_ASPACE_BASE).unwrap() < KERNEL_ASPACE_SIZE
+    KERNEL_ASPACE_RANGE.start.get() <= virt.get() && virt.get() < KERNEL_ASPACE_RANGE.end.get()
 }
 
 /// Invalidate address translation caches for the given `address_range` in the given `address_space`.
@@ -518,7 +524,8 @@ impl AddressSpace {
 
     fn pgtable_ptr_from_phys(&self, phys: PhysicalAddress) -> NonNull<PageTableEntry> {
         NonNull::new(
-            KERNEL_ASPACE_BASE
+            KERNEL_ASPACE_RANGE
+                .start
                 .checked_add(phys.get())
                 .unwrap()
                 .as_mut_ptr()

--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -6,10 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::arch::{mb, wmb};
+use crate::vm::Error;
 use crate::vm::flush::Flush;
 use crate::vm::frame_alloc::Frame;
-use crate::vm::Error;
-use crate::vm::{frame_alloc, PhysicalAddress, VirtualAddress};
+use crate::vm::{PhysicalAddress, VirtualAddress, frame_alloc};
 use alloc::vec;
 use alloc::vec::Vec;
 use bitflags::bitflags;

--- a/kernel/src/vm/address.rs
+++ b/kernel/src/vm/address.rs
@@ -337,15 +337,21 @@ address_impl!(VirtualAddress);
 impl VirtualAddress {
     #[must_use]
     pub const fn new(n: usize) -> Option<Self> {
-        if (n & arch::CANONICAL_ADDRESS_MASK).wrapping_sub(1) >= arch::CANONICAL_ADDRESS_MASK - 1 {
-            Some(Self(n))
+        let this = Self(n);
+        if this.is_canonical() {
+            Some(this)
         } else {
             None
         }
     }
+
+    pub const fn is_canonical(self) -> bool {
+        (self.0 & arch::CANONICAL_ADDRESS_MASK).wrapping_sub(1) >= arch::CANONICAL_ADDRESS_MASK - 1
+    }
+
     #[must_use]
     pub fn from_phys(phys: PhysicalAddress) -> Option<VirtualAddress> {
-        arch::KERNEL_ASPACE_BASE.checked_add(phys.0)
+        arch::KERNEL_ASPACE_RANGE.start.checked_add(phys.0)
     }
 
     #[inline]

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -116,7 +116,12 @@ impl AddressSpace {
             Error::MisalignedEnd
         );
         ensure!(
-            layout.pad_to_align().size() <= self.max_range.end.checked_sub_addr(self.max_range.start).unwrap_or_default(),
+            layout.pad_to_align().size()
+                <= self
+                    .max_range
+                    .end
+                    .checked_sub_addr(self.max_range.start)
+                    .unwrap_or_default(),
             Error::SizeTooLarge
         );
         ensure!(
@@ -165,7 +170,15 @@ impl AddressSpace {
             range.end.is_aligned_to(arch::PAGE_SIZE),
             Error::MisalignedEnd
         );
-        ensure!(range.size() <= self.max_range.end.checked_sub_addr(self.max_range.start).unwrap_or_default(), Error::SizeTooLarge);
+        ensure!(
+            range.size()
+                <= self
+                    .max_range
+                    .end
+                    .checked_sub_addr(self.max_range.start)
+                    .unwrap_or_default(),
+            Error::SizeTooLarge
+        );
         ensure!(permissions.is_valid(), Error::InvalidPermissions);
         // ensure the entire address space range is free
         if let Some(prev) = self.regions.upper_bound(range.start_bound()).get() {
@@ -290,7 +303,15 @@ impl AddressSpace {
             range.end.is_aligned_to(arch::PAGE_SIZE),
             Error::MisalignedEnd
         );
-        ensure!(range.size() <= self.max_range.end.checked_sub_addr(self.max_range.start).unwrap_or_default(), Error::SizeTooLarge);
+        ensure!(
+            range.size()
+                <= self
+                    .max_range
+                    .end
+                    .checked_sub_addr(self.max_range.start)
+                    .unwrap_or_default(),
+            Error::SizeTooLarge
+        );
 
         // ensure the entire range is mapped and doesn't cover any holes
         // `for_each_region_in_range` covers the last half so we just need to check that the regions
@@ -347,7 +368,12 @@ impl AddressSpace {
             Error::MisalignedEnd
         );
         ensure!(
-            range.size() <= self.max_range.end.checked_sub_addr(self.max_range.start).unwrap_or_default(),
+            range.size()
+                <= self
+                    .max_range
+                    .end
+                    .checked_sub_addr(self.max_range.start)
+                    .unwrap_or_default(),
             Error::AlignmentTooLarge
         );
         ensure!(new_permissions.is_valid(), Error::InvalidPermissions);
@@ -458,7 +484,15 @@ impl AddressSpace {
             range.end.is_aligned_to(arch::PAGE_SIZE),
             Error::MisalignedEnd
         );
-        ensure!(range.size() <= self.max_range.end.checked_sub_addr(self.max_range.start).unwrap_or_default(), Error::SizeTooLarge);
+        ensure!(
+            range.size()
+                <= self
+                    .max_range
+                    .end
+                    .checked_sub_addr(self.max_range.start)
+                    .unwrap_or_default(),
+            Error::SizeTooLarge
+        );
         ensure!(permissions.is_valid(), Error::InvalidPermissions);
 
         // ensure the entire address space range is free
@@ -502,7 +536,15 @@ impl AddressSpace {
             range.end.is_aligned_to(arch::PAGE_SIZE),
             Error::MisalignedEnd
         );
-        ensure!(range.size() <= self.max_range.end.checked_sub_addr(self.max_range.start).unwrap_or_default(), Error::SizeTooLarge);
+        ensure!(
+            range.size()
+                <= self
+                    .max_range
+                    .end
+                    .checked_sub_addr(self.max_range.start)
+                    .unwrap_or_default(),
+            Error::SizeTooLarge
+        );
 
         let mut batch = Batch::new(&mut self.arch);
         let mut bytes_remaining = range.size();
@@ -651,11 +693,20 @@ impl AddressSpace {
 
         // if the tree is empty, treat max_range as the gap
         if self.regions.is_empty() {
-            let aligned_gap = Range { 
-                start: self.max_range.start.checked_align_up(layout.align()).unwrap(), 
-                end: self.max_range.end.checked_sub(1).unwrap().align_down(layout.align())
+            let aligned_gap = Range {
+                start: self
+                    .max_range
+                    .start
+                    .checked_align_up(layout.align())
+                    .unwrap(),
+                end: self
+                    .max_range
+                    .end
+                    .checked_sub(1)
+                    .unwrap()
+                    .align_down(layout.align()),
             };
-            
+
             let spot_count = spots_in_range(layout, aligned_gap);
             candidate_spot_count += spot_count;
             if target_index < spot_count {

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -16,6 +16,7 @@ use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::alloc::Layout;
+use core::fmt;
 use core::num::NonZeroUsize;
 use core::pin::Pin;
 use core::range::{Bound, Range, RangeBounds};
@@ -33,8 +34,9 @@ pub enum AddressSpaceKind {
 }
 
 pub struct AddressSpace {
+    kind: AddressSpaceKind,
     /// A binary search tree of regions that make up this address space.
-    pub(super) regions: wavltree::WAVLTree<AddressSpaceRegion>,
+    regions: wavltree::WAVLTree<AddressSpaceRegion>,
     /// The maximum range this address space can encompass.
     ///
     /// This is used to check new mappings against and speed up page fault handling.
@@ -45,7 +47,26 @@ pub struct AddressSpace {
     /// The hardware address space backing this "logical" address space that changes need to be
     /// materialized into in order to take effect.
     pub arch: arch::AddressSpace,
-    kind: AddressSpaceKind,
+}
+
+impl fmt::Debug for AddressSpace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AddressSpace")
+            .field_with("regions", |f| {
+                let mut f = f.debug_list();
+                for region in self.regions.iter() {
+                    f.entry(&format_args!(
+                        "{:<40?} {}..{} {}",
+                        region.name, region.range.start, region.range.end, region.permissions
+                    ));
+                }
+                f.finish()
+            })
+            .field("max_range", &self.max_range)
+            .field("kind", &self.kind)
+            .field("rng", &self.rng)
+            .finish()
+    }
 }
 
 impl AddressSpace {

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -36,7 +36,7 @@ pub enum AddressSpaceKind {
 pub struct AddressSpace {
     kind: AddressSpaceKind,
     /// A binary search tree of regions that make up this address space.
-    regions: wavltree::WAVLTree<AddressSpaceRegion>,
+    pub(super) regions: wavltree::WAVLTree<AddressSpaceRegion>,
     /// The maximum range this address space can encompass.
     ///
     /// This is used to check new mappings against and speed up page fault handling.
@@ -65,7 +65,7 @@ impl fmt::Debug for AddressSpace {
             .field("max_range", &self.max_range)
             .field("kind", &self.kind)
             .field("rng", &self.rng)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/kernel/src/vm/bootstrap_alloc.rs
+++ b/kernel/src/vm/bootstrap_alloc.rs
@@ -95,7 +95,8 @@ impl<'a> BootstrapAllocator<'a> {
         // Safety: we just allocated the frame
         unsafe {
             ptr::write_bytes::<u8>(
-                arch::KERNEL_ASPACE_RANGE.start
+                arch::KERNEL_ASPACE_RANGE
+                    .start
                     .checked_add(addr.get())
                     .unwrap()
                     .as_mut_ptr(),

--- a/kernel/src/vm/bootstrap_alloc.rs
+++ b/kernel/src/vm/bootstrap_alloc.rs
@@ -95,7 +95,7 @@ impl<'a> BootstrapAllocator<'a> {
         // Safety: we just allocated the frame
         unsafe {
             ptr::write_bytes::<u8>(
-                arch::KERNEL_ASPACE_BASE
+                arch::KERNEL_ASPACE_RANGE.start
                     .checked_add(addr.get())
                     .unwrap()
                     .as_mut_ptr(),

--- a/kernel/src/vm/mod.rs
+++ b/kernel/src/vm/mod.rs
@@ -65,15 +65,7 @@ pub fn init(boot_info: &BootInfo, rand: &mut impl rand::RngCore) -> crate::Resul
         reserve_wired_regions(&mut aspace, boot_info, &mut flush);
         flush.flush().unwrap();
 
-        for region in aspace.regions.iter() {
-            tracing::trace!(
-                "{:<40?} {}..{} {}",
-                region.name,
-                region.range.start,
-                region.range.end,
-                region.permissions
-            );
-        }
+        log::trace!("Kernel AddressSpace {aspace:?}");
 
         Ok(Mutex::new(aspace))
     })?;


### PR DESCRIPTION
This fixes a bug where a user address space could generate invalid non-canonical addresses because the max range was incorrectly configured