### PR TITLE
fix: correctly select arena regions

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -131,6 +131,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         // initialize a simple bump allocator for allocating memory before our virtual memory subsystem
         // is available
         let allocatable_memories = allocatable_memory_regions(boot_info);
+        tracing::info!("allocatable memories: {:?}", allocatable_memories);
         let mut boot_alloc = BootstrapAllocator::new(&allocatable_memories);
 
         // initializing the global allocator

--- a/kernel/src/mem/bootstrap_alloc.rs
+++ b/kernel/src/mem/bootstrap_alloc.rs
@@ -63,7 +63,7 @@ impl<'a> BootstrapAllocator<'a> {
                 // memory is not available yet. So we rather waste some memory than outright crash.
                 if region.size() - offset < requested_size {
                     tracing::warn!(
-                        "Skipped memory region {region:?} since it was fulfill request for {requested_size} bytes. Wasted {} bytes in the process...",
+                        "Skipped memory region {region:?} since it was too small to fulfill request for {requested_size} bytes. Wasted {} bytes in the process...",
                         region.size() - offset
                     );
 

--- a/kernel/src/mem/frame_alloc/mod.rs
+++ b/kernel/src/mem/frame_alloc/mod.rs
@@ -73,12 +73,16 @@ impl FrameAllocator {
         let mut max_alignment = arch::PAGE_SIZE;
         let mut arenas = Vec::new();
 
-        let phys_regions = boot_alloc.free_regions().chain(iter::once(fdt_region));
+        let phys_regions = boot_alloc
+            .free_regions()
+            .chain(iter::once(fdt_region))
+            .collect();
         for selection_result in select_arenas(phys_regions).iterator() {
             match selection_result {
                 Ok(selection) => {
                     tracing::trace!("selection {selection:?}");
                     let arena = Arena::from_selection(selection);
+                    tracing::trace!("max arena alignment {}", arena.max_alignment());
                     max_alignment = cmp::max(max_alignment, arena.max_alignment());
                     arenas.push(arena);
                 }

--- a/loader/src/frame_alloc.rs
+++ b/loader/src/frame_alloc.rs
@@ -100,7 +100,7 @@ impl<'a> FrameAllocator<'a> {
                 // memory is not available yet. So we rather waste some memory than outright crash.
                 if region_size - offset < requested_size {
                     log::warn!(
-                        "Skipped memory region {region:?} since it was fulfill request for {requested_size} bytes. Wasted {} bytes in the process...",
+                        "Skipped memory region {region:?} since it was too small to fulfill request for {requested_size} bytes. Wasted {} bytes in the process...",
                         region_size - offset
                     );
 


### PR DESCRIPTION
This PR fixes two issues with the arena selection code:
1. When finding a hole to unsuitably large we previously just forgot about the candidate region, essentially wasting it completely. This PR allocates an intermediate vec for all candidates and pushes unsuitable candidates back into that list.
2. the region bounds adjustment code would override itself so that essentially a higher candidate region would completely override the previous arena bounds, essentially wasting the previous lower region