### PR TITLE
feat: allow configurable short backtrace

### DIFF
--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -233,7 +233,7 @@ impl<const MAX_FRAMES: usize> fmt::Display for Backtrace<'_, MAX_FRAMES> {
             writeln!(
                 f,
                 "note: Some details are omitted, \
-             run with `RUST_BACKTRACE=full` for a verbose backtrace."
+             run with `backtrace=full` bootarg for a verbose backtrace."
             )?;
         }
         if self.symbolize_ctx.is_none() {

--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -269,9 +269,7 @@ impl fmt::Display for UnknownBacktraceStyleError {
 
 impl core::error::Error for UnknownBacktraceStyleError {}
 
-/// Fixed frame used to clean the backtrace with `backtrace=short`. Note that
-/// this is only inline(never) when backtraces in std are enabled, otherwise
-/// it's fine to optimize away.
+/// Fixed frame used to clean the backtrace with `backtrace=short`.
 #[inline(never)]
 pub fn __rust_begin_short_backtrace<F, T>(f: F) -> T
 where
@@ -285,9 +283,7 @@ where
     result
 }
 
-/// Fixed frame used to clean the backtrace with `backtrace=short`. Note that
-/// this is only inline(never) when backtraces in std are enabled, otherwise
-/// it's fine to optimize away.
+/// Fixed frame used to clean the backtrace with `backtrace=short`.
 #[inline(never)]
 pub fn __rust_end_short_backtrace<F, T>(f: F) -> T
 where

--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -269,7 +269,7 @@ impl fmt::Display for UnknownBacktraceStyleError {
 
 impl core::error::Error for UnknownBacktraceStyleError {}
 
-/// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`. Note that
+/// Fixed frame used to clean the backtrace with `backtrace=short`. Note that
 /// this is only inline(never) when backtraces in std are enabled, otherwise
 /// it's fine to optimize away.
 #[inline(never)]
@@ -285,7 +285,7 @@ where
     result
 }
 
-/// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`. Note that
+/// Fixed frame used to clean the backtrace with `backtrace=short`. Note that
 /// this is only inline(never) when backtraces in std are enabled, otherwise
 /// it's fine to optimize away.
 #[inline(never)]

--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+mod print;
 mod symbolize;
 
+use crate::backtrace::print::BacktraceFmt;
 use crate::vm::VirtualAddress;
 use arrayvec::ArrayVec;
-use core::fmt::Formatter;
+use core::str::FromStr;
 use core::{fmt, slice};
 use fallible_iterator::FallibleIterator;
 use loader_api::BootInfo;
@@ -20,8 +22,8 @@ use unwind2::FrameIter;
 static BACKTRACE_INFO: OnceLock<BacktraceInfo> = OnceLock::new();
 
 #[cold]
-pub fn init(boot_info: &'static BootInfo) {
-    BACKTRACE_INFO.get_or_init(|| BacktraceInfo::new(boot_info));
+pub fn init(boot_info: &'static BootInfo, backtrace_style: BacktraceStyle) {
+    BACKTRACE_INFO.get_or_init(|| BacktraceInfo::new(boot_info, backtrace_style));
 }
 
 /// Information about the kernel required to build a backtrace
@@ -35,10 +37,31 @@ struct BacktraceInfo {
     /// The actual state required for converting addresses into symbols. This is *very* heavy to
     /// compute though, so we only construct it lazily in [`BacktraceInfo::symbolize_context`].
     symbolize_context: OnceLock<SymbolizeContext<'static>>,
+    backtrace_style: BacktraceStyle,
 }
 
+#[derive(Debug)]
+pub struct UnknownBacktraceStyleError;
+
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
+pub enum BacktraceStyle {
+    #[default]
+    Short,
+    Full,
+}
+
+#[derive(Clone)]
+pub struct Backtrace<'a, const MAX_FRAMES: usize> {
+    symbolize_ctx: Option<&'a SymbolizeContext<'static>>,
+    pub frames: ArrayVec<usize, MAX_FRAMES>,
+    pub frames_omitted: bool,
+    style: BacktraceStyle,
+}
+
+// === impl BacktraceInfo ===
+
 impl BacktraceInfo {
-    fn new(boot_info: &'static BootInfo) -> Self {
+    fn new(boot_info: &'static BootInfo, backtrace_style: BacktraceStyle) -> Self {
         BacktraceInfo {
             kernel_virt_base: boot_info.kernel_virt.start as u64,
             // Safety: we have to trust the loaders BootInfo here
@@ -58,6 +81,7 @@ impl BacktraceInfo {
                 )
             },
             symbolize_context: OnceLock::new(),
+            backtrace_style,
         }
     }
 
@@ -71,12 +95,7 @@ impl BacktraceInfo {
     }
 }
 
-#[derive(Clone)]
-pub struct Backtrace<'a, const MAX_FRAMES: usize> {
-    symbolize_ctx: Option<&'a SymbolizeContext<'static>>,
-    pub frames: ArrayVec<usize, MAX_FRAMES>,
-    pub frames_omitted: bool,
-}
+// === impl Backtrace ===
 
 impl<const MAX_FRAMES: usize> Backtrace<'_, MAX_FRAMES> {
     /// Captures a backtrace at the callsite of this function, returning an owned representation.
@@ -129,62 +148,126 @@ impl<const MAX_FRAMES: usize> Backtrace<'_, MAX_FRAMES> {
             symbolize_ctx: BACKTRACE_INFO.get().map(|info| info.symbolize_context()),
             frames,
             frames_omitted,
+            style: BACKTRACE_INFO
+                .get()
+                .map(|info| info.backtrace_style)
+                .unwrap_or_default(),
         })
     }
 }
 
 impl<const MAX_FRAMES: usize> fmt::Display for Backtrace<'_, MAX_FRAMES> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "stack backtrace:")?;
 
-        for (frame_idx, ip) in self.frames.iter().enumerate() {
+        let style = if f.alternate() {
+            BacktraceStyle::Full
+        } else {
+            self.style
+        };
+
+        let mut bt_fmt = BacktraceFmt::new(f, style);
+
+        let mut omitted_count: usize = 0;
+        let mut first_omit = true;
+        // If we're using a short backtrace, ignore all frames until we're told to start printing.
+        let mut print = style != BacktraceStyle::Short;
+
+        for ip in &self.frames {
+            let mut any = false; // did we print any symbols?
+
             // if the symbolication state isn't setup, yet we can't print symbols the addresses will have
             // to suffice...
             if let Some(symbolize_ctx) = self.symbolize_ctx {
                 let mut syms = symbolize_ctx.resolve_unsynchronized(*ip as u64).unwrap();
 
-                write!(f, "{frame_idx}: {address:#x}    -", address = ip)?;
-
-                let mut any = false; // did we print any symbols?
                 while let Some(sym) = syms.next().unwrap() {
                     any = true;
-                    if let Some(name) = sym.name() {
-                        writeln!(f, "      {name}")?;
-                    } else {
-                        writeln!(f, "      <unknown>")?;
-                    }
-                    if let Some(filename) = sym.filename() {
-                        write!(f, "      at {filename}")?;
-                        if let Some(lineno) = sym.lineno() {
-                            write!(f, ":{lineno}")?;
-                        } else {
-                            write!(f, "??")?;
+                    // `__rust_end_short_backtrace` means we are done hiding symbols
+                    // for now. Print until we see `__rust_begin_short_backtrace`.
+                    if style == BacktraceStyle::Short {
+                        if let Some(sym) = sym.name().map(|s| s.as_raw_str()) {
+                            if sym.contains("__rust_end_short_backtrace") {
+                                print = true;
+                                break;
+                            }
+                            if print && sym.contains("__rust_begin_short_backtrace") {
+                                print = false;
+                                break;
+                            }
+                            if !print {
+                                omitted_count += 1;
+                            }
                         }
-                        if let Some(colno) = sym.colno() {
-                            writeln!(f, ":{colno}")?;
-                        } else {
-                            writeln!(f, "??")?;
-                        }
                     }
-                }
-                if !any {
-                    writeln!(f, "      <unknown>")?;
+
+                    if print {
+                        if omitted_count > 0 {
+                            debug_assert!(style == BacktraceStyle::Short);
+                            // only print the message between the middle of frames
+                            if !first_omit {
+                                let _ = writeln!(
+                                    bt_fmt.formatter(),
+                                    "      [... omitted {} frame{} ...]",
+                                    omitted_count,
+                                    if omitted_count > 1 { "s" } else { "" }
+                                );
+                            }
+                            first_omit = false;
+                            omitted_count = 0;
+                        }
+                        bt_fmt.frame().print_symbol(*ip, sym)?;
+                    }
                 }
             } else {
-                writeln!(f, "{frame_idx}: {address:#x}", address = ip)?;
+                // no symbolize context always means no symbols
+                any = false;
+            }
+
+            if !any && print {
+                bt_fmt.frame().print_raw(*ip)?;
             }
         }
 
+        if style == BacktraceStyle::Short {
+            writeln!(
+                f,
+                "note: Some details are omitted, \
+             run with `RUST_BACKTRACE=full` for a verbose backtrace."
+            )?;
+        }
         if self.symbolize_ctx.is_none() {
-            let _ = writeln!(
+            writeln!(
                 f,
                 "note: backtrace subsystem wasn't initialized, no symbols were printed."
-            );
+            )?;
         }
 
         Ok(())
     }
 }
+
+// === impl BacktraceStyle ===
+
+impl FromStr for BacktraceStyle {
+    type Err = UnknownBacktraceStyleError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "short" => Ok(BacktraceStyle::Short),
+            "full" => Ok(BacktraceStyle::Full),
+            _ => Err(UnknownBacktraceStyleError),
+        }
+    }
+}
+
+impl fmt::Display for UnknownBacktraceStyleError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "unknown backtrace style")
+    }
+}
+
+impl core::error::Error for UnknownBacktraceStyleError {}
 
 /// Fixed frame used to clean the backtrace with `RUST_BACKTRACE=1`. Note that
 /// this is only inline(never) when backtraces in std are enabled, otherwise

--- a/kernel/src/backtrace/print.rs
+++ b/kernel/src/backtrace/print.rs
@@ -1,0 +1,184 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Printing of backtraces. This is adapted from the standard library.
+
+use crate::backtrace::BacktraceStyle;
+use crate::backtrace::symbolize::{Symbol, SymbolName};
+use core::fmt;
+
+const HEX_WIDTH: usize = 2 + 2 * size_of::<usize>();
+
+/// A formatter for backtraces.
+///
+/// This type can be used to print a backtrace regardless of where the backtrace
+/// itself comes from. If you have a `Backtrace` type then its `Debug`
+/// implementation already uses this printing format.
+pub struct BacktraceFmt<'a, 'b> {
+    fmt: &'a mut fmt::Formatter<'b>,
+    frame_index: usize,
+    format: BacktraceStyle,
+}
+impl<'a, 'b> BacktraceFmt<'a, 'b> {
+    /// Create a new `BacktraceFmt` which will write output to the provided
+    /// `fmt`.
+    ///
+    /// The `format` argument will control the style in which the backtrace is
+    /// printed, and the `print_path` argument will be used to print the
+    /// `BytesOrWideString` instances of filenames. This type itself doesn't do
+    /// any printing of filenames, but this callback is required to do so.
+    pub fn new(fmt: &'a mut fmt::Formatter<'b>, format: BacktraceStyle) -> Self {
+        BacktraceFmt {
+            fmt,
+            frame_index: 0,
+            format,
+        }
+    }
+
+    /// Adds a frame to the backtrace output.
+    ///
+    /// This commit returns an RAII instance of a `BacktraceFrameFmt` which can be used
+    /// to actually print a frame, and on destruction it will increment the
+    /// frame counter.
+    pub fn frame(&mut self) -> BacktraceFrameFmt<'_, 'a, 'b> {
+        BacktraceFrameFmt {
+            fmt: self,
+            symbol_index: 0,
+        }
+    }
+
+    /// Return the inner formatter.
+    ///
+    /// This is used for writing custom information between frames with `write!` and `writeln!`,
+    /// and won't increment the `frame_index` unlike the `frame` method.
+    pub fn formatter(&mut self) -> &mut fmt::Formatter<'b> {
+        self.fmt
+    }
+}
+
+/// A formatter for just one frame of a backtrace.
+///
+/// This type is created by the `BacktraceFmt::frame` function.
+pub struct BacktraceFrameFmt<'fmt, 'a, 'b> {
+    fmt: &'fmt mut BacktraceFmt<'a, 'b>,
+    symbol_index: usize,
+}
+
+impl BacktraceFrameFmt<'_, '_, '_> {
+    /// Prints a symbol with this frame formatter.
+    pub fn print_symbol(&mut self, frame_ip: usize, sym: Symbol<'_>) -> fmt::Result {
+        self.print_raw_with_column(
+            frame_ip,
+            sym.name(),
+            sym.filename(),
+            sym.lineno(),
+            sym.colno(),
+        )
+    }
+
+    /// Print a raw (read un-symbolized) address with this frame formatter. A raw address
+    /// will just show up as the address and `<unknown>` and should be used in places where we
+    /// couldn't find any symbol information for an address.
+    pub fn print_raw(&mut self, frame_ip: usize) -> fmt::Result {
+        self.print_raw_with_column(frame_ip, None, None, None, None)
+    }
+
+    fn print_raw_with_column(
+        &mut self,
+        frame_ip: usize,
+        symbol_name: Option<SymbolName<'_>>,
+        filename: Option<&str>,
+        lineno: Option<u32>,
+        colno: Option<u32>,
+    ) -> fmt::Result {
+        self.print_raw_generic(frame_ip, symbol_name, filename, lineno, colno)?;
+        self.symbol_index += 1;
+        Ok(())
+    }
+
+    // #[allow(unused_mut)]
+    fn print_raw_generic(
+        &mut self,
+        frame_ip: usize,
+        symbol_name: Option<SymbolName<'_>>,
+        filename: Option<&str>,
+        lineno: Option<u32>,
+        colno: Option<u32>,
+    ) -> fmt::Result {
+        // No need to print "null" frames, it basically just means that the
+        // system backtrace was a bit eager to trace back super far.
+        if let BacktraceStyle::Short = self.fmt.format {
+            if frame_ip == 0 {
+                return Ok(());
+            }
+        }
+
+        // Print the index of the frame as well as the optional instruction
+        // pointer of the frame. If we're beyond the first symbol of this frame
+        // though we just print appropriate whitespace.
+        if self.symbol_index == 0 {
+            write!(self.fmt.fmt, "{:4}: ", self.fmt.frame_index)?;
+
+            // Print the instruction pointer. If the symbol name is None we always print
+            // the address. Those weird frames don't happen that often and are always the most
+            // interesting in a backtrace, so we need to make sure to print at least the address so
+            // we have somewhere to start investigating!
+            if self.fmt.format == BacktraceStyle::Full || symbol_name.is_some() {
+                write!(self.fmt.fmt, "{frame_ip:HEX_WIDTH$x?} - ")?;
+            }
+        } else {
+            write!(self.fmt.fmt, "      ")?;
+            if let BacktraceStyle::Full = self.fmt.format {
+                write!(self.fmt.fmt, "{:1$}", "", HEX_WIDTH + 3)?;
+            }
+        }
+
+        // Next up write out the symbol name, using the alternate formatting for
+        // more information if we're a full backtrace. Here we also handle
+        // symbols which don't have a name,
+        match (symbol_name, &self.fmt.format) {
+            (Some(name), BacktraceStyle::Short) => write!(self.fmt.fmt, "{name:#}")?,
+            (Some(name), BacktraceStyle::Full) => write!(self.fmt.fmt, "{name}")?,
+            (None, _) => write!(self.fmt.fmt, "<unknown>")?,
+        }
+        self.fmt.fmt.write_str("\n")?;
+
+        // And last up, print out the filename/line number if they're available.
+        if let (Some(file), Some(line)) = (filename, lineno) {
+            self.print_fileline(file, line, colno)?;
+        }
+
+        Ok(())
+    }
+
+    fn print_fileline(&mut self, file: &str, line: u32, colno: Option<u32>) -> fmt::Result {
+        // Filename/line are printed on lines under the symbol name, so print
+        // some appropriate whitespace to sort of right-align ourselves.
+        if let BacktraceStyle::Full = self.fmt.format {
+            write!(self.fmt.fmt, "{:1$}", "", HEX_WIDTH)?;
+        }
+        write!(self.fmt.fmt, "             at ")?;
+
+        // Print the filename and line number.
+        write!(self.fmt.fmt, "at {file}")?;
+        write!(self.fmt.fmt, ":{line}")?;
+
+        // Add column number, if available.
+        if let Some(colno) = colno {
+            write!(self.fmt.fmt, ":{colno}")?;
+        }
+
+        writeln!(self.fmt.fmt)?;
+        Ok(())
+    }
+}
+
+impl Drop for BacktraceFrameFmt<'_, '_, '_> {
+    fn drop(&mut self) {
+        self.fmt.frame_index += 1;
+    }
+}

--- a/kernel/src/bootargs.rs
+++ b/kernel/src/bootargs.rs
@@ -5,6 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::backtrace::BacktraceStyle;
 use crate::device_tree::DeviceTree;
 use crate::error::Error;
 use crate::tracing::Filter;
@@ -22,6 +23,7 @@ pub fn parse(devtree: &DeviceTree) -> Result<Bootargs, Error> {
 #[derive(Default)]
 pub struct Bootargs {
     pub log: Filter,
+    pub backtrace: BacktraceStyle,
 }
 
 impl FromStr for Bootargs {
@@ -29,14 +31,22 @@ impl FromStr for Bootargs {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut log = None;
+        let mut backtrace = None;
 
-        let s = s.trim();
-        if let Some(current) = s.strip_prefix("log=") {
-            log = Some(Filter::from_str(current).unwrap());
+        let parts = s.trim().split(',');
+        for part in parts {
+            if let Some(current) = part.strip_prefix("log=") {
+                log = Some(Filter::from_str(current).unwrap());
+            }
+
+            if let Some(current) = part.strip_prefix("backtrace=") {
+                backtrace = Some(BacktraceStyle::from_str(current).unwrap());
+            }
         }
 
         Ok(Self {
             log: log.unwrap_or_default(),
+            backtrace: backtrace.unwrap_or_default(),
         })
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -138,17 +138,17 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         // initializing the global allocator
         allocator::init(&mut boot_alloc, boot_info);
 
-        // initialize the backtracing subsystem after the allocator has been set up
-        // since setting up the symbolization context requires allocation
-        backtrace::init(boot_info);
-
         let devtree = device_tree::init(fdt).unwrap();
         tracing::debug!("{devtree:?}");
 
-        let cmdline = bootargs::parse(devtree).unwrap();
+        let bootargs = bootargs::parse(devtree).unwrap();
+
+        // initialize the backtracing subsystem after the allocator has been set up
+        // since setting up the symbolization context requires allocation
+        backtrace::init(boot_info, bootargs.backtrace);
 
         // fully initialize the tracing subsystem now that we can allocate
-        tracing::init(cmdline.log);
+        tracing::init(bootargs.log);
 
         // perform global, architecture-specific initialization
         arch::init_early();


### PR DESCRIPTION
This PR adds configurable support for shorter backtraces. Shorter backtraces only print symbols between the `__rust_begin_short_backtrace` and `__rust_end_short_backtrace` frames cutting out the quite verbose frames related to unwinding and backtracing itself.

This behavior can be configured through a boot argument like so `backtrace=short` for short (the new default) backtraces and `backtrace=full` for more verbose full backtraces.

Use with QEMU like so `just run "" --append "backtrace=full"`