### PR TITLE
chore: move WASM array-call code to arch module

### DIFF
--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -14,6 +14,7 @@ mod vm;
 
 use crate::device_tree::DeviceTree;
 use crate::vm::VirtualAddress;
+use crate::wasm;
 pub use asid_allocator::AsidAllocator;
 use core::arch::asm;
 use riscv::sstatus::FS;
@@ -115,6 +116,29 @@ pub const NEXT_OLDER_FP_FROM_FP_OFFSET: usize = 0;
 /// Asserts that the frame pointer is sufficiently aligned for the platform.
 pub fn assert_fp_is_aligned(fp: VirtualAddress) {
     assert_eq!(fp.get() % 16, 0, "stack should always be aligned to 16");
+}
+
+/// Call the WASM array-call trampoline of the provided `func_ref`.
+pub unsafe fn array_call(
+    func_ref: &wasm::VMFuncRef,
+    callee: *mut wasm::VMContext,
+    caller: *mut wasm::VMContext,
+    args_results_ptr: *mut wasm::VMVal,
+    args_results_len: usize,
+) {
+    // Safety: caller has to ensure safety
+    unsafe {
+        sstatus::set_spp(sstatus::SPP::User);
+        riscv::sepc::set(func_ref.array_call as usize);
+        asm! {
+            "sret",
+            in("a0") callee,
+            in("a1") caller,
+            in("a2") args_results_ptr,
+            in("a3") args_results_len,
+            options(noreturn)
+        }
+    }
 }
 
 pub fn mb() {

--- a/kernel/src/wasm/func.rs
+++ b/kernel/src/wasm/func.rs
@@ -147,7 +147,7 @@ impl Func {
             tracing::debug!("jumping to WASM");
 
             // Safety: TODO
-            unsafe { func_ref.array_call(vmctx, vmctx, args_results_ptr, args_results_len) }
+            unsafe { arch::array_call(func_ref, vmctx, vmctx, args_results_ptr, args_results_len) }
         });
 
         tracing::trace!("returned from WASM {res:?}");
@@ -324,9 +324,7 @@ where
                     let storage = storage.cast::<VMVal>();
 
                     tracing::debug!("jumping to WASM");
-                    func_ref
-                        .as_ref()
-                        .array_call(vmctx, vmctx, storage, storage_len);
+                    arch::array_call(func_ref.as_ref(), vmctx, vmctx, storage, storage_len);
                 });
 
             tracing::trace!("returned from WASM {res:?}");

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -43,6 +43,7 @@ pub use linker::Linker;
 pub use memory::Memory;
 pub use module::Module;
 pub use runtime::{ConstExprEvaluator, InstanceAllocator};
+pub use runtime::{VMContext, VMFuncRef, VMVal};
 pub use store::Store;
 pub use table::Table;
 pub use translate::ModuleTranslator;

--- a/kernel/src/wasm/runtime/vmcontext.rs
+++ b/kernel/src/wasm/runtime/vmcontext.rs
@@ -297,30 +297,6 @@ pub struct VMFuncRef {
     pub type_index: VMSharedTypeIndex,
 }
 
-impl VMFuncRef {
-    pub unsafe fn array_call(
-        &self,
-        callee: *mut VMContext,
-        caller: *mut VMContext,
-        args_results_ptr: *mut VMVal,
-        args_results_len: usize,
-    ) {
-        // Safety: caller has to ensure safety
-        unsafe {
-            riscv::sstatus::set_spp(riscv::sstatus::SPP::User);
-            riscv::sepc::set(self.array_call as usize);
-            asm! {
-                "sret",
-                in("a0") callee,
-                in("a1") caller,
-                in("a2") args_results_ptr,
-                in("a3") args_results_len,
-                options(noreturn)
-            }
-        }
-    }
-}
-
 #[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct VMFunctionImport {


### PR DESCRIPTION
This change moves the details of calling the array-call trampoline to the `arch` module, since jumping to user mode is very architecture specific.