### PR TITLE
hide qemu interrupt info

### DIFF
--- a/build/xtask/src/qemu.rs
+++ b/build/xtask/src/qemu.rs
@@ -42,7 +42,7 @@ pub fn spawn(
                 "-m",
                 "256M",
                 "-d",
-                "guest_errors,int",
+                "guest_errors",
                 "-display",
                 "none",
                 "-serial",


### PR DESCRIPTION
This change hides the very verbose QEMU interrupt info from the output log