### PR TITLE
fix: eagerly commit `OwnedVMContext`

### DIFF
--- a/kernel/src/vm/user_mmap.rs
+++ b/kernel/src/vm/user_mmap.rs
@@ -221,7 +221,7 @@ impl UserMmap {
         Ok(())
     }
 
-    fn commit(
+    pub fn commit(
         &self,
         aspace: &mut AddressSpace,
         range: Range<usize>,

--- a/kernel/src/wasm/runtime/owned_vmcontext.rs
+++ b/kernel/src/wasm/runtime/owned_vmcontext.rs
@@ -2,6 +2,7 @@ use crate::arch;
 use crate::vm::{AddressRangeExt, AddressSpace, UserMmap};
 use crate::wasm::runtime::{VMContext, VMOffsets};
 use alloc::string::ToString;
+use core::range::Range;
 
 #[derive(Debug)]
 pub struct OwnedVMContext(UserMmap);
@@ -19,6 +20,8 @@ impl OwnedVMContext {
             Some("VMContext".to_string()),
         )
         .unwrap();
+        mmap.commit(aspace, Range::from(0..offsets.size() as usize), true)
+            .unwrap();
 
         Ok(Self(mmap))
     }


### PR DESCRIPTION
Eagerly commit all pages of an `OwnedVMContext` upon creation (we should even pin them in the future) since we need that memory immediately for initialization.
