### PR TITLE
feat: extract `FastRand` into standalone crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
+name = "fastrand"
+version = "0.1.0"
+dependencies = [
+ "criterion",
+]
+
+[[package]]
 name = "fdt"
 version = "0.1.0"
 dependencies = [
@@ -1014,6 +1021,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "fallible-iterator",
+ "fastrand",
  "fdt",
  "futures",
  "gimli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ fdt = { path = "libs/fdt" }
 ksharded-slab = { path = "libs/ksharded-slab" }
 ktest = { path = "libs/ktest" }
 uart-16550 = { path = "libs/uart-16550" }
+fastrand = { path = "libs/fastrand" }
 
 # third-party dependencies
 cfg-if = "1.0.0"

--- a/justfile
+++ b/justfile
@@ -125,7 +125,7 @@ build-docs crate="" *cargo_args="":
 # test documentation for a crate or the entire workspace.
 test-docs crate="" *cargo_args="":
     {{ _cargo }} test --doc \
-        {{ if crate == "" { "--workspace --exclude loader --exclude xtask --exclude toml-patch --exclude fiber" } else { "--package" } }} {{ crate }} \
+        {{ if crate == "" { "--workspace --exclude loader --exclude xtask --exclude toml-patch --exclude fiber --exclude fastrand" } else { "--package" } }} {{ crate }} \
         --target profile/riscv64/riscv64gc-k23-none-kernel.json \
         --locked \
         {{ _buildstd }} \

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -23,6 +23,7 @@ ktest.workspace = true
 addr2line.workspace = true
 uart-16550.workspace = true
 wast.workspace = true
+fastrand.workspace = true
 
 rustc-demangle.workspace = true
 log.workspace = true

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -74,7 +74,6 @@ use crate::scheduler::park::ParkToken;
 use crate::scheduler::queue::Overflow;
 use crate::task::{JoinHandle, OwnedTasks, PollResult, Schedule, TaskRef};
 use crate::time::Timer;
-use crate::util::fast_rand::FastRand;
 use crate::{arch, task};
 use core::any::type_name;
 use core::cell::{Ref, RefCell};
@@ -85,6 +84,7 @@ use core::pin::pin;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::{Context, Poll};
 use cpu_local::cpu_local;
+use fastrand::FastRand;
 use rand::RngCore;
 use spin::{Backoff, Barrier, OnceLock};
 
@@ -324,7 +324,7 @@ impl Worker {
             scheduler,
             cpuid,
             is_searching: false,
-            rng: FastRand::new(rng.next_u64()),
+            rng: FastRand::from_seed(rng.next_u64()),
             num_seq_local_queue_polls: 0,
             global_queue_interval: DEFAULT_GLOBAL_QUEUE_INTERVAL,
         }

--- a/kernel/src/util/mod.rs
+++ b/kernel/src/util/mod.rs
@@ -9,7 +9,6 @@ use core::ptr::NonNull;
 
 pub mod atomic_cell;
 pub mod either;
-pub mod fast_rand;
 pub mod maybe_uninit;
 pub mod zip_eq;
 

--- a/libs/fastrand/Cargo.toml
+++ b/libs/fastrand/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "fastrand"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+
+[dev-dependencies]
+criterion = "0.5.1"
+
+[[bench]]
+name = "bench"
+harness = false
+
+[lints]
+workspace = true

--- a/libs/fastrand/README.md
+++ b/libs/fastrand/README.md
@@ -1,0 +1,6 @@
+# `fastrand`
+
+Small, very fast, non-cryptographic random number generator.
+
+This is used in places where you need to perform inconsequential randomization, such as picking a scheduler worker to steal
+tasks from, backoff randomization etc.

--- a/libs/fastrand/benches/bench.rs
+++ b/libs/fastrand/benches/bench.rs
@@ -1,0 +1,10 @@
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use fastrand::FastRand;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let mut rng = FastRand::from_seed(42);
+    c.bench_function("fastrand", |b| b.iter(|| black_box(rng.fastrand())));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Moved the `FastRand` non-cryptographic rng from the kernel to the a standalone crate so we can more easily test, benchmark, and share it throughout the kernel.