### PR TITLE
fix: don't panic on `InstanceAllocator` drop

### DIFF
--- a/kernel/src/wasm/instance_allocator.rs
+++ b/kernel/src/wasm/instance_allocator.rs
@@ -27,16 +27,6 @@ impl PlaceholderAllocatorDontUse {
     }
 }
 
-impl Drop for PlaceholderAllocatorDontUse {
-    fn drop(&mut self) {
-        assert_eq!(
-            Arc::strong_count(&self.0),
-            1,
-            "InstanceAllocator AddressSpace had outstanding references during drop. This indicates a leak somewhere."
-        );
-    }
-}
-
 impl InstanceAllocator for PlaceholderAllocatorDontUse {
     unsafe fn allocate_vmctx(
         &self,


### PR DESCRIPTION
This removes the `Drop` assertion from the placeholder instance allocator. I assumed originally that the instance allocator should be the last place to drop its address space reference, but when running inside the scheduler, the last reference is actually the one kept by the task struct.