### PR TITLE
fix: activate address space before vmctx init

### DIFF
--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -110,6 +110,10 @@ impl AddressSpace {
         self.kind
     }
 
+    pub unsafe fn activate(&self) {
+        unsafe { self.arch.activate() }
+    }
+
     pub fn map(
         &mut self,
         layout: Layout,

--- a/kernel/src/vm/address_space.rs
+++ b/kernel/src/vm/address_space.rs
@@ -111,6 +111,7 @@ impl AddressSpace {
     }
 
     pub unsafe fn activate(&self) {
+        // Safety: ensured by caller
         unsafe { self.arch.activate() }
     }
 

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -53,8 +53,12 @@ impl Instance {
     ) -> crate::wasm::Result<Self> {
         let (mut vmctx, mut tables, mut memories) = store.alloc.allocate_module(&module)?;
 
+
         tracing::trace!("initializing instance");
         unsafe {
+            let mut aspace = store.alloc.0.lock();
+            aspace.activate();
+
             initialize_vmctx(
                 const_eval,
                 &mut vmctx,
@@ -65,7 +69,6 @@ impl Instance {
             )?;
             initialize_tables(const_eval, &mut tables, &module)?;
 
-            let mut aspace = store.alloc.0.lock();
             initialize_memories(&mut aspace, const_eval, &mut memories, &module)?;
         }
         tracing::trace!("done initializing instance");

--- a/kernel/src/wasm/runtime/instance.rs
+++ b/kernel/src/wasm/runtime/instance.rs
@@ -53,7 +53,6 @@ impl Instance {
     ) -> crate::wasm::Result<Self> {
         let (mut vmctx, mut tables, mut memories) = store.alloc.allocate_module(&module)?;
 
-
         tracing::trace!("initializing instance");
         unsafe {
             let mut aspace = store.alloc.0.lock();


### PR DESCRIPTION
This PR makes sure we're in the right address space when beginning to initialize the instance