### PR TITLE
feat: correctly initialize InstanceAllocator

### DIFF
--- a/kernel/src/arch/riscv64/asid_allocator.rs
+++ b/kernel/src/arch/riscv64/asid_allocator.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::fmt;
+use riscv::satp;
+use sync::OnceLock;
+
+// FIXME: A OnceLock to store a u16? yikes
+static MAX_ASID: OnceLock<u16> = OnceLock::new();
+
+pub fn init() {
+    // Determine the number of supported ASID bits. The ASID is a "WARL" (Write Any Values, Reads Legal Values)
+    // so we can write all 1s to and see which ones "stick".
+    // Safety: register access
+    unsafe {
+        let orig = satp::read();
+        satp::set(orig.mode(), 0xFFFF, orig.ppn());
+        let max_asid = satp::read().asid();
+        satp::set(orig.mode(), orig.asid(), orig.ppn());
+
+        tracing::trace!("supported ASID bits: {} {max_asid}", max_asid.count_ones());
+        MAX_ASID.get_or_init(|| max_asid);
+    }
+}
+
+pub struct AsidAllocator {
+    bitmap: Vec<u8>,
+    last: u16,
+}
+
+impl fmt::Debug for AsidAllocator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AsidAllocator")
+            .field("last", &self.last)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AsidAllocator {
+    pub fn new() -> Self {
+        let max_asid = *MAX_ASID.get().unwrap();
+        let bitmap_size = (max_asid as usize + 1) / 8;
+
+        Self {
+            bitmap: vec![0; bitmap_size],
+            last: 2,
+        }
+    }
+
+    pub fn alloc(&mut self) -> Option<u16> {
+        for asid in self.last + 1..u16::MAX {
+            if !self.is_set(asid) {
+                self.set(asid);
+                return Some(asid);
+            }
+        }
+        None
+    }
+
+    pub fn free(&mut self, asid: u16) {
+        debug_assert!(self.is_set(asid));
+        self.unset(asid);
+    }
+
+    fn is_set(&self, index: u16) -> bool {
+        let byte = self.bitmap[index as usize / 8];
+        (byte & 1 << (index % 8)) != 0
+    }
+    fn set(&mut self, index: u16) {
+        self.bitmap[index as usize / 8] |= 1 << (index % 8);
+    }
+    fn unset(&mut self, index: u16) {
+        self.bitmap[index as usize / 8] &= !(1 << (index % 8));
+    }
+}

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+mod asid_allocator;
 pub mod device;
 mod setjmp_longjmp;
 mod trap_handler;
@@ -13,6 +14,7 @@ mod vm;
 
 use crate::device_tree::DeviceTree;
 use crate::vm::VirtualAddress;
+pub use asid_allocator::AsidAllocator;
 use core::arch::asm;
 use riscv::sstatus::FS;
 use riscv::{interrupt, scounteren, sie, sstatus};
@@ -28,6 +30,7 @@ pub fn init_early() {
     tracing::trace!("Supported SBI extensions: {supported:?}");
 
     vm::init();
+    asid_allocator::init();
 }
 
 /// Per-cpu and RISC-V specific initialization.

--- a/kernel/src/arch/riscv64/vm.rs
+++ b/kernel/src/arch/riscv64/vm.rs
@@ -79,19 +79,6 @@ pub fn init() {
         .fill(0);
     }
 
-    // Determine the number of supported ASID bits. The ASID is a "WARL" (Write Any Values, Reads Legal Values)
-    // so we can write all 1s to and see which ones "stick".
-    // Safety: register access
-    unsafe {
-        let orig = satp::read();
-        satp::set(orig.mode(), 0xFFFF, orig.ppn());
-        let max_asid = satp::read().asid();
-        satp::set(orig.mode(), orig.asid(), orig.ppn());
-
-        // TODO use this to initialize an ASID allocator
-        tracing::trace!("supported ASID bits: {}", max_asid.count_ones());
-    }
-
     wmb();
 }
 

--- a/kernel/src/wasm/engine.rs
+++ b/kernel/src/wasm/engine.rs
@@ -1,8 +1,12 @@
+use crate::arch;
 use crate::wasm::compile::Compiler;
 use crate::wasm::cranelift::CraneliftCompiler;
 use crate::wasm::type_registry::TypeRegistry;
 use alloc::sync::Arc;
 use cranelift_codegen::settings::{Configurable, Flags};
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha20Rng;
+use sync::{Mutex, MutexGuard};
 
 /// Global context for the runtime.
 ///
@@ -16,6 +20,8 @@ pub struct Engine(Arc<EngineInner>);
 pub struct EngineInner {
     compiler: CraneliftCompiler,
     type_registry: TypeRegistry,
+    rng: Option<Mutex<ChaCha20Rng>>,
+    asid_alloc: Mutex<arch::AsidAllocator>,
 }
 
 impl Default for Engine {
@@ -32,12 +38,36 @@ impl Default for Engine {
         Self(Arc::new(EngineInner {
             compiler: CraneliftCompiler::new(target_isa),
             type_registry: TypeRegistry::default(),
+            rng: None,
+            asid_alloc: Mutex::new(arch::AsidAllocator::new()),
         }))
     }
 }
 
 impl Engine {
-    pub(crate) fn compiler(&self) -> &dyn Compiler {
+    pub fn new(rng: &mut impl Rng) -> Self {
+        let isa_builder = cranelift_codegen::isa::lookup(target_lexicon::HOST).unwrap();
+        let mut b = cranelift_codegen::settings::builder();
+        b.set("opt_level", "speed_and_size").unwrap();
+        b.set("libcall_call_conv", "isa_default").unwrap();
+        b.set("preserve_frame_pointers", "true").unwrap();
+        b.set("enable_probestack", "true").unwrap();
+        b.set("probestack_strategy", "inline").unwrap();
+        let target_isa = isa_builder.finish(Flags::new(b)).unwrap();
+
+        Self(Arc::new(EngineInner {
+            compiler: CraneliftCompiler::new(target_isa),
+            type_registry: TypeRegistry::default(),
+            rng: Some(Mutex::new(ChaCha20Rng::from_rng(rng))),
+            asid_alloc: Mutex::new(arch::AsidAllocator::new()),
+        }))
+    }
+
+    pub fn same(lhs: &Engine, rhs: &Engine) -> bool {
+        Arc::ptr_eq(&lhs.0, &rhs.0)
+    }
+
+    pub fn compiler(&self) -> &dyn Compiler {
         &self.0.compiler
     }
 
@@ -46,7 +76,11 @@ impl Engine {
         &self.0.type_registry
     }
 
-    pub(crate) fn same(lhs: &Engine, rhs: &Engine) -> bool {
-        Arc::ptr_eq(&lhs.0, &rhs.0)
+    pub fn allocate_asid(&self) -> u16 {
+        let mut alloc = self.0.asid_alloc.lock();
+        alloc.alloc().expect("out of address space identifiers")
+    }
+    pub fn rng(&self) -> Option<MutexGuard<'_, ChaCha20Rng>> {
+        Some(self.0.rng.as_ref()?.lock())
     }
 }

--- a/kernel/src/wasm/store.rs
+++ b/kernel/src/wasm/store.rs
@@ -36,7 +36,7 @@ impl Store {
 
             vmctx2instance: HashMap::new(),
 
-            alloc: PlaceholderAllocatorDontUse::default(),
+            alloc: PlaceholderAllocatorDontUse::new(engine),
         }
     }
 


### PR DESCRIPTION
Instead of the previous default implementation, this correctly initializes the instance allocator from an ASID allocator and root RNG maintained by the engine.