### PR TITLE
chore: update crate `no_std` headers

### DIFF
--- a/libs/addr2line/src/lib.rs
+++ b/libs/addr2line/src/lib.rs
@@ -19,9 +19,9 @@
 //! [`Context::find_location_range`]. Function information is obtained with
 //! [`Context::find_frames`], which returns a frame for each inline function. Each frame
 //! contains both name and location.
-#![deny(missing_docs)]
-#![no_std]
 
+#![cfg_attr(not(test), no_std)]
+#![deny(missing_docs)]
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;

--- a/libs/backtrace/src/lib.rs
+++ b/libs/backtrace/src/lib.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![no_std]
+#![no_std] // this is crate is fully incompatible with `std` due to clashing lang item definitions
+#![cfg(target_os = "none")]
 
 mod symbolize;
 

--- a/libs/fdt/src/lib.rs
+++ b/libs/fdt/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 mod error;
 mod parser;

--- a/libs/ksharded-slab/src/lib.rs
+++ b/libs/ksharded-slab/src/lib.rs
@@ -199,9 +199,9 @@
 //!
 //! See [this page](crate::implementation) for details on this crate's design
 //! and implementation.
-//!
+
+#![cfg_attr(not(test), no_std)]
 #![warn(missing_debug_implementations, missing_docs)]
-#![no_std]
 #![feature(thread_local)]
 #![feature(used_with_arg)]
 #![feature(never_type)]

--- a/libs/mpsc-queue/src/lib.rs
+++ b/libs/mpsc-queue/src/lib.rs
@@ -8,7 +8,8 @@
 //! [vyukov]: http://www.1024cores.net/home/lock-free-algorithms/queues/intrusive-mpsc-node-based-queue
 //! [intrusive]: crate#intrusive-data-structures
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
+
 extern crate alloc;
 
 use alloc::sync::Arc;

--- a/libs/riscv/src/lib.rs
+++ b/libs/riscv/src/lib.rs
@@ -6,7 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 //! RISC-V architecture support crate.
-#![no_std]
+
+#![cfg_attr(not(test), no_std)]
 #![allow(edition_2024_expr_fragment_specifier, reason = "vetted usage")]
 
 mod error;

--- a/libs/uart-16550/src/lib.rs
+++ b/libs/uart-16550/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 use bitflags::bitflags;
 use core::fmt;

--- a/libs/unwind2/src/lib.rs
+++ b/libs/unwind2/src/lib.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![no_std]
+#![no_std] // this is crate is fully incompatible with `std` due to clashing lang item definitions
+#![cfg(target_os = "none")]
 #![expect(internal_features, reason = "lang items")]
 #![feature(
     core_intrinsics,

--- a/libs/wast/src/lib.rs
+++ b/libs/wast/src/lib.rs
@@ -50,7 +50,7 @@
 //! [`Parse`]: parser::Parse
 //! [`LexError`]: lexer::LexError
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![feature(thread_local, never_type)]


### PR DESCRIPTION
Update the crate `no_std` headers to make testing easier in the future