### PR TITLE
fix: correctly check for overlapping memory regions

### DIFF
--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -313,7 +313,10 @@ fn allocatable_memory_regions(
                 continue;
             }
 
-            assert!(!other.contains(&region.start) && !other.contains(&region.end));
+            assert!(
+                !other.contains(&region.start) && !other.contains(&(region.end - 1)),
+                "regions {region:#x?} and {other:#x?} overlap"
+            );
         }
     }
 


### PR DESCRIPTION
range ends are actually *exclusive* this fixes a debug assert that was incorrectly assuming the ends are inclusive