### PR TITLE
fix: bootargs separator

### DIFF
--- a/kernel/src/bootargs.rs
+++ b/kernel/src/bootargs.rs
@@ -33,7 +33,7 @@ impl FromStr for Bootargs {
         let mut log = None;
         let mut backtrace = None;
 
-        let parts = s.trim().split(',');
+        let parts = s.trim().split(';');
         for part in parts {
             if let Some(current) = part.strip_prefix("log=") {
                 log = Some(Filter::from_str(current).unwrap());

--- a/manual/src/building/boot-args.md
+++ b/manual/src/building/boot-args.md
@@ -4,7 +4,7 @@ Boot arguments configure various aspects of the kernels behaviour. They read fro
 [`/chosen/bootargs`](https://devicetree-specification.readthedocs.io/en/stable/devicenodes.html#chosen-node) property of the
 flattened device tree that is passed to the kernel by the previous stage bootloader.
 
-The format follows a simple `key=value,key=value,..` list of comma separated of key-value pairs.
+The format is a simple `key=value;key=value;..` list of semicolon separated of key-value pairs.
 
 ## `log`
 


### PR DESCRIPTION
The previous bootargs separator `,` conflicted with the separator for log arguments which isn't great. This PR changes the bootargs separator to `;`.