### PR TITLE
wip: allow usermode programs to access kernel stacks

### DIFF
--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -547,6 +547,7 @@ impl From<Flags> for PTEFlags {
                 Flags::READ => out.insert(Self::READ),
                 Flags::WRITE => out.insert(Self::WRITE),
                 Flags::EXECUTE => out.insert(Self::EXECUTE),
+                Flags::USER => out.insert(Self::USER),
                 _ => unreachable!(),
             }
         }

--- a/loader/src/mapping.rs
+++ b/loader/src/mapping.rs
@@ -27,6 +27,7 @@ bitflags! {
         const READ = 1 << 0;
         const WRITE = 1 << 1;
         const EXECUTE = 1 << 2;
+        const USER = 1 << 3;
     }
 }
 
@@ -610,7 +611,7 @@ pub fn map_kernel_stacks(
                 virt,
                 phys,
                 NonZero::new(layout.size()).unwrap(),
-                Flags::READ | Flags::WRITE,
+                Flags::READ | Flags::WRITE | Flags::USER,
                 phys_off,
             )?;
         }


### PR DESCRIPTION
This temporary PR allows user mode WASM to run on the kernel stack as well