### PR TITLE
fix: dont panic in `Scheduler::current_task`

### DIFF
--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -254,7 +254,10 @@ unsafe extern "C" fn default_trap_entry() {
 }
 
 // https://github.com/emb-riscv/specs-markdown/blob/develop/exceptions-and-interrupts.md
-extern "C" fn default_trap_handler(
+// Note: The C-unwind here is important, we want the stable C ABI so we can call this function from
+// assembly, but we also want to be able to unwind past it into the trampoline above (so stack traces
+// are fully accurate)
+extern "C-unwind" fn default_trap_handler(
     frame: &mut TrapFrame,
     _a1: usize,
     _a2: usize,

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -219,9 +219,9 @@ impl Scheduler {
         }
     }
 
-    pub fn current_task(&self) -> Ref<'_, Option<TaskRef>> {
-        let core = self.cores.get().unwrap().borrow();
-        Ref::map(core, |core| &core.current_task)
+    pub fn current_task(&self) -> Option<Ref<'_, TaskRef>> {
+        let core = self.cores.get()?.borrow();
+        Ref::filter_map(core, |core| core.current_task.as_ref()).ok()
     }
 
     pub fn cpu_local_timer(&self) -> &Timer {


### PR DESCRIPTION
Fixes a panic in `Scheduler::current_task` when the function gets called outside of the worker loop.