### PR TITLE
chore: move iterator utilities into `util`

### DIFF
--- a/kernel/src/arch/riscv64/device/plic.rs
+++ b/kernel/src/arch/riscv64/device/plic.rs
@@ -8,6 +8,7 @@
 use crate::arch::PAGE_SIZE;
 use crate::device_tree::{Device, DeviceTree, IrqSource};
 use crate::irq::{InterruptController, IrqClaim};
+use crate::util::either::Either;
 use crate::vm::{
     AddressRangeExt, AddressSpaceRegion, Permissions, PhysicalAddress, with_kernel_aspace,
 };
@@ -322,27 +323,5 @@ fn is_supervisor_source(addr: &IrqSource) -> bool {
         IrqSource::C1(u32::MAX) | IrqSource::C3(u32::MAX, _, _) => false,
         IrqSource::C1(11) => false,
         _ => true,
-    }
-}
-
-pub enum Either<L, R> {
-    /// A value of type `L`.
-    Left(L),
-    /// A value of type `R`.
-    Right(R),
-}
-
-impl<L, R, T> Iterator for Either<L, R>
-where
-    L: Iterator<Item = T>,
-    R: Iterator<Item = T>,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Either::Left(left) => left.next(),
-            Either::Right(right) => right.next(),
-        }
     }
 }

--- a/kernel/src/util/either.rs
+++ b/kernel/src/util/either.rs
@@ -1,0 +1,28 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+pub enum Either<L, R> {
+    /// A value of type `L`.
+    Left(L),
+    /// A value of type `R`.
+    Right(R),
+}
+
+impl<L, R, T> Iterator for Either<L, R>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Either::Left(left) => left.next(),
+            Either::Right(right) => right.next(),
+        }
+    }
+}

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -8,8 +8,10 @@
 use core::ptr::NonNull;
 
 pub mod atomic_cell;
+pub mod either;
 pub mod fast_rand;
 pub mod maybe_uninit;
+pub mod zip_eq;
 
 /// Helper to construct a `NonNull<T>` from a raw pointer to `T`, with null
 /// checks elided in release mode.

--- a/kernel/src/util/zip_eq.rs
+++ b/kernel/src/util/zip_eq.rs
@@ -1,0 +1,69 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use core::fmt;
+use core::fmt::Formatter;
+use fallible_iterator::FallibleIterator;
+
+pub trait IteratorExt {
+    fn zip_eq<U>(self, other: U) -> ZipEq<Self, <U as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator;
+}
+
+impl<I> IteratorExt for I
+where
+    I: Iterator,
+{
+    fn zip_eq<U>(self, other: U) -> ZipEq<Self, <U as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator,
+    {
+        ZipEq {
+            a: self,
+            b: other.into_iter(),
+        }
+    }
+}
+
+/// like Iterator::zip but returns an error if one iterator ends before
+/// the other. The `param_predicate` is required to select exactly as many
+/// elements of `params` as there are elements in `arguments`.
+pub struct ZipEq<A, B> {
+    a: A,
+    b: B,
+}
+
+#[derive(Debug)]
+pub struct DifferentLengths;
+
+impl fmt::Display for DifferentLengths {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "iterators had different lengths")
+    }
+}
+
+impl core::error::Error for DifferentLengths {}
+
+impl<A, B> FallibleIterator for ZipEq<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    type Item = (A::Item, B::Item);
+    type Error = DifferentLengths;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        match (self.a.next(), self.b.next()) {
+            (Some(a), Some(b)) => Ok(Some((a, b))),
+            (None, None) => Ok(None),
+            _ => Err(DifferentLengths),
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the `Either` and `ZipEq` iterator utilities into the `util` module.