### PR TITLE
fix: CPU wakeup regression

### DIFF
--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -309,7 +309,6 @@ extern "C-unwind" fn default_trap_handler(
             Trap::Interrupt(Interrupt::SupervisorExternal) => with_cpu(|cpu| {
                 let mut plic = cpu.plic.borrow_mut();
                 irq::trigger_irq(plic.deref_mut());
-                scheduler().idle.notify_self();
             }),
             Trap::Exception(
                 Exception::LoadPageFault

--- a/kernel/src/scheduler/idle.rs
+++ b/kernel/src/scheduler/idle.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::CPUID;
-use crate::scheduler::park::{ParkToken, UnparkToken};
+use crate::arch;
 use alloc::vec::Vec;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use spin::Mutex;
@@ -21,7 +20,7 @@ pub struct Idle {
     /// Total number of cores
     num_cores: usize,
     /// Worker IDs that are currently sleeping
-    sleepers: Mutex<Vec<UnparkToken>>,
+    sleepers: Mutex<Vec<usize>>,
 }
 
 pub(crate) struct IdleMap {
@@ -43,7 +42,7 @@ impl Idle {
         self.num_searching.load(Ordering::Acquire)
     }
 
-    pub fn transition_worker_to_waiting(&self, worker: &super::Worker) -> ParkToken {
+    pub fn transition_worker_to_waiting(&self, worker: &super::Worker) {
         // tracing::trace!("Idle::transition_worker_to_waiting");
 
         // The worker should not be stealing at this point
@@ -57,10 +56,7 @@ impl Idle {
         let prev = self.num_idle.fetch_add(1, Ordering::Release);
         debug_assert!(prev < self.num_cores);
 
-        let park = ParkToken::new(worker.cpuid);
-        self.sleepers.lock().push(park.clone().into_unpark());
-
-        park
+        self.sleepers.lock().push(worker.cpuid);
     }
 
     pub fn transition_worker_from_waiting(&self, worker: &super::Worker) {
@@ -74,7 +70,7 @@ impl Idle {
 
         self.sleepers
             .lock()
-            .retain(|sleeper| sleeper.cpuid() != worker.cpuid);
+            .retain(|sleeper| *sleeper != worker.cpuid);
     }
 
     pub fn try_transition_worker_to_searching(&self, worker: &mut super::Worker) {
@@ -109,28 +105,21 @@ impl Idle {
     pub fn notify_one(&self) {
         // tracing::trace!("Idle::notify_one");
         if let Some(worker) = self.sleepers.lock().pop() {
-            worker.unpark();
+            // Safety: the worker placed itself into the sleepers list, so sending a wakeup is safe
+            unsafe {
+                arch::cpu_unpark(worker);
+            }
         }
     }
 
     pub fn notify_all(&self) {
         // tracing::trace!("Idle::notify_all");
         while let Some(worker) = self.sleepers.lock().pop() {
-            worker.unpark();
+            // Safety: the worker placed itself into the sleepers list, so sending a wakeup is safe
+            unsafe {
+                arch::cpu_unpark(worker);
+            }
         }
-    }
-
-    // FIXME this implementation is baaaad, especially because its run from a trap handler
-    //  it would be much better to use cpu_local storage for this
-    pub fn notify_self(&self) {
-        let cpuid = CPUID.get();
-        let mut sleepers = self.sleepers.lock();
-        let index = sleepers
-            .iter()
-            .position(|worker| worker.cpuid() == cpuid)
-            .unwrap();
-        let worker = sleepers.remove(index);
-        worker.unpark();
     }
 }
 

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -72,7 +72,7 @@ use crate::mem::with_kernel_aspace;
 use crate::scheduler::idle::Idle;
 use crate::scheduler::park::ParkToken;
 use crate::scheduler::queue::Overflow;
-use crate::task;
+use crate::{arch, task};
 use crate::task::{JoinHandle, OwnedTasks, PollResult, Schedule, TaskRef};
 use crate::time::Timer;
 use crate::util::fast_rand::FastRand;
@@ -122,7 +122,7 @@ pub struct Scheduler {
     /// All tasks currently scheduled on this runtime
     owned: OwnedTasks,
     /// Coordinates idle workers
-    pub idle: Idle,
+    idle: Idle,
     /// Signal to workers that they should be shutting down.
     shutdown: AtomicBool,
     /// Spin barrier used to synchronize shutdown between workers,
@@ -348,8 +348,11 @@ impl Worker {
 
             // if we have no tasks to run, we can sleep until an interrupt
             // occurs.
-            let park = self.scheduler.idle.transition_worker_to_waiting(self);
-            park.park();
+            self.scheduler.idle.transition_worker_to_waiting(self);
+            // Safety: TODO
+            unsafe {
+                arch::cpu_park();
+            }
 
             self.scheduler.idle.transition_worker_from_waiting(self);
         }
@@ -358,6 +361,8 @@ impl Worker {
     }
 
     fn run_task(&mut self, task: TaskRef) {
+        tracing::trace!("Running task {:?}", task);
+        
         // Make sure the worker is not in the **searching** state. This enables
         // another idle worker to try to steal work.
         if self.transition_from_searching() {

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -72,10 +72,10 @@ use crate::mem::with_kernel_aspace;
 use crate::scheduler::idle::Idle;
 use crate::scheduler::park::ParkToken;
 use crate::scheduler::queue::Overflow;
-use crate::{arch, task};
 use crate::task::{JoinHandle, OwnedTasks, PollResult, Schedule, TaskRef};
 use crate::time::Timer;
 use crate::util::fast_rand::FastRand;
+use crate::{arch, task};
 use core::any::type_name;
 use core::cell::{Ref, RefCell};
 use core::future::Future;
@@ -362,7 +362,7 @@ impl Worker {
 
     fn run_task(&mut self, task: TaskRef) {
         tracing::trace!("Running task {:?}", task);
-        
+
         // Make sure the worker is not in the **searching** state. This enables
         // another idle worker to try to steal work.
         if self.transition_from_searching() {


### PR DESCRIPTION
This PR fixes a regression in the `scheduler/park` code which would cause tasks to not be woken after timers or interrupts. While it would be great to use this in the future, I can't figure out the exact details of how to correctly do it right now