### PR TITLE
feat: await irqs

### DIFF
--- a/kernel/src/arch/riscv64/device/cpu.rs
+++ b/kernel/src/arch/riscv64/device/cpu.rs
@@ -13,7 +13,7 @@ use crate::irq::InterruptController;
 use crate::time::clock::Ticks;
 use crate::time::{Clock, NANOS_PER_SEC};
 use bitflags::bitflags;
-use core::cell::OnceCell;
+use core::cell::{OnceCell, RefCell};
 use core::fmt;
 use core::str::FromStr;
 use core::time::Duration;
@@ -29,7 +29,7 @@ pub struct Cpu {
     pub cbop_block_size: Option<usize>,
     pub cboz_block_size: Option<usize>,
     pub cbom_block_size: Option<usize>,
-    pub plic: device::plic::Plic,
+    pub plic: RefCell<device::plic::Plic>,
     pub clock: Clock,
 }
 
@@ -174,7 +174,7 @@ pub fn init(devtree: &DeviceTree) -> crate::Result<()> {
             cbop_block_size,
             cboz_block_size,
             cbom_block_size,
-            plic,
+            plic: RefCell::new(plic),
         };
         tracing::debug!("\n{info_}");
 

--- a/kernel/src/arch/riscv64/device/plic.rs
+++ b/kernel/src/arch/riscv64/device/plic.rs
@@ -136,6 +136,11 @@ impl Plic {
 
         let regs: *mut PlicRegs = mmio_region.start.as_ptr().cast_mut().cast();
 
+        // set the threshold so interrupts can actually be delivered
+        // Safety: we do our best to check this is valid, but at the end of the day, this is writing to
+        // an MMIO region, so it's inherently unsafe.
+        unsafe { regs.as_mut().unwrap().set_priority_threshold(context, 0) };
+
         Ok(Plic {
             regs,
             context,
@@ -165,7 +170,7 @@ impl InterruptController for Plic {
         // an MMIO region, so it's inherently unsafe.
         let regs = unsafe { self.regs.as_mut().unwrap() };
         regs.set_priority(NonZero::new(irq_num as usize).unwrap(), 1);
-        regs.enable(self.context, NonZero::new(irq_num as usize).unwrap(), true);
+        regs.enable(self.context, NonZero::new(irq_num as usize).unwrap(), false);
     }
 
     fn irq_unmask(&mut self, irq_num: u32) {
@@ -174,7 +179,7 @@ impl InterruptController for Plic {
         // an MMIO region, so it's inherently unsafe.
         let regs = unsafe { self.regs.as_mut().unwrap() };
         regs.set_priority(NonZero::new(irq_num as usize).unwrap(), 1);
-        regs.enable(self.context, NonZero::new(irq_num as usize).unwrap(), false);
+        regs.enable(self.context, NonZero::new(irq_num as usize).unwrap(), true);
     }
 }
 

--- a/kernel/src/sync/mod.rs
+++ b/kernel/src/sync/mod.rs
@@ -14,7 +14,6 @@ mod wake_batch;
 pub use cache_padded::CachePadded;
 pub use error::Closed;
 pub use wait_cell::WaitCell;
-#[expect(unused_imports, reason = "TODO")]
 pub use wait_queue::WaitQueue;
 #[expect(unused_imports, reason = "TODO")]
 pub use wake_batch::WakeBatch;


### PR DESCRIPTION
This PR adds the ability to asynchronously awaiting (external) interrupts with a specific number. The API is very much WIP, but currently looks like this
```rust
let irq_num = 10; // E.g. the UART IRQ number on RISCV

// The line below will suspend the calling task until an interrupt with the IRQ number 10 arrives.
let res = irq::next_event(irq_num).await;
``` 

Note that any number of tasks may await an interrupt.