### PR TITLE
fix: correctly pop all values from const eval stack

### DIFF
--- a/kernel/src/wasm/vm/const_eval.rs
+++ b/kernel/src/wasm/vm/const_eval.rs
@@ -316,10 +316,10 @@ impl ConstExprEvaluator {
             log::trace!("const expr evaluated to {:?}", self.stack[0]);
             Ok(self.stack.pop().unwrap())
         } else {
-            bail!(
-                "const expr evaluation error: expected 1 resulting value, found {}",
-                self.stack.len()
-            )
+            let len = self.stack.len();
+            // we need to correctly clear the stack here for the next time we try to use the const eval
+            self.stack.clear();
+            bail!("const expr evaluation error: expected 1 resulting value, found {len}",)
         }
     }
 

--- a/kernel/src/wasm/vm/const_eval.rs
+++ b/kernel/src/wasm/vm/const_eval.rs
@@ -314,7 +314,7 @@ impl ConstExprEvaluator {
 
         if self.stack.len() == 1 {
             log::trace!("const expr evaluated to {:?}", self.stack[0]);
-            Ok(self.stack[0])
+            Ok(self.stack.pop().unwrap())
         } else {
             bail!(
                 "const expr evaluation error: expected 1 resulting value, found {}",


### PR DESCRIPTION
The const eval stack allocation gets reused, so we need to make sure to correctly pop all values from it.