### PR TITLE
fix: correctly include release kernel in release builds

### DIFF
--- a/build/xtask/src/build.rs
+++ b/build/xtask/src/build.rs
@@ -221,7 +221,7 @@ impl<'a> Cargo<'a> {
         let output = this
             .target_dir
             .join(this.rust_target.name())
-            .join("debug")
+            .join(if opts.release { "release" } else { "debug" })
             .join(krate.as_str());
 
         Ok((this, output))


### PR DESCRIPTION
This PR fixes release builds. Previously the loader would include the debug kernel *even* when a release build was requested.