### PR TITLE
chore: always leave `SUM` bit enabled

### DIFF
--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -140,28 +140,6 @@ pub fn rmb() {
     }
 }
 
-#[inline]
-pub unsafe fn with_user_memory_access<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    // Allow supervisor access to user memory
-    // Safety: register access
-    unsafe {
-        sstatus::set_sum();
-    }
-
-    let r = f();
-
-    // Disable supervisor access to user memory
-    // Safety: register access
-    unsafe {
-        sstatus::clear_sum();
-    }
-
-    r
-}
-
 /// Suspend the calling cpu indefinitely.
 ///
 /// # Safety

--- a/kernel/src/vm/user_mmap.rs
+++ b/kernel/src/vm/user_mmap.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::arch;
-use crate::arch::with_user_memory_access;
 use crate::vm::address::AddressRangeExt;
 use crate::vm::{
     AddressSpace, AddressSpaceKind, AddressSpaceRegion, ArchAddressSpace, Batch, Error,
@@ -105,11 +104,9 @@ impl UserMmap {
 
         // Safety: checked by caller
         unsafe {
-            with_user_memory_access(|| {
-                let slice = slice::from_raw_parts(self.range.start.as_ptr(), self.range().size());
+            let slice = slice::from_raw_parts(self.range.start.as_ptr(), self.range().size());
 
-                f(&slice[range]);
-            });
+            f(&slice[range]);
         }
 
         Ok(())
@@ -132,11 +129,9 @@ impl UserMmap {
 
         // Safety: checked by caller
         unsafe {
-            with_user_memory_access(|| {
-                let slice =
-                    slice::from_raw_parts_mut(self.range.start.as_mut_ptr(), self.range().size());
-                f(&mut slice[range]);
-            });
+            let slice =
+                slice::from_raw_parts_mut(self.range.start.as_mut_ptr(), self.range().size());
+            f(&mut slice[range]);
         }
 
         Ok(())

--- a/kernel/src/wasm/func.rs
+++ b/kernel/src/wasm/func.rs
@@ -5,7 +5,7 @@ use crate::wasm::store::Stored;
 use crate::wasm::translate::WasmFuncType;
 use crate::wasm::type_registry::RegisteredType;
 use crate::wasm::values::Val;
-use crate::wasm::{MAX_WASM_STACK, Store, runtime};
+use crate::wasm::{runtime, Store, MAX_WASM_STACK};
 use core::arch::asm;
 use core::ffi::c_void;
 use core::mem;
@@ -65,9 +65,7 @@ impl Func {
         // do the actual call
         // Safety: caller has to ensure safety
         unsafe {
-            arch::with_user_memory_access(|| {
-                self.call_unchecked_raw(store, values_vec.as_mut_ptr(), values_vec_size)
-            })?;
+            self.call_unchecked_raw(store, values_vec.as_mut_ptr(), values_vec_size)?;
         }
 
         // copy the results out of the storage

--- a/kernel/src/wasm/func.rs
+++ b/kernel/src/wasm/func.rs
@@ -5,7 +5,7 @@ use crate::wasm::store::Stored;
 use crate::wasm::translate::WasmFuncType;
 use crate::wasm::type_registry::RegisteredType;
 use crate::wasm::values::Val;
-use crate::wasm::{runtime, Store, MAX_WASM_STACK};
+use crate::wasm::{MAX_WASM_STACK, Store, runtime};
 use core::arch::asm;
 use core::ffi::c_void;
 use core::mem;

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -17,9 +17,9 @@ use crate::wasm::runtime::vmcontext::{
 };
 use crate::wasm::runtime::{
     ConstExprEvaluator, Export, ExportedFunction, ExportedGlobal, ExportedMemory, ExportedTable,
-    Imports, InstanceAllocator, OwnedVMContext, VMContext, VMFuncRef, VMFunctionImport,
-    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOffsets, VMOpaqueContext,
-    VMTableDefinition, VMTableImport, VMCONTEXT_MAGIC,
+    Imports, InstanceAllocator, OwnedVMContext, VMCONTEXT_MAGIC, VMContext, VMFuncRef,
+    VMFunctionImport, VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOffsets,
+    VMOpaqueContext, VMTableDefinition, VMTableImport,
 };
 use crate::wasm::translate::{TableInitialValue, TableSegmentElements};
 use crate::wasm::{Extern, Module, Store};

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -17,9 +17,9 @@ use crate::wasm::runtime::vmcontext::{
 };
 use crate::wasm::runtime::{
     ConstExprEvaluator, Export, ExportedFunction, ExportedGlobal, ExportedMemory, ExportedTable,
-    Imports, InstanceAllocator, OwnedVMContext, VMCONTEXT_MAGIC, VMContext, VMFuncRef,
-    VMFunctionImport, VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOffsets,
-    VMOpaqueContext, VMTableDefinition, VMTableImport,
+    Imports, InstanceAllocator, OwnedVMContext, VMContext, VMFuncRef, VMFunctionImport,
+    VMGlobalImport, VMMemoryDefinition, VMMemoryImport, VMOffsets, VMOpaqueContext,
+    VMTableDefinition, VMTableImport, VMCONTEXT_MAGIC,
 };
 use crate::wasm::translate::{TableInitialValue, TableSegmentElements};
 use crate::wasm::{Extern, Module, Store};
@@ -55,22 +55,18 @@ impl Instance {
 
         tracing::trace!("initializing instance");
         unsafe {
-            arch::with_user_memory_access(|| -> crate::wasm::Result<()> {
-                initialize_vmctx(
-                    const_eval,
-                    &mut vmctx,
-                    &mut tables,
-                    &mut memories,
-                    &module,
-                    imports,
-                )?;
-                initialize_tables(const_eval, &mut tables, &module)?;
+            initialize_vmctx(
+                const_eval,
+                &mut vmctx,
+                &mut tables,
+                &mut memories,
+                &module,
+                imports,
+            )?;
+            initialize_tables(const_eval, &mut tables, &module)?;
 
-                let mut aspace = store.alloc.0.lock();
-                initialize_memories(&mut aspace, const_eval, &mut memories, &module)?;
-
-                Ok(())
-            })?;
+            let mut aspace = store.alloc.0.lock();
+            initialize_memories(&mut aspace, const_eval, &mut memories, &module)?;
         }
         tracing::trace!("done initializing instance");
 

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -211,6 +211,8 @@ pub unsafe fn handoff_to_kernel(hartid: usize, boot_ticks: u64, init: &GlobalIni
 
     // Safety: inline assembly
     unsafe {
+        riscv::sstatus::set_sum();
+
         asm! {
             "mv  sp, {stack_top}", // Set the kernel stack ptr
             "mv  tp, {tls_start}", // Set the kernel thread ptr


### PR DESCRIPTION
This change makes it so the RISCV `SUM` (Supervisor User Memory access) bit is set at startup and never unset. This will allow the more complex interwoven memory usage of WASM engines (i.e. allowing access to the shared stack memory and VMContext object)