### PR TITLE
feat: introduce xtask build system

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -40,10 +55,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
 
 [[package]]
 name = "anyhow"
@@ -58,6 +117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,13 +137,28 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 name = "backtrace"
 version = "0.1.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "arrayvec",
  "fallible-iterator",
  "gimli",
  "rustc-demangle",
  "unwind2",
  "xmas-elf",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line 0.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
 ]
 
 [[package]]
@@ -180,6 +265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -188,8 +274,22 @@ version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -197,6 +297,39 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e1761c0e16f8883bbbb8ce5990867f4f06bf11a0253da6495a04ce4b6ef0ec"
+dependencies = [
+ "backtrace 0.3.74",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ddd8d5bfda1e11a501d0a7303f3bfed9aa632ebdb859be40d0fd70478ed70d5"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core 0.1.33",
+ "tracing-error",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "cpu-local"
@@ -445,6 +578,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,6 +759,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,15 +925,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.5.0",
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -810,7 +1003,7 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
- "addr2line",
+ "addr2line 0.24.2",
  "anyhow",
  "arrayvec",
  "bitflags",
@@ -1006,6 +1199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mpsc-queue"
 version = "0.1.0"
 dependencies = [
@@ -1054,6 +1256,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,7 +1293,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -1094,6 +1305,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "percent-encoding"
@@ -1427,6 +1644,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1821,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml-patch"
+version = "0.1.0"
+dependencies = [
+ "eyre",
+ "indoc",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1914,16 @@ dependencies = [
 name = "tracing-core"
 version = "0.2.0"
 source = "git+https://github.com/tokio-rs/tracing?branch=master#7a3ddfb02ac9b6e6f9c6bbe75feac2f2f3af91df"
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing 0.1.41",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "tracing-log"
@@ -1722,6 +2008,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
@@ -2087,6 +2379,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,6 +2415,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18245fcbb8b3de8dd198ce7944fdd4096986fd6cd306b0fcfa27df817bd545d6"
 dependencies = [
  "zero",
+]
+
+[[package]]
+name = "xtask"
+version = "0.1.0"
+dependencies = [
+ "atty",
+ "clap",
+ "color-eyre",
+ "indexmap",
+ "serde",
+ "toml",
+ "toml-patch",
+ "toml_edit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["kernel", "libs/*", "loader", "loader/api", "libs/ktest/macros"]
+members = ["kernel", "libs/*", "build/*", "loader", "loader/api", "libs/ktest/macros"]
 resolver = "2"
 
 [workspace.package]
@@ -138,6 +138,14 @@ wasmtime-slab = "31.0.0"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
+color-eyre = "0.6.3"
+eyre = "0.6.12"
+clap = { version = "4.2.7", features = ["derive", "env"] }
+serde = { version = "1.0.219", features = ["derive"] }
+toml = "0.8.20"
+indexmap = { version = "2.9.0", features = ["serde"] }
+toml_edit = "0.22.24"
+indoc = "2.0.6"
 
 [profile.release]
 debug = "limited" # The kernel should be able to print stack traces of itself even in release mode

--- a/build/toml-patch/Cargo.toml
+++ b/build/toml-patch/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "toml-patch"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+eyre.workspace = true
+toml_edit.workspace = true
+
+[dev-dependencies]
+indoc.workspace = true
+
+[lints]
+workspace = true

--- a/build/toml-patch/src/lib.rs
+++ b/build/toml-patch/src/lib.rs
@@ -1,0 +1,474 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Implements patching of TOML documents
+//!
+//! The `toml_edit` crate is great, but it has a major limitation: tables are
+//! ordered with a global `position`.  This means that to insert a new table,
+//! you have to shift everything after that table downwards, and adjust relative
+//! positions within the new table.
+//!
+//! This crate exposes a single function [`merge_toml_documents`] which does
+//! this for you!
+
+use eyre::{Result, bail, eyre};
+use std::collections::BTreeMap;
+use toml_edit::{visit::Visit, visit_mut::VisitMut};
+
+pub fn merge_toml_documents(
+    original: &mut toml_edit::DocumentMut,
+    mut patches: toml_edit::DocumentMut,
+) -> Result<()> {
+    // Find offsets where we need to insert gaps for incoming patches
+    let mut offsets = BTreeMap::new();
+    compute_offsets(original, &patches, &mut offsets)?;
+
+    // Convert from single to cumulative offsets.  Since this is in a BTreeMap,
+    // it's already sorted, so we accumulate in a single pass.
+    let mut sum = 0;
+    for i in offsets.values_mut() {
+        let prev = *i;
+        *i += sum;
+        sum += prev;
+    }
+
+    // Apply offsets, adding gaps to the original document
+    let mut visitor = OffsetVisitor { offsets: &offsets };
+    visitor.visit_document_mut(original);
+
+    // Now that we've opened up gaps, we can splice in the new data
+    merge_toml_tables(original.as_table_mut(), &mut patches)
+}
+
+/// Computes offsets that will be applied when `patches` is merged
+///
+/// Values are accumulated into `offsets`
+fn compute_offsets(
+    original: &toml_edit::Table,
+    patches: &toml_edit::Table,
+    offsets: &mut BTreeMap<usize, usize>,
+) -> Result<()> {
+    for (k, v) in patches.iter() {
+        if let Some(u) = original.get(k) {
+            if u.type_name() != v.type_name() {
+                bail!(
+                    "type mismatch for '{k}': {} != {}",
+                    u.type_name(),
+                    v.type_name()
+                );
+            }
+            use toml_edit::Item;
+            match u {
+                Item::None | Item::Value(..) => (),
+                Item::Table(u) => {
+                    // Recurse!
+                    compute_offsets(u, v.as_table().unwrap(), offsets)?;
+                }
+                Item::ArrayOfTables(..) => {
+                    let mut visitor = TableRangeVisitor::default();
+                    visitor.visit_item(u);
+                    let range_in = visitor
+                        .range
+                        .ok_or_else(|| eyre!("cannot append to an empty array of tables"))?;
+
+                    // Find the range spanned by the incoming tables, which will
+                    // be appended to the list `u`
+                    let mut visitor = TableRangeVisitor::default();
+                    visitor.visit_item(v);
+                    let patch_span = visitor
+                        .range
+                        .ok_or_else(|| eyre!("cannot append empty array of tables"))?;
+
+                    // Record the shift here
+                    offsets.insert(range_in.end, patch_span.len());
+                }
+            }
+        } else {
+            // We are going to insert our new values after all of the old values
+            //
+            // First, we need to find the maximum position in our original table
+            let mut visitor = TableRangeVisitor::default();
+            visitor.visit_table(original);
+            let last = visitor.range.map(|r| r.end).unwrap_or_default();
+
+            // We'll be applying an offset based on the size of the incoming
+            // list of patches (in table positions)
+            let mut visitor = TableRangeVisitor::default();
+            visitor.visit_table(patches);
+            if let Some(r) = visitor.range {
+                offsets.insert(last + 1, r.len());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Accumulates the full range of table positions
+#[derive(Default)]
+struct TableRangeVisitor {
+    range: Option<std::ops::Range<usize>>,
+}
+
+impl<'doc> Visit<'doc> for TableRangeVisitor {
+    fn visit_table(&mut self, t: &'doc toml_edit::Table) {
+        if let Some(pos) = t.position() {
+            self.range = Some(match self.range.take() {
+                Some(r) => r.start.min(pos)..r.end.max(pos + 1),
+                None => pos..pos + 1,
+            });
+        }
+        // call the default implementation to recurse
+        self.visit_table_like(t);
+    }
+}
+
+/// Applies an offset to every table position
+#[derive(Default)]
+struct TableShiftVisitor {
+    offset: isize,
+}
+
+impl VisitMut for TableShiftVisitor {
+    fn visit_table_mut(&mut self, t: &mut toml_edit::Table) {
+        if let Some(pos) = t.position() {
+            let pos: isize = pos.try_into().unwrap();
+            t.set_position((pos + self.offset).try_into().unwrap())
+        }
+        // call the default implementation to recurse
+        self.visit_table_like_mut(t);
+    }
+}
+
+/// Applies an offset that varies based on table position
+struct OffsetVisitor<'a> {
+    /// Map from position in original table to offset
+    ///
+    /// This is a sparse map containing **cumulative** offsets.
+    ///
+    /// The offset at position `i` is `self.offsets[j]`, where `j` is the
+    /// largest key such that `j <= i`.
+    offsets: &'a BTreeMap<usize, usize>,
+}
+
+impl<'a> VisitMut for OffsetVisitor<'a> {
+    fn visit_table_mut(&mut self, t: &mut toml_edit::Table) {
+        if let Some(pos) = t.position() {
+            // Find the largest offset with a value <= pos, which determines
+            // the cumulative offset at this point in the document.
+            //
+            // If `pos` is _before_ the first offset in the table, then return a
+            // base case with no offset, i.e. (0, 0)
+            let (prev_pos, offset) = self.offsets.range(0..=pos).next_back().unwrap_or((&0, &0));
+            assert!(*prev_pos <= pos); // sanity-checking
+            t.set_position(offset + pos);
+        }
+        self.visit_table_like_mut(t);
+    }
+}
+
+/// Merges a pair of TOML tables
+///
+/// The incoming `patches` table is modified during execution to put its
+/// position at the end of the original table.
+///
+/// When this function is called, `original` must include gaps for `patches`
+fn merge_toml_tables(
+    original: &mut toml_edit::Table,
+    patches: &mut toml_edit::Table,
+) -> Result<()> {
+    for (k, v) in patches.iter_mut() {
+        if let Some(u) = original.get_mut(k.get()) {
+            assert_eq!(u.type_name(), v.type_name()); // already checked
+            use toml_edit::Item;
+            match u {
+                Item::None => bail!("can't patch `None`"),
+                Item::Value(u) => {
+                    // I'm not sure whether it's possible for the Item
+                    // type_name to match and Value type_name to *not*
+                    // match, but better safe than sorry here.
+                    let v = v.as_value().unwrap();
+                    if u.type_name() != v.type_name() {
+                        bail!(
+                            "type mismatch for '{k}': {} != {}",
+                            u.type_name(),
+                            v.type_name()
+                        );
+                    }
+
+                    use toml_edit::Value;
+                    match u {
+                        // Single values replace the previous value
+                        Value::Float(..)
+                        | Value::String(..)
+                        | Value::Integer(..)
+                        | Value::Boolean(..)
+                        | Value::Datetime(..) => *u = v.clone(),
+
+                        // Inline tables are not yet supported, but should be
+                        // merged once we get around to implementing it
+                        Value::InlineTable(..) => {
+                            bail!("patching inline tables is not yet implemented");
+                        }
+                        // Arrays are extended
+                        Value::Array(u) => {
+                            u.extend(v.as_array().unwrap().iter().cloned());
+                        }
+                    }
+                }
+                Item::Table(u) => {
+                    // Recurse!
+                    merge_toml_tables(u, v.as_table_mut().unwrap())?;
+                }
+                Item::ArrayOfTables(arr) => {
+                    // Compute an offset based on table position
+                    let mut visitor = TableRangeVisitor::default();
+                    visitor.visit_array_of_tables(arr);
+                    let range_in = visitor.range.unwrap();
+                    let last = range_in.end;
+
+                    let mut visitor = TableRangeVisitor::default();
+                    visitor.visit_item(v);
+                    let start = visitor.range.map(|r| r.start as isize).unwrap();
+                    let offset = last as isize - start;
+
+                    // Apply that offset to the incoming tables
+                    let mut visitor = TableShiftVisitor { offset };
+                    visitor.visit_item_mut(v);
+
+                    // Merge by extending the table array
+                    arr.extend(v.as_array_of_tables().unwrap().iter().cloned());
+                }
+            }
+        } else {
+            let mut visitor = TableRangeVisitor::default();
+            visitor.visit_table(original);
+            let last = visitor.range.map(|r| r.end).unwrap_or_default();
+
+            let mut visitor = TableRangeVisitor::default();
+            visitor.visit_item(v);
+            let start = visitor.range.map(|r| r.start as isize).unwrap_or(0);
+            let offset = last as isize - start;
+
+            // Apply that offset to the incoming tables
+            let mut visitor = TableShiftVisitor { offset };
+            visitor.visit_item_mut(v);
+
+            // Merge by inserting the new element
+            original.insert(k.get(), v.clone());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    fn patch_and_compare(a: &str, b: &str, out: &str) {
+        let mut a: toml_edit::DocumentMut = a.parse().unwrap();
+        let b = b.parse().unwrap();
+        merge_toml_documents(&mut a, b).unwrap();
+        if a.to_string() != out {
+            eprintln!("patching failed.  Got result:");
+            eprintln!("{}", a.to_string());
+            eprintln!("----------------");
+            eprintln!("{}", out);
+        }
+        assert_eq!(a.to_string(), out);
+    }
+    #[test]
+    fn test_patching() {
+        patch_and_compare(
+            indoc! {r#"
+                name = "foo"
+                age = 37
+            "#},
+            indoc! {r#"
+                age = 38
+            "#},
+            indoc! {r#"
+                name = "foo"
+                age = 38
+            "#},
+        );
+        patch_and_compare(
+            indoc! {r#"
+                name = "foo"
+                age = 37
+
+                [nested]
+                hi = "there"
+            "#},
+            indoc! {r#"
+                age = 38
+
+                [nested]
+                omg = "bbq"
+            "#},
+            indoc! {r#"
+                name = "foo"
+                age = 38
+
+                [nested]
+                hi = "there"
+                omg = "bbq"
+            "#},
+        );
+        patch_and_compare(
+            indoc! {r#"
+                name = "foo"
+                age = 37
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+
+                [config.spi]
+                spi1 = "great"
+            "#},
+            indoc! {r#"
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+                [config.pcie]
+                presence = false
+            "#},
+            indoc! {r#"
+                name = "foo"
+                age = 37
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+
+                [config.spi]
+                spi1 = "great"
+                [config.pcie]
+                presence = false
+            "#},
+        );
+        // Same as above, but swap the order in the patch
+        patch_and_compare(
+            indoc! {r#"
+                name = "foo"
+                age = 37
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+
+                [config.spi]
+                spi1 = "great"
+            "#},
+            indoc! {r#"
+                bar = "foo"
+                [config.pcie]
+                presence = false
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+            "#},
+            indoc! {r#"
+                name = "foo"
+                age = 37
+                bar = "foo"
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+
+                [config.spi]
+                spi1 = "great"
+                [config.pcie]
+                presence = false
+            "#},
+        );
+        patch_and_compare(
+            indoc! {r#"
+                name = "foo"
+                age = 37
+
+                [block]
+                great = true
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+
+                [config.spi]
+                spi1 = "great"
+            "#},
+            indoc! {r#"
+                bar = "foo"
+                [config.pcie]
+                presence = false
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+            "#},
+            indoc! {r#"
+                name = "foo"
+                age = 37
+                bar = "foo"
+
+                [block]
+                great = true
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+
+                [config.spi]
+                spi1 = "great"
+                [config.pcie]
+                presence = false
+            "#},
+        );
+        patch_and_compare(
+            indoc! {r#"
+                name = "foo"
+
+                [tasks.jefe]
+                features = ["hello", "world"]
+                great = true
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+
+                [config.spi]
+                spi1 = "great"
+            "#},
+            indoc! {r#"
+                tasks.jefe.features = ["aaaaahhhh!"]
+                [config.pcie]
+                presence = false
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+            "#},
+            indoc! {r#"
+                name = "foo"
+
+                [tasks.jefe]
+                features = ["hello", "world","aaaaahhhh!"]
+                great = true
+
+                [config]
+                [[config.i2c.buses]]
+                i2c0 = "fine"
+                [[config.i2c.buses]]
+                i2c4 = { status = "running" }
+
+                [config.spi]
+                spi1 = "great"
+                [config.pcie]
+                presence = false
+            "#},
+        );
+    }
+}

--- a/build/xtask/Cargo.toml
+++ b/build/xtask/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "xtask"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+color-eyre.workspace = true
+clap.workspace = true
+serde.workspace = true
+toml.workspace = true
+indexmap.workspace = true
+toml_edit.workspace = true
+toml-patch = { path = "../toml-patch" }
+atty = "0.2.14"
+
+[lints]
+workspace = true

--- a/build/xtask/src/build.rs
+++ b/build/xtask/src/build.rs
@@ -1,0 +1,305 @@
+use crate::Options;
+use crate::profile::{LogLevel, Profile, RustTarget};
+use atty::Stream;
+use color_eyre::eyre::{Context, bail};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const DEFAULT_KERNEL_STACK_SIZE_PAGES: u32 = 256;
+
+pub fn build_kernel(opts: &Options, profile: &Profile) -> crate::Result<PathBuf> {
+    let mut build = BuildOptions::new(opts, &profile, BuildTarget::Kernel)
+        .build_std(true)
+        .verbose(opts.verbose)
+        .release(opts.release)
+        .finish();
+
+    let stacksize_pages = profile
+        .kernel
+        .stacksize_pages
+        .unwrap_or(DEFAULT_KERNEL_STACK_SIZE_PAGES);
+
+    let max_log_level = match profile
+        .kernel
+        .max_log_level
+        .unwrap_or(profile.max_log_level)
+    {
+        LogLevel::Trace => "::tracing::Level::TRACE",
+        LogLevel::Debug => "::tracing::Level::DEBUG",
+        LogLevel::Info => "::tracing::Level::INFO",
+        LogLevel::Warn => "::tracing::Level::WARN",
+        LogLevel::Error => "::tracing::Level::ERROR",
+    };
+
+    build.cmd.env(
+        "K23_CONSTANTS",
+        format!(
+            r#"
+    pub const STACK_SIZE_PAGES: u32 = {stacksize_pages};
+    pub const MAX_LOG_LEVEL: ::tracing::Level = {max_log_level};
+    "#
+        ),
+    );
+
+    build.run()?;
+    Ok(build.output)
+}
+
+pub fn build_loader(opts: &Options, profile: &Profile, kernel: &Path) -> crate::Result<PathBuf> {
+    let mut build = BuildOptions::new(opts, &profile, BuildTarget::Loader)
+        .build_std(true)
+        .verbose(opts.verbose)
+        .release(opts.release)
+        .finish();
+
+    let max_log_level = match profile
+        .kernel
+        .max_log_level
+        .unwrap_or(profile.max_log_level)
+    {
+        LogLevel::Trace => "::log::Level::Trace",
+        LogLevel::Debug => "::log::Level::Debug",
+        LogLevel::Info => "::log::Level::Info",
+        LogLevel::Warn => "::log::Level::Warn",
+        LogLevel::Error => "::log::Level::Error",
+    };
+
+    build.cmd.env(
+        "K23_CONSTANTS",
+        format!(
+            r#"
+    pub const MAX_LOG_LEVEL: ::log::Level = {max_log_level};
+    "#
+        ),
+    );
+    build.cmd.env("KERNEL", kernel);
+
+    build.run()?;
+    Ok(build.output)
+}
+
+pub enum BuildTarget {
+    Kernel,
+    Loader,
+}
+
+pub struct BuildOptions<'a> {
+    profile: &'a Profile,
+    cargo_path: &'a Path,
+    target_dir: Option<&'a Path>,
+    release: bool,
+    verbose: bool,
+    build_std: bool,
+    no_default_features: bool,
+    features: Vec<String>,
+    chosen_target: RustTarget,
+    kernel_target: RustTarget,
+    loader_target: RustTarget,
+    crate_name: &'static str,
+}
+
+impl<'a> BuildOptions<'a> {
+    pub fn new(opts: &'a Options, profile: &'a Profile, target: BuildTarget) -> Self {
+        let kernel_target = profile.kernel.target.resolve(&profile);
+        let loader_target = profile.loader.target.resolve(&profile);
+
+        let (no_default_features, features, chosen_target, crate_name) = match target {
+            BuildTarget::Kernel => (
+                profile.kernel.no_default_features,
+                profile.kernel.features.clone(),
+                kernel_target.clone(),
+                "kernel",
+            ),
+            BuildTarget::Loader => (
+                profile.loader.no_default_features,
+                profile.loader.features.clone(),
+                loader_target.clone(),
+                "loader",
+            ),
+        };
+
+        Self {
+            profile,
+            cargo_path: &opts.cargo_path,
+            target_dir: opts.target_dir.as_deref(),
+            release: false,
+            verbose: false,
+            build_std: false,
+            no_default_features,
+            features,
+            crate_name,
+            chosen_target,
+            kernel_target,
+            loader_target,
+        }
+    }
+
+    pub fn release(mut self, release: bool) -> Self {
+        self.release = release;
+        self
+    }
+
+    pub fn verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
+        self
+    }
+
+    pub fn build_std(mut self, build_std: bool) -> Self {
+        self.build_std = build_std;
+        self
+    }
+
+    pub fn finish(self) -> Build<'a> {
+        let mut cmd = Command::new(&self.cargo_path);
+        cmd.args([
+            "build",
+            "-p",
+            self.crate_name,
+            "--target",
+            &self.chosen_target.to_string(),
+        ]);
+
+        if self.release {
+            cmd.arg("--release");
+        }
+
+        if self.no_default_features {
+            cmd.arg("--no-default-features");
+        }
+        if self.verbose {
+            cmd.arg("-v");
+        }
+
+        if !self.features.is_empty() {
+            cmd.arg("--features");
+            cmd.arg(self.features.join(","));
+        }
+
+        if self.build_std {
+            cmd.args([
+                "-Z",
+                "build-std=core,alloc",
+                "-Z",
+                "build-std-features=compiler-builtins-mem",
+            ]);
+        }
+
+        cmd.env("K23_CONFIG_PATH", &self.profile.file_path);
+
+        // We're capturing stderr (for diagnosis), so `cargo` won't automatically
+        // turn on color.  If *we* are a TTY, then force it on.
+        if atty::is(Stream::Stderr) {
+            cmd.arg("--color");
+            cmd.arg("always");
+        }
+
+        let target_dir = self
+            .target_dir
+            .clone()
+            .unwrap_or(Path::new("target"))
+            .canonicalize()
+            .unwrap();
+
+        let output = target_dir
+            .join(self.chosen_target.name())
+            .join("debug")
+            .join(self.crate_name);
+
+        if let Some(target_dir) = self.target_dir {
+            cmd.env("CARGO_TARGET_DIR", target_dir);
+        }
+
+        Build {
+            profile: self.profile,
+            cmd,
+            output,
+            target_dir,
+            kernel_target: self.kernel_target,
+            loader_target: self.loader_target,
+        }
+    }
+}
+
+pub struct Build<'a> {
+    profile: &'a Profile,
+    cmd: Command,
+    output: PathBuf,
+    target_dir: PathBuf,
+    kernel_target: RustTarget,
+    loader_target: RustTarget,
+}
+
+impl Build<'_> {
+    fn check_rebuild(&self) -> crate::Result<()> {
+        let buildstamp_file = self.target_dir.join("buildstamp");
+
+        let rebuild = match std::fs::read(&buildstamp_file) {
+            Ok(contents) => {
+                if let Ok(contents) = std::str::from_utf8(&contents) {
+                    if let Ok(cmp) = u64::from_str_radix(contents, 16) {
+                        self.profile.buildhash != cmp
+                    } else {
+                        println!("buildstamp file contents unknown; re-building.");
+                        true
+                    }
+                } else {
+                    println!("buildstamp file contents corrupt; re-building.");
+                    true
+                }
+            }
+            Err(_) => {
+                println!("no buildstamp file found; re-building.");
+                true
+            }
+        };
+        // if we need to rebuild, we should clean everything before we start building
+        if rebuild {
+            println!("profile.toml has changed; rebuilding...");
+            cargo_clean(&["kernel"], &self.kernel_target.to_string())?;
+            cargo_clean(&["loader"], &self.loader_target.to_string())?;
+        }
+
+        // now that we're clean, update our buildstamp file; any failure to build
+        // from here on need not trigger a clean
+        std::fs::write(&buildstamp_file, format!("{:x}", self.profile.buildhash))?;
+
+        Ok(())
+    }
+
+    fn run(&mut self) -> crate::Result<()> {
+        self.check_rebuild()?;
+
+        let out = self
+            .cmd
+            .stderr(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .spawn()?
+            .wait()?;
+
+        if !out.success() {
+            bail!("build failed");
+        }
+
+        Ok(())
+    }
+}
+
+fn cargo_clean(names: &[&str], target: &str) -> crate::Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("clean");
+    println!("cleaning {:?}", names);
+    for name in names {
+        cmd.arg("-p").arg(name);
+    }
+    cmd.arg("--release").arg("--target").arg(target);
+
+    let status = cmd
+        .status()
+        .context(format!("failed to cargo clean ({:?})", cmd))?;
+
+    if !status.success() {
+        bail!("command failed, see output for details");
+    }
+
+    Ok(())
+}

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -1,0 +1,181 @@
+extern crate core;
+
+mod build;
+mod profile;
+mod qemu;
+
+use crate::profile::Profile;
+use clap::{Parser, ValueHint};
+use color_eyre::eyre::Result;
+use std::fs;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+#[derive(Debug, Parser)]
+struct Options {
+    #[clap(subcommand)]
+    pub subcommand: SubCommand,
+
+    #[clap(long, short, global = true)]
+    pub verbose: bool,
+
+    #[clap(long, global = true)]
+    pub release: bool,
+
+    /// Overrides the directory in which to build the output image.
+    #[clap(short, long, env = "OUT_DIR", value_hint = ValueHint::DirPath, global = true)]
+    pub out_dir: Option<PathBuf>,
+
+    /// Overrides the target directory for the kernel build.
+    #[clap(
+        short,
+        long,
+        env = "CARGO_TARGET_DIR",
+        value_hint = ValueHint::DirPath,
+        global = true
+    )]
+    pub target_dir: Option<PathBuf>,
+
+    /// Overrides the path to the `cargo` executable.
+    ///
+    /// By default, this is read from the `CARGO` environment variable.
+    #[clap(
+        long = "cargo",
+        env = "CARGO",
+        default_value = "cargo",
+        value_hint = ValueHint::ExecutablePath,
+        global = true
+    )]
+    pub cargo_path: PathBuf,
+}
+
+#[derive(Debug, Parser)]
+enum SubCommand {
+    Build {
+        /// The path to the build configuration file
+        #[clap(value_hint = ValueHint::FilePath)]
+        profile: PathBuf,
+    },
+    Dist {
+        /// The path to the build configuration file
+        #[clap(value_hint = ValueHint::FilePath)]
+        profile: PathBuf,
+    },
+    /// Builds a bootable disk image and runs it in QEMU (implied `build`).
+    Qemu {
+        /// The path to the build configuration file
+        #[clap(value_hint = ValueHint::FilePath)]
+        profile: PathBuf,
+        #[clap(flatten)]
+        qemu: qemu::QemuOptions,
+    },
+    Lldb {
+        /// The path to the build configuration file
+        #[clap(value_hint = ValueHint::FilePath)]
+        profile: PathBuf,
+        /// The TCP port to listen for debug connections on.
+        #[clap(long, default_value = "1234")]
+        gdb_port: u16,
+        /// Extra arguments passed to QEMU.
+        #[clap(raw = true, conflicts_with = "norun")]
+        qemu_args: Vec<String>,
+        /// Do not start a new k23 instance; just run `lldb`
+        #[clap(long, short, conflicts_with = "gdb_port", conflicts_with = "qemu_args")]
+        norun: bool,
+    },
+}
+
+fn main() -> Result<()> {
+    let opts = Options::parse();
+
+    match opts.subcommand {
+        SubCommand::Build { ref profile } => {
+            let profile = Profile::from_file(&profile)?;
+            let kernel = build::build_kernel(&opts, &profile)?;
+            let _image = build::build_loader(&opts, &profile, &kernel)?;
+        }
+        SubCommand::Dist { ref profile } => {
+            let profile = Profile::from_file(&profile)?;
+            let kernel = build::build_kernel(&opts, &profile)?;
+            let _image = build::build_loader(&opts, &profile, &kernel)?;
+
+            // TODO do something with it now
+
+            todo!()
+        }
+        SubCommand::Qemu {
+            ref profile,
+            ref qemu,
+        } => {
+            let profile = Profile::from_file(&profile)?;
+            let kernel = build::build_kernel(&opts, &profile)?;
+            let image = build::build_loader(&opts, &profile, &kernel)?;
+            qemu::run(qemu, profile, &image, true, false)?;
+        }
+        SubCommand::Lldb {
+            ref profile,
+            gdb_port,
+            ref qemu_args,
+            norun,
+        } => {
+            let profile = Profile::from_file(&profile)?;
+
+            let target_dir = opts
+                .target_dir
+                .clone()
+                .unwrap_or(PathBuf::from("target"))
+                .canonicalize()?;
+
+            let (kernel, loader) = if !norun {
+                let qemu_opts = qemu::QemuOptions {
+                    wait_for_debugger: true,
+                    gdb_port,
+                    qemu_args: qemu_args.clone(),
+                };
+
+                let kernel = build::build_kernel(&opts, &profile)?;
+                let loader = build::build_loader(&opts, &profile, &kernel)?;
+
+                qemu::run(&qemu_opts, profile, &loader, false, true)?;
+
+                (kernel, loader)
+            } else {
+                let kernel = target_dir
+                    .join(profile.kernel.target.resolve(&profile).name())
+                    .join("debug")
+                    .join("kernel");
+
+                let loader = target_dir
+                    .join(profile.loader.target.resolve(&profile).name())
+                    .join("debug")
+                    .join("loader");
+
+                (kernel, loader)
+            };
+
+            let lldb_script = target_dir.join("lldb_script.txt");
+            fs::write(
+                &lldb_script,
+                format!(
+                    r#"
+target create {loader}
+target modules add {kernel}
+target modules load --file {kernel} -s 0xffffffc000000000
+gdb-remote localhost:{gdb_port}
+            "#,
+                    loader = loader.display(),
+                    kernel = kernel.display()
+                ),
+            )?;
+
+            Command::new("rust-lldb")
+                .args(["-s", lldb_script.to_str().unwrap()])
+                .stdin(Stdio::inherit())
+                .stdout(Stdio::inherit())
+                .stderr(Stdio::inherit())
+                .output()?;
+        }
+    }
+
+    Ok(())
+}

--- a/build/xtask/src/profile.rs
+++ b/build/xtask/src/profile.rs
@@ -1,0 +1,211 @@
+#![allow(unused)]
+
+use color_eyre::eyre::{Context, bail, eyre};
+use serde::Deserialize;
+use std::collections::BTreeSet;
+use std::fmt::{Display, Formatter};
+use std::hash::{DefaultHasher, Hasher};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+struct RawProfile {
+    arch: Architecture,
+    name: String,
+    #[serde(default)]
+    version: u32,
+    #[serde(default)]
+    max_log_level: LogLevel,
+    kernel: Kernel,
+    loader: Loader,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub enum Architecture {
+    #[serde(rename = "riscv64")]
+    Riscv64,
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Default, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LogLevel {
+    Trace = 0,
+    Debug,
+    #[default]
+    Info,
+    Warn,
+    Error,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Kernel {
+    pub target: RawRustTarget,
+    pub stacksize_pages: Option<u32>,
+    pub max_log_level: Option<LogLevel>,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub no_default_features: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Loader {
+    pub target: RawRustTarget,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub no_default_features: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RawRustTarget(String);
+
+#[derive(Clone, Debug)]
+pub enum RustTarget {
+    Builtin(String),
+    Json(PathBuf),
+}
+
+impl RawRustTarget {
+    pub fn resolve(&self, profile: &Profile) -> RustTarget {
+        if self.0.ends_with(".json") {
+            RustTarget::Json(profile.resolve_path(&self.0).unwrap())
+        } else {
+            RustTarget::Builtin(self.0.clone())
+        }
+    }
+}
+
+impl RustTarget {
+    pub fn name(&self) -> &str {
+        match self {
+            RustTarget::Builtin(name) => name.as_str(),
+            RustTarget::Json(path) => path.file_stem().unwrap().to_str().unwrap(),
+        }
+    }
+}
+
+impl Display for RustTarget {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RustTarget::Builtin(s) => write!(f, "{s}"),
+            RustTarget::Json(p) => write!(f, "{}", p.display()),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Profile {
+    pub arch: Architecture,
+    pub name: String,
+    pub version: u32,
+    pub max_log_level: LogLevel,
+    pub kernel: Kernel,
+    pub loader: Loader,
+    pub buildhash: u64,
+    pub file_path: PathBuf,
+}
+
+impl Profile {
+    pub fn from_file(file_path: &Path) -> crate::Result<Self> {
+        let mut hasher = DefaultHasher::new();
+
+        let doc = read_and_flatten_toml(file_path, &mut hasher, &mut BTreeSet::new())?;
+        let profile_contents = doc.to_string();
+
+        let toml: RawProfile = toml::from_str(&profile_contents)?;
+
+        // if we had any other checks, perform them here
+
+        Ok(Self {
+            arch: toml.arch,
+            name: toml.name,
+            version: toml.version,
+            max_log_level: toml.max_log_level,
+            kernel: toml.kernel,
+            loader: toml.loader,
+            buildhash: hasher.finish(),
+            file_path: file_path.to_path_buf(),
+        })
+    }
+
+    pub fn resolve_path(&self, path: impl AsRef<Path>) -> crate::Result<PathBuf> {
+        self.file_path
+            .parent()
+            .unwrap()
+            .join(path)
+            .canonicalize()
+            .map_err(Into::into)
+    }
+}
+
+fn read_and_flatten_toml(
+    profile: &Path,
+    hasher: &mut DefaultHasher,
+    seen: &mut BTreeSet<PathBuf>,
+) -> crate::Result<toml_edit::DocumentMut> {
+    use toml_patch::merge_toml_documents;
+
+    // Prevent diamond inheritance
+    if !seen.insert(profile.to_owned()) {
+        bail!(
+            "{profile:?} is inherited more than once; \
+             diamond dependencies are not allowed"
+        );
+    }
+    let profile_contents =
+        std::fs::read(profile).with_context(|| format!("could not read {}", profile.display()))?;
+
+    // Accumulate the contents into the buildhash here, so that we hash both
+    // the inheritance file and the target (recursively, if necessary)
+    hasher.write(&profile_contents);
+
+    let profile_contents =
+        std::str::from_utf8(&profile_contents).context("failed to read manifest as UTF-8")?;
+
+    // Additive TOML file inheritance
+    let mut doc = profile_contents
+        .parse::<toml_edit::DocumentMut>()
+        .context("failed to parse TOML file")?;
+    let Some(inherited_from) = doc.remove("inherit") else {
+        // No further inheritance, so return the current document
+        return Ok(doc);
+    };
+
+    use toml_edit::{Item, Value};
+    let mut original = match inherited_from {
+        // Single inheritance
+        Item::Value(Value::String(s)) => {
+            let file = profile.parent().unwrap().join(s.value());
+            read_and_flatten_toml(&file, hasher, seen)
+                .with_context(|| format!("Could not load {file:?}"))?
+        }
+        // Multiple inheritance, applied sequentially
+        Item::Value(Value::Array(a)) => {
+            let mut doc: Option<toml_edit::DocumentMut> = None;
+            for a in a.iter() {
+                if let Value::String(s) = a {
+                    let file = profile.parent().unwrap().join(s.value());
+                    let next: toml_edit::DocumentMut =
+                        read_and_flatten_toml(&file, hasher, seen)
+                            .with_context(|| format!("Could not load {file:?}"))?;
+                    match doc.as_mut() {
+                        Some(doc) => merge_toml_documents(doc, next)?,
+                        None => doc = Some(next),
+                    }
+                } else {
+                    bail!("could not inherit from {a}; bad type");
+                }
+            }
+            doc.ok_or_else(|| eyre!("inherit array cannot be empty"))?
+        }
+        v => bail!("could not inherit from {v}; bad type"),
+    };
+
+    // Finally, apply any changes that are local in this file
+    merge_toml_documents(&mut original, doc)?;
+    Ok(original)
+}

--- a/build/xtask/src/qemu.rs
+++ b/build/xtask/src/qemu.rs
@@ -1,0 +1,104 @@
+use crate::profile::{Architecture, Profile};
+use clap::Parser;
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+#[derive(Debug, Parser)]
+pub struct QemuOptions {
+    /// Listen for GDB connections and wait for a debugger to attach.
+    #[clap(long, short)]
+    pub wait_for_debugger: bool,
+    /// The TCP port to listen for debug connections on.
+    #[clap(long, default_value = "1234")]
+    pub gdb_port: u16,
+    /// Extra arguments passed to QEMU.
+    #[clap(raw = true)]
+    pub qemu_args: Vec<String>,
+}
+
+pub fn run(
+    qemu: &QemuOptions,
+    profile: Profile,
+    image: &Path,
+    inherit_stdio: bool,
+    separate_thread: bool,
+) -> crate::Result<()> {
+    let mut cmd = match profile.arch {
+        Architecture::Riscv64 => {
+            let mut cmd = Command::new("qemu-system-riscv64");
+            cmd.args([
+                "-machine",
+                "virt",
+                "-cpu",
+                "rv64",
+                "-m",
+                "256M",
+                "-d",
+                "guest_errors",
+                "-display",
+                "none",
+                "-serial",
+                "mon:stdio",
+                "-semihosting-config",
+                "enable=on,target=native",
+                "-smp",
+                "cpus=1",
+                // "-smp",
+                // "cpus=8",
+                // "-object",
+                // "memory-backend-ram,size=128M,id=m0",
+                // "-object",
+                // "memory-backend-ram,size=128M,id=m1",
+                // "-numa",
+                // "node,cpus=0-3,nodeid=0,memdev=m0",
+                // "-numa",
+                // "node,cpus=4-7,nodeid=1,memdev=m1",
+                // "-numa",
+                // "dist,src=0,dst=1,val=20",
+                // "-monitor",
+                // "unix:qemu-monitor-socket,server,nowait",
+                "-kernel",
+                image.to_str().unwrap(),
+            ]);
+            cmd.args(&qemu.qemu_args);
+            cmd
+        }
+    };
+
+    if qemu.wait_for_debugger {
+        cmd.arg("-S")
+            .arg("-gdb")
+            .arg(format!("tcp::{}", qemu.gdb_port));
+    }
+
+    if inherit_stdio {
+        cmd.stderr(Stdio::inherit());
+        cmd.stdout(Stdio::inherit());
+        cmd.stdin(Stdio::inherit());
+    } else {
+        cmd.stderr(Stdio::null());
+        cmd.stdout(Stdio::null());
+        cmd.stdin(Stdio::null());
+    }
+
+    let mut run = move || {
+        let mut qemu = KillOnDrop(cmd.spawn().expect("Failed to spawn qemu. Is it installed?"));
+        qemu.0.wait().unwrap();
+    };
+
+    if separate_thread {
+        std::thread::spawn(run);
+    } else {
+        run();
+    }
+
+    Ok(())
+}
+
+struct KillOnDrop(Child);
+
+impl Drop for KillOnDrop {
+    fn drop(&mut self) {
+        self.0.kill().ok();
+    }
+}

--- a/justfile
+++ b/justfile
@@ -3,38 +3,28 @@
 set windows-shell := ["powershell.exe", "-c"]
 
 # Overrides the default Rust toolchain set in `rust-toolchain.toml`.
+
 toolchain := ""
 
 # configures what profile to use for builds.
-profile := env_var_or_default("K23_PROFILE", "dev")
-export K23_PROFILE := profile
 
 _cargo := "cargo" + if toolchain != "" { " +" + toolchain } else { "" }
-_rustflags := env_var_or_default("RUSTFLAGS", "")
 _buildstd := "-Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem"
 _rustdoc := _cargo + " doc --no-deps --all-features"
 
-_loader_artifact := "target/riscv64gc-unknown-none-elf" / (if profile == "dev" { "debug" } else { profile }) / "loader"
-_kernel_artifact := "target/riscv64gc-k23-none-kernel" / (if profile == "dev" { "debug" } else { profile }) / "kernel"
-
 # If we're running in Github Actions and cargo-action-fmt is installed, then add
 # a command suffix that formats errors.
-_fmt_clippy := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
-    ```
+
+_fmt_clippy := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else { ```
     if command -v cargo-action-fmt >/dev/null 2>&1; then
         echo "--message-format=json -- -Dwarnings | cargo-action-fmt"
     fi
-    ```
-}
-
-_fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
-    ```
+    ``` }
+_fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else { ```
     if command -v cargo-action-fmt >/dev/null 2>&1; then
         echo "--message-format=json | cargo-action-fmt"
     fi
-    ```
-}
-
+    ``` }
 _docstring := "
 justfile for k23
 see https://just.systems/man/en/
@@ -49,8 +39,6 @@ Variables can be set using `just VARIABLE=VALUE ...` or
 `just --set VARIABLE VALUE ...`.
 "
 
-# env var to set the cargo runner for the riscv64 target
-export CARGO_TARGET_RISCV64GC_K23_NONE_KERNEL_RUNNER := "just _run_riscv64"
 # as of recent Rust nightly versions the old `CARGO_RUSTC_CURRENT_DIR` we used to locate the kernel artifact from the
 # loader build script got removed :/ This is a stopgap until they come up with a replacement.
 # https://github.com/rust-lang/cargo/issues/3946
@@ -61,22 +49,19 @@ _default:
     @echo '{{ _docstring }}'
     @just --list
 
-# run the OS
-run cargo_args="" *args="":
-    {{ _cargo }} run \
-        -p kernel \
-        --target kernel/riscv64gc-k23-none-kernel.json \
-        --locked \
-        --profile {{ profile }} \
-        {{ _buildstd }} \
-        {{ cargo_args }} \
-        -- {{ args }}
+# Alias for `cargo xtask qemu`
+run profile args="" *qemu_args="":
+    {{ _cargo }} xtask qemu {{ profile }} {{ args }} -- {{ qemu_args }}
+
+# Alias for `cargo xtask build`
+build profile args="" *qemu_args="":
+    {{ _cargo }} xtask build {{ profile }} {{ args }} -- {{ qemu_args }}
 
 # quick check for development
 check crate="" *cargo_args="":
     {{ _cargo }} check \
-        {{ if crate == "" { "--workspace --exclude loader" } else { "-p" } }} {{ crate }} \
-        --target kernel/riscv64gc-k23-none-kernel.json \
+        {{ if crate == "" { "--workspace --exclude loader --exclude xtask --exclude toml-patch" } else { "-p" } }} {{ crate }} \
+        --target profile/riscv64/riscv64gc-k23-none-kernel.json \
         --locked \
         {{ _buildstd }} \
         {{ _fmt }} \
@@ -98,8 +83,8 @@ lint crate="" *cargo_args="": (clippy crate cargo_args) (check-fmt crate cargo_a
 # run clippy on a crate or the entire workspace.
 clippy crate="" *cargo_args="":
     {{ _cargo }} clippy \
-        {{ if crate == "" { "--workspace --exclude loader" } else { "-p" } }} {{ crate }} \
-        --target kernel/riscv64gc-k23-none-kernel.json \
+        {{ if crate == "" { "--workspace --exclude loader --exclude xtask --exclude toml-patch" } else { "-p" } }} {{ crate }} \
+        --target profile/riscv64/riscv64gc-k23-none-kernel.json \
         --locked \
         {{ _buildstd }} \
         {{ _fmt_clippy }} \
@@ -125,8 +110,8 @@ check-docs crate="" *cargo_args="": (build-docs crate cargo_args) (test-docs cra
 # build documentation for a crate or the entire workspace.
 build-docs crate="" *cargo_args="":
     {{ _rustdoc }} \
-        {{ if crate == '' { '--workspace --exclude loader --exclude wast' } else { '--package' } }} {{ crate }} \
-        --target kernel/riscv64gc-k23-none-kernel.json \
+        {{ if crate == '' { '--workspace --exclude loader --exclude wast --exclude xtask --exclude toml-patch' } else { '--package' } }} {{ crate }} \
+        --target profile/riscv64/riscv64gc-k23-none-kernel.json \
         {{ _buildstd }} \
         {{ _fmt }} \
         {{ cargo_args }}
@@ -140,8 +125,8 @@ build-docs crate="" *cargo_args="":
 # test documentation for a crate or the entire workspace.
 test-docs crate="" *cargo_args="":
     {{ _cargo }} test --doc \
-        {{ if crate == "" { "--workspace --exclude loader" } else { "--package" } }} {{ crate }} \
-        --target kernel/riscv64gc-k23-none-kernel.json \
+        {{ if crate == "" { "--workspace --exclude loader --exclude xtask --exclude toml-patch" } else { "--package" } }} {{ crate }} \
+        --target profile/riscv64/riscv64gc-k23-none-kernel.json \
         --locked \
         {{ _buildstd }} \
         {{ _fmt }} \
@@ -151,61 +136,13 @@ test-docs crate="" *cargo_args="":
 test cargo_args="" *args="":
     {{ _cargo }} test \
         -p kernel \
-        --target kernel/riscv64gc-k23-none-kernel.json \
+        --target profile/riscv64/riscv64gc-k23-none-kernel.json \
         --locked \
-        --profile {{ profile }} \
         {{ _buildstd }} \
         {{ _fmt }} \
         {{ cargo_args }} \
         -- {{ args }}
 
-build: && (_build_bootimg _kernel_artifact)
-    {{_cargo}} build \
-        -p kernel \
-        --locked \
-        --target kernel/riscv64gc-k23-none-kernel.json \
-        --profile {{ profile }} \
-        {{ _buildstd }} \
-        {{ _fmt }}
-
 # open the manual in development mode
 manual:
     cd manual && mdbook serve --open
-
-# This default configuration produces a 8-cpu system with a NUMA topology like this:
-#  _____________      _____________
-# |             |    |             |
-# | Node 0      |    | Node 1      |
-# | cpu 0,1,2,3 |-20-| cpu 4,5,6,7 |
-# |_____________|    |_____________|
-#
-_run_riscv64 binary *args: (_build_bootimg binary)
-    @echo Running {{binary}}
-    qemu-system-riscv64 \
-        -kernel \
-        {{_loader_artifact}} \
-        -machine virt \
-        -cpu rv64 \
-        -m 256M \
-        -d guest_errors \
-        -display none \
-        -serial mon:stdio \
-        -semihosting-config \
-        enable=on,target=native \
-        -smp cpus=8 \
-        -object memory-backend-ram,size=128M,id=m0 \
-        -object memory-backend-ram,size=128M,id=m1 \
-        -numa node,cpus=0-3,nodeid=0,memdev=m0 \
-        -numa node,cpus=4-7,nodeid=1,memdev=m1 \
-        -numa dist,src=0,dst=1,val=20 \
-        -monitor unix:qemu-monitor-socket,server,nowait \
-        {{args}}
-
-_build_bootimg $KERNEL:
-    {{_cargo}} build \
-        -p loader \
-        --locked \
-        --target riscv64gc-unknown-none-elf \
-        --profile {{ profile }} \
-        {{ _buildstd }} \
-        {{ _fmt }}

--- a/manual/src/building/boot-args.md
+++ b/manual/src/building/boot-args.md
@@ -12,9 +12,9 @@ Allows configuring the verbosity and filtering of debug messages.
 
 ```sh
 # Enable the most verbose logging messages
-just run "" --append "log=trace"
+cargo xtask qemu profile/riscv64/qemu.toml -- --append "log=trace"
 # A more reasonable configuration that keeps trace messages enabled, but silences the very spammy ones
-just run "" --append "log=trace,cranelift_codegen=off,ksharded_slab=off"
+cargo xtask qemu profile/riscv64/qemu.toml -- --append "log=trace,cranelift_codegen=off,ksharded_slab=off"
 ```
 
 ## `backtrace`
@@ -24,7 +24,7 @@ Allows configuring the verbosity of kernel panic backtraces. There are two possi
 
 ```sh
 # To print shorter panic backtraces (the default)
-just run "" --append "backtrace=short"
+cargo xtask qemu profile/riscv64/qemu.toml -- --append "backtrace=short"
 # To print more verbose panic backtraces
-just run "" --append "backtrace=full"
+cargo xtask qemu profile/riscv64/qemu.toml -- --append "backtrace=full"
 ```

--- a/manual/src/building/debugging.md
+++ b/manual/src/building/debugging.md
@@ -32,13 +32,13 @@ by passing the `log` boot argument.
 For example, to enable all levels you can pass this directive in the `log` boot argument:
 
 ```sh
-just run "" --append "log=trace"
+cargo xtask qemu profile/riscv64/qemu.toml -- --append "log=trace"
 ```
 
 A more reasonable configuration that omits the quite verbose output from cranelift but otherwise keeps the trace logging:
 
 ```sh
-just run "" --append "log=trace,cranelift_codegen=off"
+cargo xtask qemu profile/riscv64/qemu.toml -- --append "log=trace,cranelift_codegen=off"
 ```
 
 ### Attaching to the Kernel

--- a/profile/base.toml
+++ b/profile/base.toml
@@ -1,0 +1,2 @@
+name = "base"
+version = 0

--- a/profile/riscv64/qemu.toml
+++ b/profile/riscv64/qemu.toml
@@ -1,0 +1,10 @@
+name = "riscv64-qemu"
+arch = "riscv64"
+inherit = "../base.toml"
+max-log-level = "trace"
+
+[kernel]
+target = "./riscv64gc-k23-none-kernel.json"
+
+[loader]
+target = "riscv64gc-unknown-none-elf"

--- a/profile/riscv64/riscv64gc-k23-none-kernel.json
+++ b/profile/riscv64/riscv64gc-k23-none-kernel.json
@@ -1,7 +1,5 @@
 {
   "arch": "riscv64",
-  "vendor": "k23",
-  "env": "kernel",
   "code-model": "medium",
   "cpu": "generic-rv64",
   "data-layout": "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "nightly-2025-02-21"
 components = ["rustfmt", "clippy", "rust-src", "llvm-tools"]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32-unknown-unknown", "riscv64gc-unknown-none-elf"]
 profile = "minimal"


### PR DESCRIPTION
This change switches some of the terrible justfile based build system to a proper Rust xtask one. We should have done this ages ago...

This fixes a number of things:
1. We can now specify build settings (including the target) in a toml profile file. This way we can have different profiles for x86, aarch64, or even variations of the same architecture in the future
2. This finally lets us pass the kernel args properly without just getting in the way