### PR TITLE
feat: fiber future

### DIFF
--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -88,6 +88,7 @@ use cpu_local::cpu_local;
 use rand::RngCore;
 use spin::{Backoff, Barrier, OnceLock};
 
+pub use yield_now::yield_now;
 const DEFAULT_GLOBAL_QUEUE_INTERVAL: u32 = 61;
 
 static SCHEDULER: OnceLock<Scheduler> = OnceLock::new();


### PR DESCRIPTION
This implements an adapter for the `Fiber` primitive that makes it behave as a `Future` which can then be used to be spawned onto the scheduler