### PR TITLE
chore: add `jujutsu` to nix shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,7 @@
             cargo-deny
             typos
             wasm-tools
+            jujutsu
 
             # for testing the kernel
             qemu


### PR DESCRIPTION
This adds the jujutsu (`jj`) version control system to the NIX shell