### PR TITLE
refactor: use `UserMmap` throughout wasm code

### DIFF
--- a/kernel/src/vm/user_mmap.rs
+++ b/kernel/src/vm/user_mmap.rs
@@ -12,6 +12,7 @@ use crate::vm::{
     AddressSpace, AddressSpaceKind, AddressSpaceRegion, ArchAddressSpace, Batch, Error,
     Permissions, VirtualAddress,
 };
+use alloc::string::String;
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
 use core::range::Range;
@@ -43,7 +44,12 @@ impl UserMmap {
     }
 
     /// Creates a new read-write (`RW`) memory mapping in the given address space.
-    pub fn new_zeroed(aspace: &mut AddressSpace, len: usize, align: usize) -> Result<Self, Error> {
+    pub fn new_zeroed(
+        aspace: &mut AddressSpace,
+        len: usize,
+        align: usize,
+        name: Option<String>,
+    ) -> Result<Self, Error> {
         debug_assert!(
             matches!(aspace.kind(), AddressSpaceKind::User),
             "cannot create UserMmap in kernel address space"
@@ -58,7 +64,7 @@ impl UserMmap {
         let region = aspace.map(
             layout,
             Permissions::READ | Permissions::WRITE | Permissions::USER,
-            |range, perms, _batch| Ok(AddressSpaceRegion::new_zeroed(range, perms, None)),
+            |range, perms, _batch| Ok(AddressSpaceRegion::new_zeroed(range, perms, name)),
         )?;
 
         tracing::trace!("new_zeroed: {len} {:?}", region.range);

--- a/kernel/src/wasm/runtime/memory.rs
+++ b/kernel/src/wasm/runtime/memory.rs
@@ -24,9 +24,8 @@ pub struct Memory {
 }
 
 impl Memory {
-    #[expect(clippy::unnecessary_wraps, reason = "TODO")]
     pub fn try_new(
-        _aspace: &mut AddressSpace,
+        aspace: &mut AddressSpace,
         desc: &MemoryDesc,
         actual_minimum_bytes: usize,
         actual_maximum_bytes: Option<usize>,
@@ -35,14 +34,16 @@ impl Memory {
         // Ensure that our guard regions are multiples of the host page size.
         let offset_guard_bytes = round_usize_up_to_host_pages(offset_guard_bytes);
 
-        // let bound_bytes = round_usize_up_to_host_pages(MEMORY_MAX);
-        // let allocation_bytes = bound_bytes.min(actual_maximum_bytes.unwrap_or(usize::MAX));
-        // let request_bytes = allocation_bytes + offset_guard_bytes;
+        let bound_bytes = round_usize_up_to_host_pages(MEMORY_MAX);
+        let allocation_bytes = bound_bytes.min(actual_maximum_bytes.unwrap_or(usize::MAX));
+        let request_bytes = allocation_bytes + offset_guard_bytes;
 
-        // let mmap = UserMmap::new_zeroed(aspace, request_bytes, 2 * 1048576).map_err(|_| Error::MmapFailed)?;
+        // TODO the align arg should be a named const not a weird number like this
+        let mmap = UserMmap::new_zeroed(aspace, request_bytes, 2 * 1048576, None)
+            .map_err(|_| Error::MmapFailed)?;
 
         Ok(Self {
-            mmap: UserMmap::new_empty(),
+            mmap,
             len: actual_minimum_bytes,
             maximum: actual_maximum_bytes,
             page_size_log2: desc.page_size_log2,

--- a/kernel/src/wasm/runtime/mmap_vec.rs
+++ b/kernel/src/wasm/runtime/mmap_vec.rs
@@ -25,8 +25,13 @@ impl<T> MmapVec<T> {
 
     pub fn new_zeroed(aspace: &mut AddressSpace, capacity: usize) -> crate::wasm::Result<Self> {
         Ok(Self {
-            mmap: UserMmap::new_zeroed(aspace, capacity, max(align_of::<T>(), arch::PAGE_SIZE))
-                .map_err(|_| Error::MmapFailed)?,
+            mmap: UserMmap::new_zeroed(
+                aspace,
+                capacity,
+                max(align_of::<T>(), arch::PAGE_SIZE),
+                None,
+            )
+            .map_err(|_| Error::MmapFailed)?,
             len: 0,
             _m: PhantomData,
         })

--- a/kernel/src/wasm/runtime/owned_vmcontext.rs
+++ b/kernel/src/wasm/runtime/owned_vmcontext.rs
@@ -1,14 +1,10 @@
 use crate::arch;
-use crate::vm::{AddressRangeExt, AddressSpace, AddressSpaceRegion, Permissions, VirtualAddress};
+use crate::vm::{AddressRangeExt, AddressSpace, UserMmap};
 use crate::wasm::runtime::{VMContext, VMOffsets};
 use alloc::string::ToString;
-use core::alloc::Layout;
-use core::range::Range;
 
 #[derive(Debug)]
-pub struct OwnedVMContext {
-    range: Range<VirtualAddress>,
-}
+pub struct OwnedVMContext(UserMmap);
 
 impl OwnedVMContext {
     #[expect(clippy::unnecessary_wraps, reason = "TODO")]
@@ -16,31 +12,21 @@ impl OwnedVMContext {
         aspace: &mut AddressSpace,
         offsets: &VMOffsets,
     ) -> crate::wasm::Result<OwnedVMContext> {
-        let layout = Layout::from_size_align(offsets.size() as usize, arch::PAGE_SIZE).unwrap();
+        let mmap = UserMmap::new_zeroed(
+            aspace,
+            offsets.size() as usize,
+            arch::PAGE_SIZE,
+            Some("VMContext".to_string()),
+        )
+        .unwrap();
 
-        let virt_range = aspace
-            .map(
-                layout,
-                Permissions::READ | Permissions::WRITE,
-                |range, flags, batch| {
-                    let region =
-                        AddressSpaceRegion::new_zeroed(range, flags, Some("VMContext".to_string()));
-
-                    region.commit(batch, range, true)?;
-
-                    Ok(region)
-                },
-            )
-            .unwrap()
-            .range;
-
-        Ok(Self { range: virt_range })
+        Ok(Self(mmap))
     }
     pub fn as_ptr(&self) -> *const VMContext {
-        self.range.start.as_ptr().cast()
+        self.0.as_ptr().cast()
     }
     pub fn as_mut_ptr(&mut self) -> *mut VMContext {
-        self.range.start.as_mut_ptr().cast()
+        self.0.as_mut_ptr().cast()
     }
     pub unsafe fn plus_offset<T>(&self, offset: u32) -> *const T {
         // Safety: caller has to ensure offset is valid


### PR DESCRIPTION
This PR makes the WASM `Memory` and `OwnedVMContext` actually use the `UserMmap`