### PR TITLE
feat: run WASM asynchronously

### DIFF
--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -88,8 +88,8 @@ unsafe extern "C" fn default_trap_entry() {
         naked_asm! {
             // FIXME this is a workaround for bug in rustc/llvm
             //  https://github.com/rust-lang/rust/issues/80608#issuecomment-1094267279
-            ".align 4",
             ".attribute arch, \"rv64gc\"",
+            ".align 4",
             ".cfi_startproc",
 
             // Set the CFI rule for the return address to always return zero

--- a/kernel/src/fiber.rs
+++ b/kernel/src/fiber.rs
@@ -248,6 +248,10 @@ unsafe extern "C" fn fiber_switch(top_of_stack: *mut u8) {
     // Safety: inline assembly
     unsafe {
         naked_asm! {
+            // FIXME this is a workaround for bug in rustc/llvm
+            //  https://github.com/rust-lang/rust/issues/80608#issuecomment-1094267279
+            ".attribute arch, \"rv64gc\"",
+
             // We're switching to arbitrary code somewhere else, so pessimistically
             // assume that all callee-save register are clobbered. This means we need
             // to save/restore all of them.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -176,10 +176,6 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         Instant::from_ticks(Ticks(boot_ticks)).elapsed()
     );
 
-    if cpuid == 0 {
-        wasm::test();
-    }
-
     cfg_if! {
         if #[cfg(test)] {
             let mut output = riscv::hio::HostStream::new_stderr();

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -175,6 +175,10 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         Instant::from_ticks(Ticks(boot_ticks)).elapsed()
     );
 
+    if cpuid == 0 {
+        wasm::test();
+    }
+
     cfg_if! {
         if #[cfg(test)] {
             let mut output = riscv::hio::HostStream::new_stderr();

--- a/kernel/src/wasm/func.rs
+++ b/kernel/src/wasm/func.rs
@@ -37,9 +37,11 @@ impl Func {
         params: &[Val],
         results: &mut [Val],
     ) -> wasm::Result<()> {
-        // Safety: TODO should check arg & ret types and count here
         store
-            .on_fiber(|store| unsafe { self.call_unchecked(store, params, results) })
+            .on_fiber(|store| {
+                // Safety: TODO should check arg & ret types and count here
+                unsafe { self.call_unchecked(store, params, results) }
+            })
             .await?
     }
 

--- a/kernel/src/wasm/func.rs
+++ b/kernel/src/wasm/func.rs
@@ -4,7 +4,7 @@ use crate::wasm::store::Stored;
 use crate::wasm::translate::WasmFuncType;
 use crate::wasm::type_registry::RegisteredType;
 use crate::wasm::values::Val;
-use crate::wasm::{runtime, Error, Store, Trap, MAX_WASM_STACK};
+use crate::wasm::{Error, MAX_WASM_STACK, Store, Trap, runtime};
 use crate::{arch, wasm};
 use core::arch::asm;
 use core::ffi::c_void;
@@ -37,7 +37,10 @@ impl Func {
         params: &[Val],
         results: &mut [Val],
     ) -> wasm::Result<()> {
-        store.on_fiber(|store| unsafe { self.call_unchecked(store, params, results) }).await?
+        // Safety: TODO should check arg & ret types and count here
+        store
+            .on_fiber(|store| unsafe { self.call_unchecked(store, params, results) })
+            .await?
     }
 
     /// Calls the given function with the provided arguments and places the results in the provided

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -26,8 +26,8 @@ mod utils;
 mod values;
 
 use crate::scheduler::scheduler;
-use crate::vm::ArchAddressSpace;
 use crate::vm::frame_alloc::FRAME_ALLOC;
+use crate::vm::ArchAddressSpace;
 use crate::{enum_accessors, owned_enum_accessors};
 use core::fmt::Write;
 use wasmparser::Validator;
@@ -171,11 +171,7 @@ pub fn test() {
         let func = instance.get_func(&mut store, "fib_test").unwrap();
 
         scheduler().spawn(store.alloc.0.clone(), async move {
-            // TODO replace with checked
-            // Safety: WIP
-            unsafe {
-                func.call_unchecked(&mut store, &[], &mut []).unwrap();
-            }
+            func.call(&mut store, &[], &mut []).await.unwrap();
             tracing::info!("done");
         });
     }

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -26,8 +26,8 @@ mod utils;
 mod values;
 
 use crate::scheduler::scheduler;
-use crate::vm::frame_alloc::FRAME_ALLOC;
 use crate::vm::ArchAddressSpace;
+use crate::vm::frame_alloc::FRAME_ALLOC;
 use crate::{enum_accessors, owned_enum_accessors};
 use core::fmt::Write;
 use wasmparser::Validator;


### PR DESCRIPTION
This PR builds off the previous one to actually expose and async `call` method for WASM functions. 