### PR TITLE
refactor: turn frame allocation functions into `FrameAllocator` methods

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -153,10 +153,10 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         // initialize the global frame allocator
         // at this point we have parsed and processed the flattened device tree, so we pass it to the
         // frame allocator for reuse
-        frame_alloc::init(boot_alloc, fdt_region_phys);
+        let frame_alloc = frame_alloc::init(boot_alloc, fdt_region_phys);
 
         // initialize the virtual memory subsystem
-        vm::init(boot_info, &mut rng).unwrap();
+        vm::init(boot_info, &mut rng, frame_alloc).unwrap();
     });
 
     // perform LATE per-cpu, architecture-specific initialization
@@ -298,3 +298,12 @@ fn locate_device_tree(boot_info: &BootInfo) -> (&'static [u8], Range<PhysicalAdd
         Range::from(PhysicalAddress::new(fdt.range.start)..PhysicalAddress::new(fdt.range.end)),
     )
 }
+
+// struct System {
+//     rng: Mutex<ChaCha20Rng>,
+//     devtree: device_tree::DeviceTree,
+//     cmdline: cmdline::Cmdline,
+//     backtrace: (),
+//     frame_alloc: (),
+//
+// }

--- a/kernel/src/vm/address_space_region.rs
+++ b/kernel/src/vm/address_space_region.rs
@@ -7,6 +7,7 @@
 
 use crate::arch;
 use crate::vm::address::VirtualAddress;
+use crate::vm::frame_alloc::FrameAllocator;
 use crate::vm::{AddressRangeExt, Batch, Error, PageFaultFlags, Permissions, PhysicalAddress, Vmo};
 use alloc::boxed::Box;
 use alloc::string::String;
@@ -43,6 +44,7 @@ pub struct AddressSpaceRegion {
 
 impl AddressSpaceRegion {
     pub fn new_zeroed(
+        frame_alloc: &'static FrameAllocator,
         range: Range<VirtualAddress>,
         permissions: Permissions,
         name: Option<String>,
@@ -51,7 +53,7 @@ impl AddressSpaceRegion {
             range,
             permissions,
             name,
-            vmo: Arc::new(Vmo::new_zeroed()),
+            vmo: Arc::new(Vmo::new_zeroed(frame_alloc)),
             vmo_offset: 0,
             max_gap: 0,
             max_range: range,

--- a/kernel/src/vm/frame_alloc/mod.rs
+++ b/kernel/src/vm/frame_alloc/mod.rs
@@ -7,32 +7,69 @@
 
 mod arena;
 mod frame;
-mod frame_list;
+pub mod frame_list;
 
 use crate::arch;
 use crate::cpu_local::CpuLocal;
-use crate::vm::PhysicalAddress;
-use crate::vm::address::VirtualAddress;
 use crate::vm::bootstrap_alloc::BootstrapAllocator;
+use crate::vm::{PhysicalAddress, VirtualAddress};
 use alloc::vec::Vec;
-use arena::{Arena, select_arenas};
+use arena::Arena;
+use arena::select_arenas;
 use core::alloc::Layout;
 use core::cell::RefCell;
-use core::fmt::Formatter;
 use core::ptr::NonNull;
 use core::range::Range;
 use core::sync::atomic::AtomicUsize;
 use core::{cmp, fmt, iter, slice};
 use fallible_iterator::FallibleIterator;
-pub use frame::{Frame, FrameInfo};
-pub use frame_list::{Entry, FrameList};
 use sync::{Mutex, OnceLock};
 
-static FRAME_ALLOC: OnceLock<FrameAllocator> = OnceLock::new();
+use crate::vm::frame_alloc::frame_list::FrameList;
+pub use frame::{Frame, FrameInfo};
 
-#[cold]
-pub fn init(boot_alloc: BootstrapAllocator, fdt_region: Range<PhysicalAddress>) {
-    FRAME_ALLOC.get_or_init(|| {
+pub static FRAME_ALLOC: OnceLock<FrameAllocator> = OnceLock::new();
+pub fn init(
+    boot_alloc: BootstrapAllocator,
+    fdt_region: Range<PhysicalAddress>,
+) -> &'static FrameAllocator {
+    FRAME_ALLOC.get_or_init(|| FrameAllocator::new(boot_alloc, fdt_region))
+}
+
+#[derive(Debug)]
+pub struct FrameAllocator {
+    /// Global list of arenas that can be allocated from.
+    global: Mutex<GlobalFrameAllocator>,
+    max_alignment: usize,
+    /// Per-cpu cache of frames to speed up allocation.
+    cpu_local_cache: CpuLocal<RefCell<CpuLocalFrameCache>>,
+    /// Number of frames - across all cpus - that are in cpu-local caches.
+    /// This value must only ever be treated as a hint and should only be used to
+    /// produce more accurate frame usage statistics.
+    frames_in_caches_hint: AtomicUsize,
+}
+
+#[derive(Debug)]
+struct GlobalFrameAllocator {
+    arenas: Vec<Arena>,
+}
+
+#[derive(Debug, Default)]
+struct CpuLocalFrameCache {
+    free_list: linked_list::List<FrameInfo>,
+}
+
+/// Allocation failure that may be due to resource exhaustion or invalid combination of arguments
+/// such as a too-large alignment. Importantly this error is *not-permanent*, a caller choosing to
+/// retry allocation at a later point in time or with different arguments and might receive a successful
+/// result.
+#[derive(Debug)]
+pub struct AllocError;
+
+// === impl FrameAllocator ===
+
+impl FrameAllocator {
+    pub fn new(boot_alloc: BootstrapAllocator, fdt_region: Range<PhysicalAddress>) -> Self {
         let mut max_alignment = arch::PAGE_SIZE;
         let mut arenas = Vec::new();
 
@@ -52,147 +89,104 @@ pub fn init(boot_alloc: BootstrapAllocator, fdt_region: Range<PhysicalAddress>) 
         }
 
         FrameAllocator {
-            global: Mutex::new(GlobalFrameAllocator {
-                arenas,
-                max_alignment,
-            }),
+            global: Mutex::new(GlobalFrameAllocator { arenas }),
+            max_alignment,
             frames_in_caches_hint: AtomicUsize::new(0),
             cpu_local_cache: CpuLocal::new(),
         }
-    });
-}
-
-pub struct FrameAllocator {
-    /// Global list of arenas that can be allocated from.
-    global: Mutex<GlobalFrameAllocator>,
-    /// Per-cpu cache of frames to speed up allocation.
-    cpu_local_cache: CpuLocal<RefCell<CpuLocalFrameCache>>,
-    /// Number of frames - across all cpus - that are in cpu-local caches.
-    /// This value must only ever be treated as a hint and should only be used to
-    /// produce more accurate frame usage statistics.
-    frames_in_caches_hint: AtomicUsize,
-}
-
-/// Allocation failure that may be due to resource exhaustion or invalid combination of arguments
-/// such as a too-large alignment. Importantly this error is *not-permanent*, a caller choosing to
-/// retry allocation at a later point in time or with different arguments and might receive a successful
-/// result.
-#[derive(Debug)]
-pub struct AllocError;
-
-impl fmt::Display for AllocError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        f.write_str("AllocError")
-    }
-}
-
-impl core::error::Error for AllocError {}
-
-/// Allocate a single [`Frame`].
-pub fn alloc_one() -> Result<Frame, AllocError> {
-    let alloc = FRAME_ALLOC
-        .get()
-        .expect("cannot access FRAME_ALLOC before it is initialized");
-
-    let mut cpu_local_cache = alloc.cpu_local_cache.get_or_default().borrow_mut();
-    let frame = cpu_local_cache
-        .allocate_one()
-        .or_else(|| {
-            let mut global_alloc = alloc.global.lock();
-
-            global_alloc.allocate_one()
-        })
-        .ok_or(AllocError)?;
-
-    // Safety: we just allocated the frame
-    let frame = unsafe { Frame::from_free_info(frame) };
-
-    #[cfg(debug_assertions)]
-    frame.assert_valid();
-    Ok(frame)
-}
-
-/// Allocate a single [`Frame`] and ensure the backing physical memory is zero initialized.
-pub fn alloc_one_zeroed() -> Result<Frame, AllocError> {
-    let frame = alloc_one()?;
-
-    // Translate the physical address into a virtual one through the physmap
-    let virt = VirtualAddress::from_phys(frame.addr()).unwrap();
-
-    // memset'ing the slice to zero
-    // Safety: the slice has just been allocated
-    unsafe {
-        slice::from_raw_parts_mut(virt.as_mut_ptr(), arch::PAGE_SIZE).fill(0);
     }
 
-    Ok(frame)
-}
+    /// Allocate a single [`Frame`].
+    pub fn alloc_one(&self) -> Result<Frame, AllocError> {
+        let mut cpu_local_cache = self.cpu_local_cache.get_or_default().borrow_mut();
+        let frame = cpu_local_cache
+            .allocate_one()
+            .or_else(|| {
+                let mut global_alloc = self.global.lock();
 
-/// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`.
-pub fn alloc_contiguous(layout: Layout) -> Result<FrameList, AllocError> {
-    let alloc = FRAME_ALLOC
-        .get()
-        .expect("cannot access FRAME_ALLOC before it is initialized");
+                global_alloc.allocate_one()
+            })
+            .ok_or(AllocError)?;
 
-    // try to allocate from the per-cpu cache first
-    let mut cpu_local_cache = alloc.cpu_local_cache.get_or_default().borrow_mut();
-    let frames = cpu_local_cache
-        .allocate_contiguous(layout)
-        .or_else(|| {
-            let mut global_alloc = alloc.global.lock();
-
-            tracing::trace!(
-                "CPU-local cache exhausted, refilling {} frames...",
-                layout.size() / arch::PAGE_SIZE
-            );
-            let mut frames = global_alloc.allocate_contiguous(layout)?;
-            cpu_local_cache.free_list.append(&mut frames);
-
-            tracing::trace!("retrying allocation...");
-            // If this fails then we failed to pull enough frames from the global allocator
-            // which means we're fully out of frames
-            cpu_local_cache.allocate_contiguous(layout)
-        })
-        .ok_or(AllocError)?;
-
-    let frames = FrameList::from_iter(frames.into_iter().map(|info| {
         // Safety: we just allocated the frame
-        unsafe { Frame::from_free_info(info) }
-    }));
-    #[cfg(debug_assertions)]
-    frames.assert_valid();
-    Ok(frames)
-}
+        let frame = unsafe { Frame::from_free_info(frame) };
 
-/// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`
-/// and ensuring the backing physical memory is zero initialized.
-pub fn alloc_contiguous_zeroed(layout: Layout) -> Result<FrameList, AllocError> {
-    let frames = alloc_contiguous(layout)?;
-
-    // Translate the physical address into a virtual one through the physmap
-    let virt = VirtualAddress::from_phys(frames.first().unwrap().addr()).unwrap();
-
-    // memset'ing the slice to zero
-    // Safety: the slice has just been allocated
-    unsafe {
-        slice::from_raw_parts_mut(virt.as_mut_ptr(), frames.size()).fill(0);
+        #[cfg(debug_assertions)]
+        frame.assert_valid();
+        Ok(frame)
     }
 
-    Ok(frames)
+    /// Allocate a single [`Frame`] and ensure the backing physical memory is zero initialized.
+    pub fn alloc_one_zeroed(&self) -> Result<Frame, AllocError> {
+        let frame = self.alloc_one()?;
+
+        // Translate the physical address into a virtual one through the physmap
+        let virt = VirtualAddress::from_phys(frame.addr()).unwrap();
+
+        // memset'ing the slice to zero
+        // Safety: the slice has just been allocated
+        unsafe {
+            slice::from_raw_parts_mut(virt.as_mut_ptr(), arch::PAGE_SIZE).fill(0);
+        }
+
+        Ok(frame)
+    }
+
+    /// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`.
+    pub fn alloc_contiguous(&self, layout: Layout) -> Result<FrameList, AllocError> {
+        // try to allocate from the per-cpu cache first
+        let mut cpu_local_cache = self.cpu_local_cache.get_or_default().borrow_mut();
+        let frames = cpu_local_cache
+            .allocate_contiguous(layout)
+            .or_else(|| {
+                let mut global_alloc = self.global.lock();
+
+                tracing::trace!(
+                    "CPU-local cache exhausted, refilling {} frames...",
+                    layout.size() / arch::PAGE_SIZE
+                );
+                let mut frames = global_alloc.allocate_contiguous(layout)?;
+                cpu_local_cache.free_list.append(&mut frames);
+
+                tracing::trace!("retrying allocation...");
+                // If this fails then we failed to pull enough frames from the global allocator
+                // which means we're fully out of frames
+                cpu_local_cache.allocate_contiguous(layout)
+            })
+            .ok_or(AllocError)?;
+
+        let frames = FrameList::from_iter(frames.into_iter().map(|info| {
+            // Safety: we just allocated the frame
+            unsafe { Frame::from_free_info(info) }
+        }));
+        #[cfg(debug_assertions)]
+        frames.assert_valid();
+        Ok(frames)
+    }
+
+    /// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`
+    /// and ensuring the backing physical memory is zero initialized.
+    pub fn alloc_contiguous_zeroed(&self, layout: Layout) -> Result<FrameList, AllocError> {
+        let frames = self.alloc_contiguous(layout)?;
+
+        // Translate the physical address into a virtual one through the physmap
+        let virt = VirtualAddress::from_phys(frames.first().unwrap().addr()).unwrap();
+
+        // memset'ing the slice to zero
+        // Safety: the slice has just been allocated
+        unsafe {
+            slice::from_raw_parts_mut(virt.as_mut_ptr(), frames.size()).fill(0);
+        }
+
+        Ok(frames)
+    }
+
+    pub fn max_alignment(&self) -> usize {
+        self.max_alignment
+    }
 }
 
-pub fn max_alignment() -> usize {
-    let alloc = FRAME_ALLOC
-        .get()
-        .expect("cannot access FRAME_ALLOC before it is initialized");
-
-    alloc.global.lock().max_alignment
-}
-
-struct GlobalFrameAllocator {
-    arenas: Vec<Arena>,
-    max_alignment: usize,
-}
+// === impl GlobalFrameAllocator ===
 
 impl GlobalFrameAllocator {
     fn allocate_one(&mut self) -> Option<NonNull<FrameInfo>> {
@@ -216,10 +210,7 @@ impl GlobalFrameAllocator {
     }
 }
 
-#[derive(Default)]
-struct CpuLocalFrameCache {
-    free_list: linked_list::List<FrameInfo>,
-}
+// === impl CpuLocalFrameCache ===
 
 impl CpuLocalFrameCache {
     fn allocate_one(&mut self) -> Option<NonNull<FrameInfo>> {
@@ -278,3 +269,13 @@ impl CpuLocalFrameCache {
         Some(split)
     }
 }
+
+// === impl AllocError ===
+
+impl fmt::Display for AllocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("AllocError")
+    }
+}
+
+impl core::error::Error for AllocError {}

--- a/kernel/src/vm/user_mmap.rs
+++ b/kernel/src/vm/user_mmap.rs
@@ -64,7 +64,14 @@ impl UserMmap {
         let region = aspace.map(
             layout,
             Permissions::READ | Permissions::WRITE | Permissions::USER,
-            |range, perms, _batch| Ok(AddressSpaceRegion::new_zeroed(range, perms, name)),
+            |range, perms, batch| {
+                Ok(AddressSpaceRegion::new_zeroed(
+                    batch.frame_alloc,
+                    range,
+                    perms,
+                    name,
+                ))
+            },
         )?;
 
         tracing::trace!("new_zeroed: {len} {:?}", region.range);
@@ -233,7 +240,7 @@ impl UserMmap {
                 end: self.range.end.checked_add(range.start).unwrap(),
             };
 
-            let mut batch = Batch::new(&mut aspace.arch);
+            let mut batch = Batch::new(&mut aspace.arch, aspace.frame_alloc);
             cursor
                 .get_mut()
                 .unwrap()

--- a/kernel/src/wasm/instance_allocator.rs
+++ b/kernel/src/wasm/instance_allocator.rs
@@ -1,4 +1,5 @@
 use crate::vm::AddressSpace;
+use crate::vm::frame_alloc::FrameAllocator;
 use crate::wasm::Engine;
 use crate::wasm::indices::{DefinedMemoryIndex, DefinedTableIndex};
 use crate::wasm::runtime::{InstanceAllocator, Memory, Table};
@@ -14,10 +15,11 @@ use sync::Mutex;
 pub struct PlaceholderAllocatorDontUse(pub(super) Arc<Mutex<AddressSpace>>);
 
 impl PlaceholderAllocatorDontUse {
-    pub fn new(engine: &Engine) -> Self {
+    pub fn new(engine: &Engine, frame_alloc: &'static FrameAllocator) -> Self {
         let aspace = AddressSpace::new_user(
             engine.allocate_asid(),
             engine.rng().map(|mut rng| ChaCha20Rng::from_rng(&mut rng)),
+            frame_alloc,
         )
         .unwrap();
 

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -32,6 +32,7 @@ mod values;
 pub use errors::Error;
 use wasmparser::Validator;
 pub(crate) type Result<T> = core::result::Result<T, Error>;
+use crate::vm::frame_alloc::FRAME_ALLOC;
 use crate::vm::{AddressSpace, ArchAddressSpace, KERNEL_ASPACE, VirtualAddress};
 use crate::wasm::instance_allocator::PlaceholderAllocatorDontUse;
 use crate::{arch, enum_accessors, owned_enum_accessors};
@@ -126,7 +127,7 @@ pub fn test() {
     let engine = Engine::default();
     let mut validator = Validator::new();
     let mut linker = Linker::new(&engine);
-    let mut store = Store::new(&engine);
+    let mut store = Store::new(&engine, FRAME_ALLOC.get().unwrap());
     let mut const_eval = ConstExprEvaluator::default();
     // let mut aspace = AddressSpace::new_user(2, None).unwrap();
 

--- a/kernel/src/wasm/store.rs
+++ b/kernel/src/wasm/store.rs
@@ -1,3 +1,4 @@
+use crate::vm::frame_alloc::FrameAllocator;
 use crate::wasm::instance_allocator::PlaceholderAllocatorDontUse;
 use crate::wasm::runtime::{VMContext, VMOpaqueContext, VMVal};
 use crate::wasm::{Engine, runtime};
@@ -24,7 +25,7 @@ pub struct Store {
 
 impl Store {
     /// Constructs a new store with the given engine.
-    pub fn new(engine: &Engine) -> Self {
+    pub fn new(engine: &Engine, frame_alloc: &'static FrameAllocator) -> Self {
         Self {
             engine: engine.clone(),
             instances: Vec::new(),
@@ -36,7 +37,7 @@ impl Store {
 
             vmctx2instance: HashMap::new(),
 
-            alloc: PlaceholderAllocatorDontUse::new(engine),
+            alloc: PlaceholderAllocatorDontUse::new(engine, frame_alloc),
         }
     }
 


### PR DESCRIPTION
In preparation for state unification, this PR turns all previously freestanding frame allocation functions `frame_alloc::*` into methods of the `FrameAllocator` struct.