### PR TITLE
fix: spin loom constructors

### DIFF
--- a/libs/spin/src/backoff.rs
+++ b/libs/spin/src/backoff.rs
@@ -71,7 +71,7 @@ impl Backoff {
         for _ in 0..spins {
             // In tests, especially in loom tests, we need to yield the thread back to the runtime
             // so it can make progress. See https://github.com/tokio-rs/loom/issues/162#issuecomment-665128979
-            #[cfg(test)]
+            #[cfg(loom)]
             crate::loom::thread::yield_now();
 
             hint::spin_loop();

--- a/libs/spin/src/barrier.rs
+++ b/libs/spin/src/barrier.rs
@@ -45,6 +45,8 @@ impl Barrier {
 
             while local_gen == lock.generation_id && lock.count < self.num_threads {
                 drop(lock);
+                #[cfg(loom)]
+                crate::loom::thread::yield_now();
                 hint::spin_loop();
                 lock = self.lock.lock();
             }

--- a/libs/spin/src/lazy_lock.rs
+++ b/libs/spin/src/lazy_lock.rs
@@ -14,6 +14,7 @@ use core::{
     panic::{RefUnwindSafe, UnwindSafe},
     ptr,
 };
+use util::loom_const_fn;
 
 union Data<T, F> {
     value: ManuallyDrop<T>,
@@ -29,12 +30,14 @@ pub struct LazyLock<T, F = fn() -> T> {
 }
 
 impl<T, F: FnOnce() -> T> LazyLock<T, F> {
-    pub const fn new(f: F) -> Self {
-        Self {
-            once: Once::new(),
-            data: UnsafeCell::new(Data {
-                f: ManuallyDrop::new(f),
-            }),
+    loom_const_fn! {
+        pub const fn new(f: F) -> Self {
+            Self {
+                once: Once::new(),
+                data: UnsafeCell::new(Data {
+                    f: ManuallyDrop::new(f),
+                }),
+            }
         }
     }
 

--- a/libs/spin/src/once.rs
+++ b/libs/spin/src/once.rs
@@ -123,6 +123,8 @@ impl Once {
 
     pub fn wait(&self) {
         while !self.poll() {
+            #[cfg(loom)]
+            crate::loom::thread::yield_now();
             core::hint::spin_loop();
         }
     }

--- a/libs/spin/src/once_lock.rs
+++ b/libs/spin/src/once_lock.rs
@@ -12,6 +12,7 @@ use core::{
     mem::MaybeUninit,
     panic::{RefUnwindSafe, UnwindSafe},
 };
+use util::loom_const_fn;
 
 /// A synchronization primitive which can be written to only once.
 ///
@@ -22,11 +23,13 @@ pub struct OnceLock<T> {
 }
 
 impl<T> OnceLock<T> {
-    #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            once: Once::new(),
-            data: UnsafeCell::new(MaybeUninit::uninit()),
+    loom_const_fn! {
+        #[must_use]
+        pub const fn new() -> Self {
+            Self {
+                once: Once::new(),
+                data: UnsafeCell::new(MaybeUninit::uninit()),
+            }
         }
     }
 

--- a/libs/spin/src/rw_lock.rs
+++ b/libs/spin/src/rw_lock.rs
@@ -217,6 +217,8 @@ impl<T: ?Sized> RwLock<T> {
 
     fn lock_shared(&self) {
         while !self.try_lock_shared() {
+            #[cfg(loom)]
+            crate::loom::thread::yield_now();
             core::hint::spin_loop();
         }
     }
@@ -293,6 +295,8 @@ impl<T: ?Sized> RwLock<T> {
 
     unsafe fn upgrade(&self) {
         while !self.try_upgrade_internal(false) {
+            #[cfg(loom)]
+            crate::loom::thread::yield_now();
             core::hint::spin_loop();
         }
     }


### PR DESCRIPTION
This fixes the usage of `spin` types when compiling under loom