### PR TITLE
fix: regression of IRQ wakeup

### DIFF
--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -309,6 +309,7 @@ extern "C-unwind" fn default_trap_handler(
             Trap::Interrupt(Interrupt::SupervisorExternal) => with_cpu(|cpu| {
                 let mut plic = cpu.plic.borrow_mut();
                 irq::trigger_irq(plic.deref_mut());
+                scheduler().idle.notify_self();
             }),
             Trap::Exception(
                 Exception::LoadPageFault

--- a/kernel/src/irq.rs
+++ b/kernel/src/irq.rs
@@ -42,12 +42,13 @@ pub fn trigger_irq(irq_ctl: &mut dyn InterruptController) {
         return;
     };
 
+    // acknowledge the interrupt as fast as possible
+    irq_ctl.irq_complete(claim);
+
     let queues = QUEUES.read();
     if let Some(queue) = queues.get(&claim.as_u32()) {
         queue.wake_all();
     }
-
-    irq_ctl.irq_complete(claim);
 }
 
 pub async fn next_event(irq_num: u32) -> Result<(), sync::Closed> {

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -122,7 +122,7 @@ pub struct Scheduler {
     /// All tasks currently scheduled on this runtime
     owned: OwnedTasks,
     /// Coordinates idle workers
-    idle: Idle,
+    pub idle: Idle,
     /// Signal to workers that they should be shutting down.
     shutdown: AtomicBool,
     /// Spin barrier used to synchronize shutdown between workers,


### PR DESCRIPTION
This fixes a regression in the IRQ handling introduced by 429b5c4556416ec79e0ad1c86a3423b7c58d1d72 where cores would treat all IRQs as spurious wakeups