### PR TITLE
fix: remove assert in zero frame provider

### DIFF
--- a/kernel/src/mem/provider.rs
+++ b/kernel/src/mem/provider.rs
@@ -86,10 +86,6 @@ impl Provider for TheZeroFrame {
     }
 
     fn free_frame(&self, frame: Frame) {
-        debug_assert!(
-            Frame::ptr_eq(&frame, self.frame()),
-            "attempted to free unrelated frame with the zero frame provider"
-        );
         drop(frame);
     }
 


### PR DESCRIPTION
This fixe removes an incorrect assertion in the zero frame provider. When cloning the zero page into a writable, it receives a different identity, but was still provided by the provider, so freeing using should work too.