### PR TITLE
feat: `TypedFunc`

### DIFF
--- a/kernel/src/arch/riscv64/device/plic.rs
+++ b/kernel/src/arch/riscv64/device/plic.rs
@@ -8,6 +8,7 @@
 use crate::arch::PAGE_SIZE;
 use crate::device_tree::{Device, DeviceTree, IrqSource};
 use crate::irq::{InterruptController, IrqClaim};
+use crate::util::either::Either;
 use crate::vm::{
     AddressRangeExt, AddressSpaceRegion, Permissions, PhysicalAddress, with_kernel_aspace,
 };
@@ -322,27 +323,5 @@ fn is_supervisor_source(addr: &IrqSource) -> bool {
         IrqSource::C1(u32::MAX) | IrqSource::C3(u32::MAX, _, _) => false,
         IrqSource::C1(11) => false,
         _ => true,
-    }
-}
-
-pub enum Either<L, R> {
-    /// A value of type `L`.
-    Left(L),
-    /// A value of type `R`.
-    Right(R),
-}
-
-impl<L, R, T> Iterator for Either<L, R>
-where
-    L: Iterator<Item = T>,
-    R: Iterator<Item = T>,
-{
-    type Item = T;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        match self {
-            Either::Left(left) => left.next(),
-            Either::Right(right) => right.next(),
-        }
     }
 }

--- a/kernel/src/error.rs
+++ b/kernel/src/error.rs
@@ -109,8 +109,8 @@ macro_rules! bail {
     ($error:expr) => {
         return Err($error);
     };
-    ($error:expr, $msg:expr) => {
-        tracing::error!($msg);
+    ($error:expr, $($msg:tt)*) => {
+        tracing::error!($($msg)*);
         return Err($error);
     };
 }

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -20,7 +20,7 @@ use core::str::FromStr;
 use fallible_iterator::FallibleIterator;
 use spin::Once;
 
-static COMMANDS: &[Command] = &[PANIC, FAULT, VERSION, SHUTDOWN];
+static COMMANDS: &[Command] = &[PANIC, FAULT, VERSION, SHUTDOWN, crate::wasm::TEST];
 
 pub fn init(devtree: &'static DeviceTree, sched: &'static Scheduler) {
     static ONCE: Once = Once::new();

--- a/kernel/src/util/either.rs
+++ b/kernel/src/util/either.rs
@@ -1,0 +1,28 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+pub enum Either<L, R> {
+    /// A value of type `L`.
+    Left(L),
+    /// A value of type `R`.
+    Right(R),
+}
+
+impl<L, R, T> Iterator for Either<L, R>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Either::Left(left) => left.next(),
+            Either::Right(right) => right.next(),
+        }
+    }
+}

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -8,8 +8,10 @@
 use core::ptr::NonNull;
 
 pub mod atomic_cell;
+pub mod either;
 pub mod fast_rand;
 pub mod maybe_uninit;
+pub mod zip_eq;
 
 /// Helper to construct a `NonNull<T>` from a raw pointer to `T`, with null
 /// checks elided in release mode.

--- a/kernel/src/util/zip_eq.rs
+++ b/kernel/src/util/zip_eq.rs
@@ -1,0 +1,69 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use core::fmt;
+use core::fmt::Formatter;
+use fallible_iterator::FallibleIterator;
+
+pub trait IteratorExt {
+    fn zip_eq<U>(self, other: U) -> ZipEq<Self, <U as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator;
+}
+
+impl<I> IteratorExt for I
+where
+    I: Iterator,
+{
+    fn zip_eq<U>(self, other: U) -> ZipEq<Self, <U as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator,
+    {
+        ZipEq {
+            a: self,
+            b: other.into_iter(),
+        }
+    }
+}
+
+/// like Iterator::zip but returns an error if one iterator ends before
+/// the other. The `param_predicate` is required to select exactly as many
+/// elements of `params` as there are elements in `arguments`.
+pub struct ZipEq<A, B> {
+    a: A,
+    b: B,
+}
+
+#[derive(Debug)]
+pub struct DifferentLengths;
+
+impl fmt::Display for DifferentLengths {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "iterators had different lengths")
+    }
+}
+
+impl core::error::Error for DifferentLengths {}
+
+impl<A, B> FallibleIterator for ZipEq<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    type Item = (A::Item, B::Item);
+    type Error = DifferentLengths;
+
+    fn next(&mut self) -> Result<Option<Self::Item>, Self::Error> {
+        match (self.a.next(), self.b.next()) {
+            (Some(a), Some(b)) => Ok(Some((a, b))),
+            (None, None) => Ok(None),
+            _ => Err(DifferentLengths),
+        }
+    }
+}

--- a/kernel/src/wasm/cranelift/env.rs
+++ b/kernel/src/wasm/cranelift/env.rs
@@ -11,8 +11,8 @@ use crate::wasm::indices::{
 };
 use crate::wasm::runtime::{VMFuncRef, VMMemoryDefinition, VMOffsets, VMTableDefinition};
 use crate::wasm::translate::{
-    ModuleTypes, TranslatedModule, WasmFuncType, WasmHeapTopTypeInner, WasmHeapType,
-    WasmHeapTypeInner, WasmRefType, WasmparserTypeConverter,
+    ModuleTypes, TranslatedModule, WasmFuncType, WasmHeapType, WasmHeapTypeInner, WasmRefType,
+    WasmparserTypeConverter,
 };
 use crate::wasm::trap::{TRAP_BAD_SIGNATURE, TRAP_INDIRECT_CALL_TO_NULL, TRAP_NULL_REFERENCE};
 use crate::wasm::utils::{reference_type, value_type, wasm_call_signature};
@@ -455,8 +455,8 @@ impl TranslationEnvironment<'_> {
     pub fn reference_type(&self, hty: &WasmHeapType) -> (Type, bool) {
         let ty = reference_type(hty, self.pointer_type());
         let needs_stack_map = match hty.top().inner {
-            WasmHeapTopTypeInner::Extern | WasmHeapTopTypeInner::Any => true,
-            WasmHeapTopTypeInner::Func => false,
+            WasmHeapTypeInner::Extern | WasmHeapTypeInner::Any => true,
+            WasmHeapTypeInner::Func => false,
             _ => todo!(),
         };
         (ty, needs_stack_map)
@@ -1389,7 +1389,7 @@ impl<'a, 'func, 'module_env> CallBuilder<'a, 'func, 'module_env> {
         // but essentially this all boils down to the "old" runtime signature check or a static
         // signature check for typed function references.
         let expected_type = &self.env.module.tables[table_index].element_type;
-        match expected_type.heap_type.ty {
+        match expected_type.heap_type.inner {
             // This is the old "funcref" (ref null func) type. This means inserting code
             // for a runtime signature check.
             WasmHeapTypeInner::Func => {

--- a/kernel/src/wasm/errors.rs
+++ b/kernel/src/wasm/errors.rs
@@ -67,6 +67,8 @@ pub enum Error {
         field: String,
     },
     FutureDropped,
+    MismatchedTypes,
+    CrossStore,
 }
 
 impl fmt::Display for Error {
@@ -103,6 +105,8 @@ impl fmt::Display for Error {
                 writeln!(f, "Name {module}::{field} is already defined")
             }
             Self::FutureDropped => f.write_str("Fiber future dropped"),
+            Self::MismatchedTypes => f.write_str("Type mismatch"),
+            Self::CrossStore => f.write_str("Attempted to use values across stores"),
         }
     }
 }

--- a/kernel/src/wasm/func.rs
+++ b/kernel/src/wasm/func.rs
@@ -1,14 +1,20 @@
+use crate::util::zip_eq::IteratorExt;
 use crate::wasm::indices::VMSharedTypeIndex;
-use crate::wasm::runtime::{StaticVMOffsets, VMContext, VMFunctionImport, VMVal};
+use crate::wasm::runtime::{StaticVMOffsets, VMContext, VMFuncRef, VMFunctionImport, VMVal};
 use crate::wasm::store::Stored;
-use crate::wasm::translate::WasmFuncType;
+use crate::wasm::translate::{WasmFuncType, WasmHeapType, WasmRefType, WasmValType};
 use crate::wasm::type_registry::RegisteredType;
 use crate::wasm::values::Val;
 use crate::wasm::{Error, MAX_WASM_STACK, Store, Trap, runtime};
-use crate::{arch, wasm};
+use crate::{arch, ensure, wasm};
 use core::arch::asm;
 use core::ffi::c_void;
-use core::mem;
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+use core::{mem, ptr};
+use fallible_iterator::FallibleIterator;
+use wasmparser::ValType;
 
 /// A WebAssembly function.
 #[derive(Debug, Clone, Copy)]
@@ -37,9 +43,30 @@ impl Func {
         params: &[Val],
         results: &mut [Val],
     ) -> wasm::Result<()> {
+        let ty = self.ty(store);
+        let ty = ty.as_wasm_func_type();
+
+        let mut params_ = ty.params.iter().zip_eq(params);
+        while let Some((expected, param)) = params_.next().map_err(|_| Error::MismatchedTypes)? {
+            let found = param.ty();
+            ensure!(
+                *expected == found,
+                Error::MismatchedTypes,
+                "Type mismatch. Expected `{expected:?}`, but found `{found:?}`"
+            );
+        }
+
+        ensure!(
+            results.len() >= ty.results.len(),
+            Error::MismatchedTypes,
+            "Results slice too small. Need space for at least {}, but got only {}",
+            ty.results.len(),
+            results.len()
+        );
+
         store
             .on_fiber(|store| {
-                // Safety: TODO should check arg & ret types and count here
+                // Safety: we have checked the
                 unsafe { self.call_unchecked(store, params, results) }
             })
             .await?
@@ -62,9 +89,7 @@ impl Func {
         params: &[Val],
         results: &mut [Val],
     ) -> wasm::Result<()> {
-        let ty = self.ty(store);
-        let ty = ty.as_wasm_func_type();
-        let values_vec_size = params.len().max(ty.results.len());
+        let values_vec_size = params.len().max(results.len());
 
         // take out the argument storage from the store
         let mut values_vec = store.take_wasm_vmval_storage();
@@ -83,6 +108,9 @@ impl Func {
         }
 
         // copy the results out of the storage
+        let ty = self.ty(store);
+        let ty = ty.as_wasm_func_type();
+
         for ((i, slot), vmval) in results.iter_mut().enumerate().zip(&values_vec) {
             let ty = &ty.results[i];
             // Safety: caller has to ensure safety
@@ -106,7 +134,7 @@ impl Func {
         store: &mut Store,
         args_results_ptr: *mut VMVal,
         args_results_len: usize,
-    ) -> crate::wasm::Result<()> {
+    ) -> wasm::Result<()> {
         // Safety: funcref is always initialized
         let func_ref = unsafe { store[self.0].func_ref.as_ref() };
         // Safety: funcref is always initialized
@@ -117,37 +145,31 @@ impl Func {
 
         let res = wasm::trap_handler::catch_traps(vmctx, module.offsets().static_.clone(), || {
             tracing::debug!("jumping to WASM");
-            // Safety: caller has to ensure safety
-            unsafe {
-                riscv::sstatus::set_spp(riscv::sstatus::SPP::User);
-                riscv::sepc::set(func_ref.array_call as usize);
-                asm! {
-                "sret",
-                in("a0") vmctx,
-                in("a1") vmctx,
-                in("a2") args_results_ptr,
-                in("a3") args_results_len,
-                options(noreturn)
-                }
-            }
+
+            // Safety: TODO
+            unsafe { func_ref.array_call(vmctx, vmctx, args_results_ptr, args_results_len) }
         });
 
         tracing::trace!("returned from WASM {res:?}");
         match res {
-                Ok(_)
-                // The userspace ABI uses the Trap::Exit code to signal a graceful exit
-                | Err(Error::Trap {
-                          trap: Trap::Exit, ..
-                      }) => Ok(()),
-                Err(err) => Err(err),
-            }
+            Ok(_)
+            // The userspace ABI uses the Trap::Exit code to signal a graceful exit
+            | Err(Error::Trap {
+                      trap: Trap::Exit, ..
+                  }) => Ok(()),
+            Err(err) => Err(err),
+        }
     }
 
-    pub(crate) fn as_raw(&self, store: &mut Store) -> *mut c_void {
+    pub(super) fn as_raw(&self, store: &mut Store) -> *mut c_void {
         store[self.0].func_ref.as_ptr().cast()
     }
 
-    pub(crate) fn as_vmfunction_import(&self, store: &Store) -> VMFunctionImport {
+    fn as_vm_func_ref(self, store: &Store) -> NonNull<VMFuncRef> {
+        store[self.0].func_ref
+    }
+
+    pub(super) fn as_vmfunction_import(&self, store: &Store) -> VMFunctionImport {
         // Safety: at this point `VMContext` is initialized, so accessing its fields is safe
         let func_ref = unsafe { store[self.0].func_ref.as_ref() };
         VMFunctionImport {
@@ -157,8 +179,537 @@ impl Func {
         }
     }
 
-    pub(crate) fn from_vm_export(store: &mut Store, export: runtime::ExportedFunction) -> Self {
+    /// # Safety
+    ///
+    /// The caller must ensure `export` is a valid exported function within `store`.
+    pub(super) unsafe fn from_vm_export(
+        store: &mut Store,
+        export: runtime::ExportedFunction,
+    ) -> Self {
         Self(store.push_function(export))
+    }
+
+    /// # Safety
+    ///
+    /// The caller must ensure the func ref is a valid function reference in this store.
+    unsafe fn from_vm_func_ref(store: &mut Store, func_ref: NonNull<VMFuncRef>) -> Self {
+        // Safety: ensured by caller
+        unsafe {
+            debug_assert!(func_ref.as_ref().type_index != VMSharedTypeIndex::default());
+            let export = runtime::ExportedFunction { func_ref };
+            Self::from_vm_export(store, export)
+        }
+    }
+
+    pub fn typed<Params, Results>(self, store: &Store) -> wasm::Result<TypedFunc<Params, Results>>
+    where
+        Params: WasmParams,
+        Results: WasmResults,
+    {
+        let ty = self.ty(store);
+        let wasm_ty = ty.as_wasm_func_type();
+        Params::typecheck(wasm_ty.params.iter())?;
+        Results::typecheck(wasm_ty.results.iter())?;
+
+        Ok(TypedFunc {
+            ty,
+            func: self,
+            _m: PhantomData,
+        })
+    }
+}
+
+/// A WebAssembly function type.
+///
+/// This is essentially a reference counted index into the engine's type registry.
+pub struct FuncType(RegisteredType);
+
+impl FuncType {
+    pub(crate) fn type_index(&self) -> VMSharedTypeIndex {
+        self.0.index()
+    }
+
+    pub fn as_wasm_func_type(&self) -> &WasmFuncType {
+        self.0.unwrap_func()
+    }
+
+    pub(crate) fn into_registered_type(self) -> RegisteredType {
+        self.0
+    }
+
+    pub fn param(&self, i: usize) -> Option<&WasmValType> {
+        let func = self.0.unwrap_func();
+        func.params.get(i)
+    }
+}
+
+/// A WebAssembly function.
+pub struct TypedFunc<Params, Results> {
+    func: Func,
+    ty: FuncType,
+    _m: PhantomData<fn(Params) -> Results>,
+}
+
+impl<Params, Results> TypedFunc<Params, Results>
+where
+    Params: WasmParams,
+    Results: WasmResults,
+{
+    /// Invokes this WebAssembly function with the specified parameters.
+    ///
+    /// # Errors
+    ///
+    /// For more information on errors see the documentation on [`Func::call`].
+    pub async fn call(&self, store: &mut Store, params: Params) -> wasm::Result<Results> {
+        #[cfg(debug_assertions)]
+        Self::assert_typecheck(self.ty.as_wasm_func_type());
+
+        store
+            .on_fiber(|store| {
+                // Safety: The `Func::typed` constructor ensured that this types generics and the
+                // types required by the WASM function match
+                unsafe { Self::call_raw(store, &self.ty, store[self.func.0].func_ref, params) }
+            })
+            .await?
+    }
+
+    /// Do the raw call of a typed function.
+    ///
+    /// Calling typed functions is a bit more optimized than calling untyped ones, in particular type
+    /// checking has already been performed when constructing the typed function reference.
+    ///
+    /// # Implementation
+    ///
+    /// This function uses the type information encoded in the `Params` and `Results` generics to
+    /// allocate the `VMVal` storage array on the stack. It then lowers the Rust parameters into their
+    /// WASM `VMVal` representation and writes them to the stack allocated array.
+    ///
+    /// We then call into WASM through the array-call trampoline just like [`Func::call_unchecked_raw`].
+    ///
+    /// Once we return from WASM, we load the expected result values from the stack allocated array,
+    /// convert them into their Rust representations and return.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the provided [`VMFuncRef`] is of the correct type for this [`TypedFunc`].
+    unsafe fn call_raw(
+        store: &mut Store,
+        ty: &FuncType,
+        func_ref: NonNull<VMFuncRef>,
+        params: Params,
+    ) -> wasm::Result<Results> {
+        // Safety: ensured by caller
+        unsafe {
+            union Storage<T: Copy, U: Copy> {
+                params: MaybeUninit<T>,
+                results: U,
+            }
+
+            let mut storage = Storage::<Params::VMValStorage, Results::VMValStorage> {
+                params: MaybeUninit::uninit(),
+            };
+
+            // Lower the Rust types into their WASM VMVal representation and store them into the buffer
+            params.store(store, ty, &mut storage.params)?;
+
+            let vmctx = VMContext::from_opaque(func_ref.as_ref().vmctx);
+            let module = store[store.get_instance_from_vmctx(vmctx)].module();
+
+            let _guard = enter_wasm(vmctx, &module.offsets().static_);
+
+            let res =
+                wasm::trap_handler::catch_traps(vmctx, module.offsets().static_.clone(), || {
+                    let storage_len = size_of_val::<Storage<_, _>>(&storage) / size_of::<VMVal>();
+                    let storage: *mut Storage<_, _> = &mut storage;
+                    let storage = storage.cast::<VMVal>();
+
+                    tracing::debug!("jumping to WASM");
+                    func_ref
+                        .as_ref()
+                        .array_call(vmctx, vmctx, storage, storage_len);
+                });
+
+            tracing::trace!("returned from WASM {res:?}");
+
+            match res {
+                Ok(_)
+                // The userspace ABI uses the Trap::Exit code to signal a graceful exit
+                | Err(Error::Trap {
+                          trap: Trap::Exit, ..
+                      }) => Ok(Results::load(store, &storage.results)),
+                Err(err) => Err(err),
+            }
+        }
+    }
+
+    fn assert_typecheck(ty: &WasmFuncType) {
+        Params::typecheck(ty.params.iter()).expect("params should match");
+        Results::typecheck(ty.results.iter()).expect("results should match");
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum TypeCheckPosition {
+    Param,
+    Result,
+}
+
+/// A type that can be used as an argument or return value for WASM functions.
+///
+/// # Safety
+///
+/// This trait should not be implemented manually.
+pub unsafe trait WasmTy: Send {
+    fn valtype() -> WasmValType;
+    fn store(self, store: &mut Store, ptr: &mut MaybeUninit<VMVal>) -> wasm::Result<()>;
+    unsafe fn load(store: &mut Store, ptr: &VMVal) -> Self;
+    #[inline]
+    fn typecheck(actual: &WasmValType, position: TypeCheckPosition) -> wasm::Result<()> {
+        let expected = Self::valtype();
+
+        match position {
+            TypeCheckPosition::Result => actual.ensure_matches(&expected),
+            TypeCheckPosition::Param => match (expected.get_ref(), actual.get_ref()) {
+                (Some(expected_ref), Some(actual_ref)) if actual_ref.heap_type.is_concrete() => {
+                    expected_ref
+                        .heap_type
+                        .top()
+                        .ensure_matches(&actual_ref.heap_type.top())
+                }
+                _ => actual.ensure_matches(&expected),
+            },
+        }
+    }
+    fn dynamic_concrete_type_check(
+        &self,
+        store: &Store,
+        nullable: bool,
+        actual: &WasmHeapType,
+    ) -> wasm::Result<()>;
+    fn compatible_with_store(&self, store: &Store) -> bool;
+}
+
+/// A type that can be used as an argument for WASM functions.
+///
+/// This trait is implemented for bare types that may be passed to WASM and tuples of those types.
+///
+/// # Safety
+///
+/// This trait should not be implemented manually.
+pub unsafe trait WasmParams: Send {
+    type VMValStorage: Copy;
+    fn typecheck<'a>(params: impl ExactSizeIterator<Item = &'a WasmValType>) -> wasm::Result<()>;
+    fn store(
+        self,
+        store: &mut Store,
+        func_ty: &FuncType,
+        dst: &mut MaybeUninit<Self::VMValStorage>,
+    ) -> wasm::Result<()>;
+}
+
+/// A type that may be returned from WASM functions.
+///
+/// This trait is implemented for bare types that may be passed to WASM and tuples of those types.
+///
+/// # Safety
+///
+/// This trait should not be implemented manually.
+pub unsafe trait WasmResults: WasmParams {
+    unsafe fn load(store: &mut Store, abi: &Self::VMValStorage) -> Self;
+}
+
+macro_rules! integers {
+    ($($integer:ident/$get_integer:ident => $ty:ident)*) => ($(
+        // Safety: this macro correctly delegates to the integer methods
+        unsafe impl WasmTy for $integer {
+            #[inline]
+            fn valtype() -> WasmValType {
+                WasmValType::$ty
+            }
+
+            #[inline]
+            fn store(self, _store: &mut Store, ptr: &mut MaybeUninit<VMVal>) -> wasm::Result<()> {
+                ptr.write(VMVal::$integer(self));
+                Ok(())
+            }
+
+            #[inline]
+            unsafe fn load(_store: &mut Store, ptr: &VMVal) -> Self {
+                ptr.$get_integer()
+            }
+
+            #[inline]
+            fn dynamic_concrete_type_check(
+                &self,
+                _store: &Store,
+                _nullable: bool,
+                _actual: &WasmHeapType,
+            ) -> wasm::Result<()> {
+                unreachable!("`dynamic_concrete_type_check` not implemented for integers");
+            }
+
+            #[inline]
+            fn compatible_with_store(&self, _store: &Store) -> bool {
+                true
+            }
+        }
+    )*)
+}
+
+integers! {
+    i32/get_i32 => I32
+    i64/get_i64 => I64
+    u32/get_u32 => I32
+    u64/get_u64 => I64
+}
+
+macro_rules! floats {
+    ($($float:ident/$get_float:ident => $ty:ident)*) => ($(
+        // Safety: this macro correctly delegates to the float methods
+        unsafe impl WasmTy for $float {
+            #[inline]
+            fn valtype() -> WasmValType {
+                WasmValType::$ty
+            }
+
+            #[inline]
+            fn store(self, _store: &mut Store, ptr: &mut MaybeUninit<VMVal>) -> wasm::Result<()> {
+                ptr.write(VMVal::$float(self.to_bits()));
+                Ok(())
+            }
+
+            #[inline]
+            unsafe fn load(_store: &mut Store, ptr: &VMVal) -> Self {
+                $float::from_bits(ptr.$get_float())
+            }
+
+            #[inline]
+            fn dynamic_concrete_type_check(
+                &self,
+                _store: &Store,
+                _nullable: bool,
+                _actual: &WasmHeapType,
+            ) -> wasm::Result<()> {
+                unreachable!("`dynamic_concrete_type_check` not implemented for floats");
+            }
+
+            #[inline]
+            fn compatible_with_store(&self, _store: &Store) -> bool {
+                true
+            }
+        }
+    )*)
+}
+
+floats! {
+    f32/get_f32 => F32
+    f64/get_f64 => F64
+}
+
+// Safety: functions are lowered as VMFuncRef pointers. TODO the correctness of this should be checked by tests
+unsafe impl WasmTy for Func {
+    fn valtype() -> WasmValType {
+        WasmValType::Ref(WasmRefType::FUNCREF)
+    }
+
+    fn store(self, store: &mut Store, ptr: &mut MaybeUninit<VMVal>) -> wasm::Result<()> {
+        let raw = self.as_vm_func_ref(store).as_ptr();
+        ptr.write(VMVal::funcref(raw.cast::<c_void>()));
+        Ok(())
+    }
+
+    unsafe fn load(store: &mut Store, ptr: &VMVal) -> Self {
+        // Safety: ensured by caller
+        unsafe {
+            let ptr = NonNull::new(ptr.get_funcref()).unwrap().cast();
+            Func::from_vm_func_ref(store, ptr)
+        }
+    }
+
+    fn dynamic_concrete_type_check(
+        &self,
+        _store: &Store,
+        _nullable: bool,
+        _actual: &WasmHeapType,
+    ) -> wasm::Result<()> {
+        todo!()
+    }
+
+    fn compatible_with_store(&self, store: &Store) -> bool {
+        store.has_function(self.0)
+    }
+}
+
+// Safety: functions are lowered as VMFuncRef pointers. TODO the correctness of this should be checked by tests
+unsafe impl WasmTy for Option<Func> {
+    fn valtype() -> WasmValType {
+        WasmValType::Ref(WasmRefType::FUNCREF)
+    }
+
+    fn store(self, store: &mut Store, ptr: &mut MaybeUninit<VMVal>) -> wasm::Result<()> {
+        let raw = if let Some(f) = self {
+            f.as_vm_func_ref(store).as_ptr()
+        } else {
+            ptr::null_mut()
+        };
+        ptr.write(VMVal::funcref(raw.cast::<c_void>()));
+        Ok(())
+    }
+
+    unsafe fn load(store: &mut Store, ptr: &VMVal) -> Self {
+        // Safety: ensured by caller
+        unsafe {
+            let ptr = NonNull::new(ptr.get_funcref())?.cast();
+            Some(Func::from_vm_func_ref(store, ptr))
+        }
+    }
+
+    fn dynamic_concrete_type_check(
+        &self,
+        _store: &Store,
+        _nullable: bool,
+        _actual: &WasmHeapType,
+    ) -> wasm::Result<()> {
+        todo!()
+    }
+
+    fn compatible_with_store(&self, store: &Store) -> bool {
+        if let Some(f) = self {
+            store.has_function(f.0)
+        } else {
+            true
+        }
+    }
+}
+
+macro_rules! for_each_function_signature {
+    ($mac:ident) => {
+        $mac!(0);
+        $mac!(1 A1);
+        $mac!(2 A1 A2);
+        $mac!(3 A1 A2 A3);
+        $mac!(4 A1 A2 A3 A4);
+        $mac!(5 A1 A2 A3 A4 A5);
+        $mac!(6 A1 A2 A3 A4 A5 A6);
+        $mac!(7 A1 A2 A3 A4 A5 A6 A7);
+        $mac!(8 A1 A2 A3 A4 A5 A6 A7 A8);
+        $mac!(9 A1 A2 A3 A4 A5 A6 A7 A8 A9);
+        $mac!(10 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10);
+        $mac!(11 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11);
+        $mac!(12 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12);
+        $mac!(13 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13);
+        $mac!(14 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14);
+        $mac!(15 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15);
+        $mac!(16 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15 A16);
+        $mac!(17 A1 A2 A3 A4 A5 A6 A7 A8 A9 A10 A11 A12 A13 A14 A15 A16 A17);
+    };
+}
+
+macro_rules! impl_wasm_params {
+    ($n:tt $($t:ident)*) => {
+        #[allow(non_snake_case, reason = "argument names above are uppercase")]
+        // Safety: see `WasmTy` for details
+        unsafe impl<$($t: WasmTy,)*> WasmParams for ($($t,)*) {
+            type VMValStorage = [VMVal; $n];
+
+            fn typecheck<'a>(mut params: impl ExactSizeIterator<Item = &'a WasmValType>) -> wasm::Result<()> {
+                let mut _n = 0;
+
+                $(
+                    match params.next() {
+                        Some(t) => {
+                            _n += 1;
+                            $t::typecheck(t, TypeCheckPosition::Param)?
+                        },
+                        None => {
+                            $crate::bail!(Error::MismatchedTypes, "expected {} types, found {}", $n as usize, params.len() + _n);
+                        },
+                    }
+                )*
+
+                match params.next() {
+                    None => Ok(()),
+                    Some(_) => {
+                        _n += 1;
+                        $crate::bail!(Error::MismatchedTypes, "expected {} types, found {}", $n, params.len() + _n);
+                    },
+                }
+            }
+
+            fn store(self, _store: &mut Store, _func_ty: &FuncType, _dst: &mut MaybeUninit<Self::VMValStorage>) -> wasm::Result<()> {
+                use $crate::util::maybe_uninit::MaybeUninitExt;
+
+                let ($($t,)*) = self;
+                let mut _i: usize = 0;
+
+                $(
+                    if !$t.compatible_with_store(_store) {
+                        $crate::bail!(Error::CrossStore, "attempt to pass cross-`Store` value to Wasm as function argument");
+                    }
+
+                    if $t::valtype().is_ref() {
+                        let param_ty = _func_ty.param(_i).unwrap();
+                        let ref_ty = param_ty.unwrap_ref();
+                        if ref_ty.heap_type.is_concrete() {
+                            $t.dynamic_concrete_type_check(_store, ref_ty.nullable, &ref_ty.heap_type)?;
+                        }
+                    }
+
+                    // Safety: the macro guarantees that `Self::VMValStorage` has enough space
+                    let dst = unsafe { _dst.map(|p| &raw mut (*p)[_i]) };
+                    $t.store(_store, dst)?;
+
+                    _i += 1;
+                )*
+                Ok(())
+            }
+        }
+    }
+}
+
+macro_rules! impl_wasm_results {
+    ($n:tt $($t:ident)*) => {
+        #[allow(non_snake_case, reason = "argument names above are uppercase")]
+        #[allow(clippy::unused_unit, reason = "the empty tuple case generates an empty tuple as return value, which makes clippy mad but thats fine")]
+        // Safety: see `WasmTy` for details
+        unsafe impl<$($t: WasmTy,)*> WasmResults for ($($t,)*) {
+            unsafe fn load(_store: &mut Store, _abi: &Self::VMValStorage) -> Self {
+                let [$($t,)*] = _abi;
+                // Safety: ensured by caller
+                ($(unsafe { $t::load(_store, $t) },)*)
+            }
+        }
+    }
+}
+
+for_each_function_signature!(impl_wasm_params);
+for_each_function_signature!(impl_wasm_results);
+
+// Forwards from a bare type `T` to the 1-tuple type `(T,)`
+// Safety: see `impl_wasm_params!`
+unsafe impl<T: WasmTy> WasmParams for T {
+    type VMValStorage = <(T,) as WasmParams>::VMValStorage;
+
+    fn typecheck<'a>(params: impl ExactSizeIterator<Item = &'a WasmValType>) -> wasm::Result<()> {
+        <(T,) as WasmParams>::typecheck(params)
+    }
+
+    fn store(
+        self,
+        store: &mut Store,
+        func_ty: &FuncType,
+        dst: &mut MaybeUninit<Self::VMValStorage>,
+    ) -> wasm::Result<()> {
+        <(T,) as WasmParams>::store((self,), store, func_ty, dst)
+    }
+}
+
+// Forwards from a bare type `T` to the 1-tuple type `(T,)`
+// Safety: see `impl_wasm_results!`
+unsafe impl<T: WasmTy> WasmResults for T {
+    unsafe fn load(store: &mut Store, abi: &Self::VMValStorage) -> Self {
+        // Safety: ensured by caller
+        unsafe { <(T,) as WasmResults>::load(store, abi).0 }
     }
 }
 
@@ -190,24 +741,5 @@ impl Drop for WasmExecutionGuard {
         unsafe {
             *self.stack_limit_ptr = self.prev_stack;
         }
-    }
-}
-
-/// A WebAssembly function type.
-///
-/// This is essentially a reference counted index into the engine's type registry.
-pub struct FuncType(RegisteredType);
-
-impl FuncType {
-    pub(crate) fn type_index(&self) -> VMSharedTypeIndex {
-        self.0.index()
-    }
-
-    pub fn as_wasm_func_type(&self) -> &WasmFuncType {
-        self.0.unwrap_func()
-    }
-
-    pub(crate) fn into_registered_type(self) -> RegisteredType {
-        self.0
     }
 }

--- a/kernel/src/wasm/global.rs
+++ b/kernel/src/wasm/global.rs
@@ -20,17 +20,24 @@ impl Global {
     // pub fn set(&self, store: &mut Store, val: Val) {
     //     todo!()
     // }
-    pub(crate) fn as_vmglobal_import(&self, store: &Store) -> VMGlobalImport {
+    pub(super) fn as_vmglobal_import(&self, store: &Store) -> VMGlobalImport {
         VMGlobalImport {
             from: store[self.0].definition,
             vmctx: store[self.0].vmctx,
         }
     }
-    pub(crate) fn from_vm_export(store: &mut Store, export: runtime::ExportedGlobal) -> Self {
+
+    /// # Safety
+    ///
+    /// The caller must ensure `export` is a valid exported global within `store`.
+    pub(super) unsafe fn from_vm_export(
+        store: &mut Store,
+        export: runtime::ExportedGlobal,
+    ) -> Self {
         Self(store.push_global(export))
     }
 
-    pub(crate) fn comes_from_same_store(self, store: &Store) -> bool {
+    pub fn comes_from_same_store(self, store: &Store) -> bool {
         store.has_global(self.0)
     }
 }

--- a/kernel/src/wasm/indices.rs
+++ b/kernel/src/wasm/indices.rs
@@ -112,6 +112,13 @@ entity_impl!(ModuleInternedRecGroupIndex);
 pub struct VMSharedTypeIndex(u32);
 entity_impl!(VMSharedTypeIndex);
 
+impl Default for VMSharedTypeIndex {
+    #[inline]
+    fn default() -> Self {
+        Self(u32::MAX)
+    }
+}
+
 #[cfg(test)]
 mod test_vmshared_type_index {
     use super::VMSharedTypeIndex;

--- a/kernel/src/wasm/instance.rs
+++ b/kernel/src/wasm/instance.rs
@@ -120,7 +120,8 @@ impl Instance {
         }
 
         let instance = &mut store[self.0]; // Reborrow the &mut InstanceHandle
-        let item = Extern::from_export(instance.get_export_by_index(entity), store);
+        // Safety: we just took `instance` from the store, so all its exports must also belong to the store
+        let item = unsafe { Extern::from_export(instance.get_export_by_index(entity), store) };
         let data = &mut store[self.0];
         data.exports[export_name_index] = Some(item.clone());
         item

--- a/kernel/src/wasm/memory.rs
+++ b/kernel/src/wasm/memory.rs
@@ -13,17 +13,24 @@ impl Memory {
     // pub fn ty(&self, _store: &Store) -> &MemoryType {
     //     todo!()
     // }
-    pub(crate) fn as_vmmemory_import(&self, store: &Store) -> VMMemoryImport {
+    pub(super) fn as_vmmemory_import(&self, store: &Store) -> VMMemoryImport {
         VMMemoryImport {
             from: store[self.0].definition,
             vmctx: store[self.0].vmctx,
         }
     }
-    pub(crate) fn from_vm_export(store: &mut Store, export: runtime::ExportedMemory) -> Self {
+
+    /// # Safety
+    ///
+    /// The caller must ensure `export` is a valid exported memory within `store`.
+    pub(super) unsafe fn from_vm_export(
+        store: &mut Store,
+        export: runtime::ExportedMemory,
+    ) -> Self {
         Self(store.push_memory(export))
     }
 
-    pub(crate) fn comes_from_same_store(self, store: &Store) -> bool {
+    pub fn comes_from_same_store(self, store: &Store) -> bool {
         store.has_memory(self.0)
     }
 }

--- a/kernel/src/wasm/table.rs
+++ b/kernel/src/wasm/table.rs
@@ -13,16 +13,21 @@ impl Table {
     // pub fn ty(&self, _store: &Store) -> &TableType {
     //     todo!()
     // }
-    pub(crate) fn as_vmtable_import(&self, store: &Store) -> VMTableImport {
+    pub(super) fn as_vmtable_import(&self, store: &Store) -> VMTableImport {
         VMTableImport {
             from: store[self.0].definition,
             vmctx: store[self.0].vmctx,
         }
     }
-    pub(crate) fn from_vm_export(store: &mut Store, export: runtime::ExportedTable) -> Self {
+
+    /// # Safety
+    ///
+    /// The caller must ensure `export` is a valid exported table within `store`.
+    pub(super) unsafe fn from_vm_export(store: &mut Store, export: runtime::ExportedTable) -> Self {
         Self(store.push_table(export))
     }
-    pub(crate) fn comes_from_same_store(self, store: &Store) -> bool {
+
+    pub fn comes_from_same_store(self, store: &Store) -> bool {
         store.has_table(self.0)
     }
 }

--- a/kernel/src/wasm/translate/mod.rs
+++ b/kernel/src/wasm/translate/mod.rs
@@ -22,8 +22,8 @@ pub use module_translator::ModuleTranslator;
 pub use module_types::ModuleTypes;
 pub use type_convert::WasmparserTypeConverter;
 pub use types::{
-    EntityType, WasmFuncType, WasmHeapTopTypeInner, WasmHeapType, WasmHeapTypeInner, WasmRecGroup,
-    WasmRefType, WasmSubType, WasmValType,
+    EntityType, WasmFuncType, WasmHeapType, WasmHeapTypeInner, WasmRecGroup, WasmRefType,
+    WasmSubType, WasmValType,
 };
 use wasmparser::WasmFeatures;
 use wasmparser::collections::IndexMap;

--- a/kernel/src/wasm/translate/type_convert.rs
+++ b/kernel/src/wasm/translate/type_convert.rs
@@ -61,7 +61,7 @@ impl<'a> WasmparserTypeConverter<'a> {
                     AbstractHeapType::NoCont => NoCont,
                 };
 
-                WasmHeapType { shared, ty }
+                WasmHeapType { shared, inner: ty }
             }
         }
     }

--- a/kernel/src/wasm/values.rs
+++ b/kernel/src/wasm/values.rs
@@ -1,6 +1,6 @@
 use crate::wasm::func::Func;
 use crate::wasm::runtime::VMVal;
-use crate::wasm::translate::{WasmHeapTopTypeInner, WasmHeapType, WasmValType};
+use crate::wasm::translate::{WasmHeapType, WasmHeapTypeInner, WasmRefType, WasmValType};
 use crate::wasm::{Store, enum_accessors};
 use core::ptr;
 
@@ -45,6 +45,17 @@ impl Val {
     #[inline]
     pub const fn null_func_ref() -> Self {
         Self::FuncRef(None)
+    }
+
+    pub const fn ty(&self) -> WasmValType {
+        match self {
+            Val::I32(_) => WasmValType::I32,
+            Val::I64(_) => WasmValType::I64,
+            Val::F32(_) => WasmValType::F32,
+            Val::F64(_) => WasmValType::F64,
+            Val::V128(_) => WasmValType::V128,
+            Val::FuncRef(_) => WasmValType::Ref(WasmRefType::FUNCREF),
+        }
     }
 
     /// Convenience method to convert this [`Val`] into a [`VMVal`].
@@ -142,7 +153,7 @@ impl Ref {
     #[inline]
     pub fn null(heap_type: &WasmHeapType) -> Self {
         match heap_type.top().inner {
-            WasmHeapTopTypeInner::Func => Ref::Func(None),
+            WasmHeapTypeInner::Func => Ref::Func(None),
             ty => todo!("heap type: {ty:?}"),
         }
     }


### PR DESCRIPTION
This PR implements the `TypedFunc` type and related machinery. `TypedFunc` allows us to front-load the type checking of WASM functions and then on subsequent calls benefit from Rusts compile-time checks again. `TypedFunc` can also optimize its argument and result lowering/lifting.

`TypedFunc` should be the primary means of interacting with WASM functions.