### PR TITLE
Introduce `abort` library and refactor abort handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,14 @@
 version = 4
 
 [[package]]
+name = "abort"
+version = "0.1.0"
+dependencies = [
+ "cfg-if",
+ "riscv",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 dependencies = [
@@ -324,9 +332,8 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 name = "cpu-local"
 version = "0.1.0"
 dependencies = [
- "cfg-if",
- "log",
- "riscv",
+ "abort",
+ "tracing 0.2.0",
 ]
 
 [[package]]
@@ -1003,6 +1010,7 @@ dependencies = [
 name = "kernel"
 version = "0.1.0"
 dependencies = [
+ "abort",
  "addr2line 0.24.2",
  "anyhow",
  "arrayvec",
@@ -1136,6 +1144,7 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 name = "loader"
 version = "0.1.0"
 dependencies = [
+ "abort",
  "arrayvec",
  "bitflags",
  "cfg-if",
@@ -2031,12 +2040,12 @@ checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 name = "unwind2"
 version = "0.1.0"
 dependencies = [
+ "abort",
  "cfg-if",
  "fallible-iterator",
  "gimli",
- "log",
- "riscv",
  "spin",
+ "tracing 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,8 @@ fdt = { path = "libs/fdt" }
 ksharded-slab = { path = "libs/ksharded-slab" }
 ktest = { path = "libs/ktest" }
 uart-16550 = { path = "libs/uart-16550" }
+fiber = { path = "libs/fiber" }
+abort = { path = "libs/abort" }
 
 # third-party dependencies
 cfg-if = "1.0.0"

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -23,6 +23,7 @@ ktest.workspace = true
 addr2line.workspace = true
 uart-16550.workspace = true
 wast.workspace = true
+abort.workspace = true
 
 rustc-demangle.workspace = true
 log.workspace = true

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -52,6 +52,7 @@ use crate::device_tree::device_tree;
 use crate::mem::bootstrap_alloc::BootstrapAllocator;
 use crate::time::Instant;
 use crate::time::clock::Ticks;
+use abort::abort;
 use arrayvec::ArrayVec;
 use cfg_if::cfg_if;
 use core::cell::Cell;
@@ -113,7 +114,10 @@ fn _start(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
         Ok(_) => arch::exit(0),
         // If the panic propagates up to this catch here there is nothing we can do, this is a terminal
         // failure.
-        Err(_) => arch::abort("unrecoverable kernel panic"),
+        Err(_) => {
+            tracing::error!("unrecoverable kernel panic");
+            abort()
+        }
     }
 }
 

--- a/kernel/src/wasm/store/mod.rs
+++ b/kernel/src/wasm/store/mod.rs
@@ -7,11 +7,14 @@
 
 mod stored;
 
+use crate::mem::VirtualAddress;
+use crate::wasm::trap_handler::WasmFault;
 use crate::wasm::vm::{
     InstanceAllocator, InstanceHandle, VMContext, VMFuncRef, VMGlobalDefinition, VMStoreContext,
     VMTableDefinition, VMVal,
 };
 use crate::wasm::{Engine, Module, vm};
+use abort::abort;
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -22,10 +25,6 @@ use core::ptr::NonNull;
 use core::{fmt, mem};
 use pin_project::pin_project;
 use static_assertions::{assert_impl_all, const_assert};
-
-use crate::arch;
-use crate::mem::VirtualAddress;
-use crate::wasm::trap_handler::WasmFault;
 pub use stored::{Stored, StoredData};
 
 pub struct Store<T>(Pin<Box<StoreInner<T>>>);
@@ -234,6 +233,6 @@ shouldn't have been able to. Other accesses may have succeeded and this one just
 happened to be caught.
 "
         );
-        arch::abort("");
+        abort();
     }
 }

--- a/libs/abort/Cargo.toml
+++ b/libs/abort/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "abort"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+# 3rd-party dependencies
+cfg-if.workspace = true
+
+[target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
+riscv.workspace = true
+
+[lints]
+workspace = true

--- a/libs/abort/src/lib.rs
+++ b/libs/abort/src/lib.rs
@@ -1,0 +1,29 @@
+#![cfg_attr(not(test), no_std)]
+
+/// Terminates the current execution in an abnormal fashion. This function will never return.
+///
+/// The function will terminate the execution, either by some platform specific means. When `std`
+/// is available, this will take the form of `std::process::abort`. On `no_std` targets this will
+/// attempt to use [semihosting] to terminate the execution, and as a fallback put the CPU into an
+/// idle loop forever.
+///
+/// [semihosting]: <https://developer.arm.com/documentation/dui0203/j/semihosting/about-semihosting/what-is-semihosting->
+///
+/// # Breakpoint support
+///
+/// The symbol `abort` will never be mangled so you can safely put a breakpoint on it
+/// as a means to catch the kernel just before it exits abnormally.
+#[unsafe(no_mangle)]
+#[inline(never)]
+pub fn abort() -> ! {
+    cfg_if::cfg_if! {
+        if #[cfg(not(target_os = "none"))] {
+            extern crate std;
+            std::process::abort();
+        } else if #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))] {
+            riscv::exit(1);
+        } else {
+            compile_error!("unsupported target architecture")
+        }
+    }
+}

--- a/libs/cpu-local/Cargo.toml
+++ b/libs/cpu-local/Cargo.toml
@@ -6,11 +6,8 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-cfg-if.workspace = true
-log.workspace = true
-
-[target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
-riscv.workspace = true
+tracing.workspace = true
+abort.workspace = true
 
 [lints]
 workspace = true

--- a/libs/cpu-local/src/destructors.rs
+++ b/libs/cpu-local/src/destructors.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::abort;
+use abort::abort;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
@@ -16,7 +16,8 @@ pub(crate) unsafe fn register(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     let Ok(mut dtors) = DTORS.try_borrow_mut() else {
         // This point can only be reached if the global allocator calls this
         // function again.
-        abort("the global allocator may not use TLS with destructors")
+        tracing::error!("the global allocator may not use TLS with destructors");
+        abort();
     };
 
     dtors.push((t, dtor));

--- a/libs/cpu-local/src/lib.rs
+++ b/libs/cpu-local/src/lib.rs
@@ -16,10 +16,9 @@ pub mod destructors;
 mod eager;
 mod lazy;
 
-use cfg_if::cfg_if;
+use abort::abort;
 use core::cell::{Cell, RefCell};
 use core::fmt;
-
 #[doc(hidden)]
 pub use eager::EagerStorage;
 #[doc(hidden)]
@@ -334,17 +333,8 @@ fn abort_on_dtor_unwind(f: impl FnOnce()) {
         fn drop(&mut self) {
             // This is not terribly descriptive, but it doesn't need to be as we'll
             // already have printed a panic message at this point.
-            abort("thread local panicked on drop");
-        }
-    }
-}
-
-pub(crate) fn abort(err: &str) -> ! {
-    cfg_if! {
-        if #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))] {
-            riscv::abort(err);
-        } else {
-            compile_error!("unsupported target architecture")
+            tracing::error!("thread local panicked on drop");
+            abort();
         }
     }
 }

--- a/libs/riscv/src/lib.rs
+++ b/libs/riscv/src/lib.rs
@@ -18,7 +18,6 @@ pub mod sbi;
 pub mod semihosting;
 
 use core::arch::asm;
-use core::fmt::Write;
 pub use error::Error;
 pub use register::*;
 pub type Result<T> = core::result::Result<T, Error>;
@@ -37,10 +36,4 @@ pub fn exit(code: i32) -> ! {
             asm!("wfi");
         }
     }
-}
-
-/// Terminates the current execution in an abnormal fashion.
-pub fn abort(err: &str) -> ! {
-    let _ = hio::HostStream::new_stdout().write_fmt(format_args!("{err}\n"));
-    exit(1);
 }

--- a/libs/unwind2/Cargo.toml
+++ b/libs/unwind2/Cargo.toml
@@ -9,11 +9,9 @@ license.workspace = true
 workspace = true
 
 [dependencies]
-log.workspace = true
 cfg-if.workspace = true
 gimli = { workspace = true, features = ["read-core"] }
 spin.workspace = true
 fallible-iterator.workspace = true
-
-[target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
-riscv.workspace = true
+abort.workspace = true
+tracing.workspace = true

--- a/libs/unwind2/src/arch/riscv64.rs
+++ b/libs/unwind2/src/arch/riscv64.rs
@@ -12,8 +12,6 @@ use core::fmt;
 use core::ops;
 use gimli::{Register, RiscV};
 
-pub use riscv::abort;
-
 // Match DWARF_FRAME_REGISTERS in libgcc
 pub const MAX_REG_RULES: usize = 65;
 

--- a/libs/unwind2/src/exception.rs
+++ b/libs/unwind2/src/exception.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::{Error, arch};
+use crate::Error;
+use abort::abort;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::ffi::c_int;
@@ -56,7 +57,8 @@ impl Exception {
             // Safety: Caller ensures `exception` is a valid exception
             unsafe {
                 drop(Box::from_raw(exception.cast::<Exception>()));
-                arch::abort("Rust panics must be rethrown");
+                tracing::error!("Rust panics must be rethrown");
+                abort();
             }
         }
 

--- a/libs/unwind2/src/lib.rs
+++ b/libs/unwind2/src/lib.rs
@@ -27,6 +27,7 @@ mod frame;
 mod lang_items;
 mod utils;
 
+use abort::abort;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::intrinsics;
@@ -210,8 +211,8 @@ where
         match unsafe { Exception::unwrap(exception.cast()) } {
             Ok(p) => data.p = ManuallyDrop::new(p),
             Err(err) => {
-                log::error!("Failed to catch exception: {err:?}");
-                arch::abort("Failed to catch exception");
+                tracing::error!("Failed to catch exception: {err:?}");
+                abort();
             }
         }
     }

--- a/loader/Cargo.toml
+++ b/loader/Cargo.toml
@@ -13,6 +13,7 @@ harness = false
 loader-api.workspace = true
 spin.workspace = true
 fdt.workspace = true
+abort.workspace = true
 
 # third-party dependencies
 log.workspace = true

--- a/loader/src/arch/mod.rs
+++ b/loader/src/arch/mod.rs
@@ -14,13 +14,3 @@ cfg_if::cfg_if! {
         compile_error!("Unsupported target architecture");
     }
 }
-
-pub fn abort(err: &str) -> ! {
-    cfg_if::cfg_if! {
-        if #[cfg(any(target_arch = "riscv64", target_arch = "riscv32"))] {
-            riscv::abort(err);
-        } else {
-            loop {}
-        }
-    }
-}

--- a/loader/src/panic.rs
+++ b/loader/src/panic.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use crate::arch;
+use abort::abort;
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {
@@ -26,5 +27,5 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 #[inline(never)]
 #[unsafe(no_mangle)]
 fn rust_panic() -> ! {
-    arch::abort("panic")
+    abort()
 }


### PR DESCRIPTION
Replaced abort functions across libraries with a centralized `abort` library. This centralized function will be unmangled, never inlined and can therefore be used as a breakpoint symbol.