### PR TITLE
chore: instrument vmctx init functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,18 @@ version = "0.2.0"
 source = "git+https://github.com/tokio-rs/tracing?branch=master#b4868674ba73f3963b125ec38b57efaadc714d90"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core 0.2.0",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.2.0"
+source = "git+https://github.com/tokio-rs/tracing?branch=master#b4868674ba73f3963b125ec38b57efaadc714d90"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ fallible-iterator = { version = "0.3.0", default-features = false }
 bumpalo = "3.17.0"
 ouroboros = "0.18.5"
 mycelium-bitfield = "0.1.5"
-tracing = { version = "0.2", git = "https://github.com/tokio-rs/tracing", branch = "master", default-features = false }
+tracing = { version = "0.2", git = "https://github.com/tokio-rs/tracing", branch = "master", default-features = false, features = ["attributes"] }
 tracing-core = { version = "0.2", git = "https://github.com/tokio-rs/tracing", branch = "master", default-features = false }
 
 # wast dependencies

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -406,6 +406,7 @@ impl Instance {
     reason = "imports should be a linear type"
 )]
 #[expect(clippy::unnecessary_wraps, reason = "TODO")]
+#[tracing::instrument(skip(module))]
 unsafe fn initialize_vmctx(
     const_eval: &mut ConstExprEvaluator,
     vmctx: &mut OwnedVMContext,
@@ -508,6 +509,7 @@ unsafe fn initialize_vmctx(
     }
 }
 
+#[tracing::instrument(skip(module))]
 fn initialize_vmfunc_refs(
     vmctx: &mut OwnedVMContext,
     module: &&Module,
@@ -569,6 +571,7 @@ fn initialize_vmfunc_refs(
     }
 }
 
+#[tracing::instrument(skip(module))]
 unsafe fn initialize_tables(
     const_eval: &mut ConstExprEvaluator,
     tables: &mut PrimaryMap<DefinedTableIndex, Table>,
@@ -619,6 +622,7 @@ unsafe fn initialize_tables(
 }
 
 #[expect(clippy::unnecessary_wraps, reason = "TODO")]
+#[tracing::instrument(skip(module))]
 unsafe fn initialize_memories(
     aspace: &mut AddressSpace,
     const_eval: &mut ConstExprEvaluator,

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -401,11 +401,6 @@ impl Instance {
     }
 }
 
-#[expect(
-    clippy::needless_pass_by_value,
-    reason = "imports should be a linear type"
-)]
-#[expect(clippy::unnecessary_wraps, reason = "TODO")]
 #[tracing::instrument(skip(module))]
 unsafe fn initialize_vmctx(
     const_eval: &mut ConstExprEvaluator,
@@ -621,7 +616,6 @@ unsafe fn initialize_tables(
     Ok(())
 }
 
-#[expect(clippy::unnecessary_wraps, reason = "TODO")]
 #[tracing::instrument(skip(module))]
 unsafe fn initialize_memories(
     aspace: &mut AddressSpace,


### PR DESCRIPTION
This adds `tracing::instrument` statements to all vmctx init functions since these are critical we'll need as much insight as possible.