### PR TITLE
fix: actually resolve relocations

### DIFF
--- a/kernel/src/wasm/compile/mod.rs
+++ b/kernel/src/wasm/compile/mod.rs
@@ -298,12 +298,13 @@ impl UnlinkedCompileOutputs {
                 };
 
                 // Ensure that we actually resolved the relocation
-                debug_assert!(text_builder.resolve_reloc(
+                let resolved = text_builder.resolve_reloc(
                     off + u64::from(r.offset),
                     r.kind,
                     r.addend,
                     target
-                ));
+                );
+                debug_assert!(resolved);
             }
 
             let loc = FunctionLoc {

--- a/kernel/src/wasm/compile/mod.rs
+++ b/kernel/src/wasm/compile/mod.rs
@@ -298,12 +298,8 @@ impl UnlinkedCompileOutputs {
                 };
 
                 // Ensure that we actually resolved the relocation
-                let resolved = text_builder.resolve_reloc(
-                    off + u64::from(r.offset),
-                    r.kind,
-                    r.addend,
-                    target
-                );
+                let resolved =
+                    text_builder.resolve_reloc(off + u64::from(r.offset), r.kind, r.addend, target);
                 debug_assert!(resolved);
             }
 


### PR DESCRIPTION
actually resolve relocations even when debug assertions are disabled. *sigh*