### PR TITLE
refactor: rename panic-unwind to panic-unwind2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ dependencies = [
  "criterion",
  "criterion-cycles-per-byte",
  "libc",
- "panic-unwind",
+ "panic-unwind2",
  "riscv",
  "windows-sys",
 ]
@@ -1008,7 +1008,7 @@ dependencies = [
  "mpsc-queue",
  "mycelium-bitfield",
  "ouroboros",
- "panic-unwind",
+ "panic-unwind2",
  "pin-project",
  "rand",
  "rand_chacha",
@@ -1300,6 +1300,18 @@ checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "panic-unwind"
+version = "0.1.0"
+dependencies = [
+ "abort",
+ "cpu-local",
+ "riscv",
+ "spin",
+ "tracing 0.2.0",
+ "unwind2",
+]
+
+[[package]]
+name = "panic-unwind2"
 version = "0.1.0"
 dependencies = [
  "abort",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ uart-16550 = { path = "libs/uart-16550" }
 fastrand = { path = "libs/fastrand" }
 fiber = { path = "libs/fiber" }
 abort = { path = "libs/abort" }
-panic-unwind = { path = "libs/panic-unwind" }
+panic-unwind2 = { path = "libs/panic-unwind2" }
 util = { path = "libs/util"}
 
 # 3rd-party dependencies

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -25,7 +25,7 @@ uart-16550.workspace = true
 wast.workspace = true
 fastrand.workspace = true
 abort.workspace = true
-panic-unwind.workspace = true
+panic-unwind2.workspace = true
 util.workspace = true
 
 # 3rd-party dependencies

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -372,7 +372,7 @@ fn handle_kernel_exception(
 
     // begin a panic on the original stack
     // Safety: we saved the register state at the beginning of the trap handler
-    unsafe { panic_unwind::begin_unwind(payload, regs, epc.checked_add(1).unwrap().get()) };
+    unsafe { panic_unwind2::begin_unwind(payload, regs, epc.checked_add(1).unwrap().get()) };
 }
 
 fn handle_recursive_fault(frame: &TrapFrame, epc: VirtualAddress) -> ! {
@@ -392,6 +392,6 @@ fn handle_recursive_fault(frame: &TrapFrame, epc: VirtualAddress) -> ! {
     // begin a panic on the original stack
     // Safety: we saved the register state at the beginning of the trap handler
     unsafe {
-        panic_unwind::begin_unwind(payload, regs, epc.checked_add(1).unwrap().get());
+        panic_unwind2::begin_unwind(payload, regs, epc.checked_add(1).unwrap().get());
     }
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -26,7 +26,7 @@
 #![feature(asm_unwind)]
 
 extern crate alloc;
-extern crate panic_unwind;
+extern crate panic_unwind2;
 
 mod allocator;
 mod arch;
@@ -98,7 +98,7 @@ static LOADER_CONFIG: LoaderConfig = {
 fn _start(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
     BOOT_INFO.get_or_init(|| boot_info);
 
-    panic_unwind::set_hook(|info| {
+    panic_unwind2::set_hook(|info| {
         tracing::error!("CPU {info}");
 
         // FIXME 32 seems adequate for unoptimized builds where the callstack can get quite deep
@@ -119,7 +119,7 @@ fn _start(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) -> ! {
     // Unwinding expects at least one landing pad in the callstack, but capturing all unwinds that
     // bubble up to this point is also a good idea since we can perform some last cleanup and
     // print an error message.
-    let res = panic_unwind::catch_unwind(|| {
+    let res = panic_unwind2::catch_unwind(|| {
         backtrace::__rust_begin_short_backtrace(|| kmain(cpuid, boot_info, boot_ticks));
     });
 

--- a/kernel/src/scheduler/queue.rs
+++ b/kernel/src/scheduler/queue.rs
@@ -388,7 +388,7 @@ impl Local {
 
 impl Drop for Local {
     fn drop(&mut self) {
-        if !panic_unwind::panicking() {
+        if !panic_unwind2::panicking() {
             assert!(self.pop().is_none(), "queue not empty");
         }
     }

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -220,12 +220,14 @@ fn handle_command<'cmd>(ctx: Context<'cmd>, commands: &'cmd [Command]) -> CmdRes
         if let Some(current) = chunk.strip_prefix(cmd.name) {
             let current = current.trim();
 
-            return panic_unwind::catch_unwind(|| cmd.run(Context { current, ..ctx })).unwrap_or({
-                Err(Error {
-                    line: cmd.name,
-                    kind: ErrorKind::Other("command failed"),
-                })
-            });
+            return panic_unwind2::catch_unwind(|| cmd.run(Context { current, ..ctx })).unwrap_or(
+                {
+                    Err(Error {
+                        line: cmd.name,
+                        kind: ErrorKind::Other("command failed"),
+                    })
+                },
+            );
         }
     }
 

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -800,7 +800,7 @@ where
         }
 
         // Poll the future.
-        let result = panic_unwind::catch_unwind(AssertUnwindSafe(|| -> Poll<F::Output> {
+        let result = panic_unwind2::catch_unwind(AssertUnwindSafe(|| -> Poll<F::Output> {
             let guard = Guard { stage: self };
 
             // Safety: caller has to ensure mutual exclusion

--- a/kernel/src/wasm/trap_handler.rs
+++ b/kernel/src/wasm/trap_handler.rs
@@ -138,7 +138,7 @@ where
 
         match unwind_reason {
             UnwindReason::Trap(reason) => Err(Trap { reason, backtrace }),
-            UnwindReason::Panic(payload) => panic_unwind::resume_unwind(payload),
+            UnwindReason::Panic(payload) => panic_unwind2::resume_unwind(payload),
         }
     }
 }
@@ -382,7 +382,7 @@ where
             Err(reason) => (T::SENTINEL, Some(UnwindReason::Trap(reason.into()))),
         };
 
-        panic_unwind::catch_unwind(AssertUnwindSafe(f))
+        panic_unwind2::catch_unwind(AssertUnwindSafe(f))
             .unwrap_or_else(|payload| (T::SENTINEL, Some(UnwindReason::Panic(payload))))
     }
 }

--- a/libs/fiber/Cargo.toml
+++ b/libs/fiber/Cargo.toml
@@ -23,7 +23,7 @@ windows-sys = { version = "0.59.0", features = [
 ] }
 
 [target.'cfg(target_os = "none")'.dependencies]
-panic-unwind.workspace = true
+panic-unwind2.workspace = true
 
 [target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
 riscv.workspace = true

--- a/libs/fiber/src/arch/riscv.rs
+++ b/libs/fiber/src/arch/riscv.rs
@@ -400,7 +400,7 @@ pub unsafe fn switch_and_throw(
         // or not
         cfg_if! {
             if #[cfg(target_os = "none")] {
-                use panic_unwind::resume_unwind;
+                use panic_unwind2::resume_unwind;
             } else {
                 use std::panic::resume_unwind;
             }

--- a/libs/fiber/src/lib.rs
+++ b/libs/fiber/src/lib.rs
@@ -311,7 +311,7 @@ impl<Input, Yield, Return, L, S: FiberStack> Fiber<Input, Yield, Return, L, S> {
             // or not
             cfg_if! {
                 if #[cfg(target_os = "none")] {
-                    use panic_unwind::catch_unwind;
+                    use panic_unwind2::catch_unwind;
                 } else {
                     use std::panic::catch_unwind;
                 }

--- a/libs/panic-unwind2/Cargo.toml
+++ b/libs/panic-unwind2/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "panic-unwind2"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+spin.workspace = true
+cpu-local.workspace = true
+unwind2.workspace = true
+abort.workspace = true
+
+# 3rd-party dependencies
+tracing.workspace = true
+#cfg-if.workspace = true
+
+[target.'cfg(any(target_arch = "riscv64", target_arch = "riscv32"))'.dependencies]
+riscv.workspace = true
+
+[lints]
+workspace = true

--- a/libs/panic-unwind2/src/hook.rs
+++ b/libs/panic-unwind2/src/hook.rs
@@ -1,0 +1,225 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use alloc::string::String;
+use core::any::Any;
+use core::panic::Location;
+use core::{fmt, mem};
+use spin::RwLock;
+
+#[derive(Debug)]
+pub struct PanicHookInfo<'a> {
+    payload: &'a (dyn Any + Send),
+    location: &'a Location<'a>,
+    can_unwind: bool,
+}
+
+impl<'a> PanicHookInfo<'a> {
+    #[inline]
+    pub(crate) fn new(
+        location: &'a Location<'a>,
+        payload: &'a (dyn Any + Send),
+        can_unwind: bool,
+    ) -> Self {
+        PanicHookInfo {
+            payload,
+            location,
+            can_unwind,
+        }
+    }
+
+    /// Returns the payload associated with the panic.
+    ///
+    /// This will commonly, but not always, be a `&'static str` or [`String`].
+    ///
+    /// A invocation of the `panic!()` macro in Rust 2021 or later will always result in a
+    /// panic payload of type `&'static str` or `String`.
+    ///
+    /// Only an invocation of [`panic_any`]
+    /// (or, in Rust 2018 and earlier, `panic!(x)` where `x` is something other than a string)
+    /// can result in a panic payload other than a `&'static str` or `String`.
+    ///
+    /// [`String`]: ../../std/string/struct.String.html
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+    ///         println!("panic occurred: {s:?}");
+    ///     } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+    ///         println!("panic occurred: {s:?}");
+    ///     } else {
+    ///         println!("panic occurred");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn payload(&self) -> &(dyn Any + Send) {
+        self.payload
+    }
+
+    /// Returns the payload associated with the panic, if it is a string.
+    ///
+    /// This returns the payload if it is of type `&'static str` or `String`.
+    ///
+    /// A invocation of the `panic!()` macro in Rust 2021 or later will always result in a
+    /// panic payload where `payload_as_str` returns `Some`.
+    ///
+    /// Only an invocation of [`panic_any`]
+    /// (or, in Rust 2018 and earlier, `panic!(x)` where `x` is something other than a string)
+    /// can result in a panic payload where `payload_as_str` returns `None`.
+    ///
+    /// # Example
+    ///
+    /// ```should_panic
+    /// #![feature(panic_payload_as_str)]
+    ///
+    /// std::panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(s) = panic_info.payload_as_str() {
+    ///         println!("panic occurred: {s:?}");
+    ///     } else {
+    ///         println!("panic occurred");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn payload_as_str(&self) -> Option<&str> {
+        if let Some(s) = self.payload.downcast_ref::<&str>() {
+            Some(s)
+        } else if let Some(s) = self.payload.downcast_ref::<String>() {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    /// Returns information about the location from which the panic originated,
+    /// if available.
+    ///
+    /// This method will currently always return [`Some`], but this may change
+    /// in future versions.
+    ///
+    /// # Examples
+    ///
+    /// ```should_panic
+    /// use std::panic;
+    ///
+    /// panic::set_hook(Box::new(|panic_info| {
+    ///     if let Some(location) = panic_info.location() {
+    ///         println!("panic occurred in file '{}' at line {}",
+    ///             location.file(),
+    ///             location.line(),
+    ///         );
+    ///     } else {
+    ///         println!("panic occurred but can't get location information...");
+    ///     }
+    /// }));
+    ///
+    /// panic!("Normal panic");
+    /// ```
+    #[must_use]
+    #[inline]
+    pub fn location(&self) -> &Location<'_> {
+        self.location
+    }
+
+    /// Returns whether the panic handler is allowed to unwind the stack from
+    /// the point where the panic occurred.
+    ///
+    /// This is true for most kinds of panics with the exception of panics
+    /// caused by trying to unwind out of a `Drop` implementation or a function
+    /// whose ABI does not support unwinding.
+    ///
+    /// It is safe for a panic handler to unwind even when this function returns
+    /// false, however this will simply cause the panic handler to be called
+    /// again.
+    #[must_use]
+    #[inline]
+    pub fn can_unwind(&self) -> bool {
+        self.can_unwind
+    }
+}
+
+impl fmt::Display for PanicHookInfo<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("panicked at ")?;
+        self.location.fmt(formatter)?;
+        if let Some(payload) = self.payload_as_str() {
+            formatter.write_str(":\n")?;
+            formatter.write_str(payload)?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) static HOOK: RwLock<Hook> = RwLock::new(Hook::Default);
+
+#[derive(Default)]
+pub(crate) enum Hook {
+    #[default]
+    Default,
+    Custom(fn(&PanicHookInfo<'_>)),
+}
+
+impl Hook {
+    #[inline]
+    fn into_fn(self) -> fn(&PanicHookInfo<'_>) {
+        match self {
+            Hook::Default => default_hook,
+            Hook::Custom(hook) => hook,
+        }
+    }
+}
+
+/// Registers a custom panic hook, replacing the previously registered hook.
+///
+/// # Panics
+///
+/// Panics if called from an already panicking CPU
+pub fn set_hook(hook: fn(&PanicHookInfo<'_>)) {
+    assert!(
+        !crate::panicking(),
+        "cannot modify the panic hook from a panicking CPU"
+    );
+
+    let new = Hook::Custom(hook);
+    let mut hook = HOOK.write();
+    let _ = mem::replace(&mut *hook, new);
+}
+
+/// Unregisters the current panic hook and returns it, registering the default hook
+/// in its place.
+///
+/// # Panics
+///
+/// Panics if called from an already panicking CPU
+pub fn take_hook() -> fn(&PanicHookInfo<'_>) {
+    assert!(
+        !crate::panicking(),
+        "cannot modify the panic hook from a panicking CPU"
+    );
+
+    let mut hook = HOOK.write();
+    let old_hook = mem::take(&mut *hook);
+    drop(hook);
+
+    old_hook.into_fn()
+}
+
+/// The default panic handler.
+pub(crate) fn default_hook(info: &PanicHookInfo<'_>) {
+    tracing::error!("{info}");
+}

--- a/libs/panic-unwind2/src/lib.rs
+++ b/libs/panic-unwind2/src/lib.rs
@@ -1,0 +1,207 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![no_std] // this is crate is fully incompatible with `std` due to clashing lang item definitions
+#![cfg(target_os = "none")]
+#![feature(panic_can_unwind)]
+#![expect(internal_features, reason = "")]
+#![feature(std_internals)]
+#![feature(formatting_options)]
+#![feature(never_type)]
+#![feature(thread_local)]
+
+extern crate alloc;
+
+mod hook;
+mod panic_count;
+
+use crate::hook::{HOOK, Hook, PanicHookInfo, default_hook};
+use crate::panic_count::MustAbort;
+use abort::abort;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::any::Any;
+use core::panic::{PanicPayload, UnwindSafe};
+use core::{fmt, mem};
+pub use hook::{set_hook, take_hook};
+
+/// Determines whether the current thread is unwinding because of panic.
+#[inline]
+pub fn panicking() -> bool {
+    !panic_count::count_is_zero()
+}
+
+/// Invokes a closure, capturing the cause of an unwinding panic if one occurs.
+///
+/// # Errors
+///
+/// If the given closure panics, the panic cause will be returned in the Err variant.
+pub fn catch_unwind<F, R>(f: F) -> Result<R, Box<dyn Any + Send + 'static>>
+where
+    F: FnOnce() -> R + UnwindSafe,
+{
+    unwind2::catch_unwind(f).inspect_err(|_| {
+        panic_count::decrease(); // decrease the panic count, since we caught it
+    })
+}
+
+/// Resume an unwind previously caught with [`catch_unwind`].
+pub fn resume_unwind(payload: Box<dyn Any + Send>) -> ! {
+    debug_assert!(panic_count::increase(false).is_none());
+    unwind2::with_context(|regs, pc| rust_panic(payload, regs.clone(), pc))
+}
+
+/// Begin unwinding from an externally captured set of registers (such as from a trap handler).
+///
+/// # Safety
+///
+/// This will start walking the stack and calling `Drop` implementations starting the the `pc` and
+/// register set you provided. Be VERY careful that it is actually correctly captured.
+pub unsafe fn begin_unwind(payload: Box<dyn Any + Send>, regs: unwind2::Registers, pc: usize) -> ! {
+    debug_assert!(panic_count::increase(false).is_none());
+    rust_panic(payload, regs, pc)
+}
+
+#[panic_handler]
+fn panic(info: &core::panic::PanicInfo) -> ! {
+    if let Some(must_abort) = panic_count::increase(true) {
+        match must_abort {
+            MustAbort::PanicInHook => {
+                tracing::error!("{info}");
+            }
+        }
+
+        tracing::error!("cpu panicked while processing panic. aborting.");
+        abort();
+    }
+
+    let loc = info.location().unwrap(); // Currently always returns Some
+    let payload = construct_panic_payload(info);
+
+    match *HOOK.read() {
+        Hook::Default => {
+            default_hook(&PanicHookInfo::new(loc, &payload, info.can_unwind()));
+        }
+        Hook::Custom(hook) => {
+            hook(&PanicHookInfo::new(loc, &payload, info.can_unwind()));
+        }
+    }
+
+    panic_count::finished_panic_hook();
+
+    if !info.can_unwind() {
+        // If a thread panics while running destructors or tries to unwind
+        // through a nounwind function (e.g. extern "C") then we cannot continue
+        // unwinding and have to abort immediately.
+        tracing::error!("cpu caused non-unwinding panic. aborting.");
+        abort();
+    }
+
+    unwind2::with_context(|regs, pc| rust_panic(payload, regs.clone(), pc))
+}
+
+/// Mirroring std, this is an unmangled function on which to slap
+/// yer breakpoints for backtracing panics.
+#[inline(never)]
+#[unsafe(no_mangle)]
+fn rust_panic(payload: Box<dyn Any + Send>, regs: unwind2::Registers, pc: usize) -> ! {
+    // Safety: `begin_unwind` will either return an error or not return at all
+    match unsafe { unwind2::begin_unwind_with(payload, regs, pc).unwrap_err_unchecked() } {
+        unwind2::Error::EndOfStack => {
+            tracing::error!(
+                "unwinding completed without finding a `catch_unwind` make sure there is at least a root level catch unwind wrapping the main function. aborting."
+            );
+            abort();
+        }
+        err => {
+            tracing::error!("unwinding failed with error {}. aborting.", err);
+            abort()
+        }
+    }
+}
+
+fn construct_panic_payload(info: &core::panic::PanicInfo) -> Box<dyn Any + Send> {
+    struct FormatStringPayload<'a> {
+        inner: &'a core::panic::PanicMessage<'a>,
+        string: Option<String>,
+    }
+
+    impl FormatStringPayload<'_> {
+        fn fill(&mut self) -> &mut String {
+            let inner = self.inner;
+            // Lazily, the first time this gets called, run the actual string formatting.
+            self.string.get_or_insert_with(|| {
+                let mut s = String::new();
+                let mut fmt = fmt::Formatter::new(&mut s, fmt::FormattingOptions::new());
+                let _err = fmt::Display::fmt(&inner, &mut fmt);
+                s
+            })
+        }
+    }
+
+    // Safety: TODO
+    unsafe impl PanicPayload for FormatStringPayload<'_> {
+        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+            let contents = mem::take(self.fill());
+            Box::into_raw(Box::new(contents))
+        }
+
+        fn get(&mut self) -> &(dyn Any + Send) {
+            self.fill()
+        }
+    }
+
+    impl fmt::Display for FormatStringPayload<'_> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            if let Some(s) = &self.string {
+                f.write_str(s)
+            } else {
+                fmt::Display::fmt(&self.inner, f)
+            }
+        }
+    }
+
+    struct StaticStrPayload(&'static str);
+
+    // Safety: TODO
+    unsafe impl PanicPayload for StaticStrPayload {
+        fn take_box(&mut self) -> *mut (dyn Any + Send) {
+            Box::into_raw(Box::new(self.0))
+        }
+
+        fn get(&mut self) -> &(dyn Any + Send) {
+            &self.0
+        }
+
+        fn as_str(&mut self) -> Option<&str> {
+            Some(self.0)
+        }
+    }
+
+    impl fmt::Display for StaticStrPayload {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    let msg = info.message();
+    if let Some(s) = msg.as_str() {
+        // Safety: take_box returns an unwrapped box
+        unsafe { Box::from_raw(StaticStrPayload(s).take_box()) }
+    } else {
+        // Safety: take_box returns an unwrapped box
+        unsafe {
+            Box::from_raw(
+                FormatStringPayload {
+                    inner: &msg,
+                    string: None,
+                }
+                .take_box(),
+            )
+        }
+    }
+}

--- a/libs/panic-unwind2/src/panic_count.rs
+++ b/libs/panic-unwind2/src/panic_count.rs
@@ -1,0 +1,81 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use core::{
+    cell::Cell,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+use cpu_local::cpu_local;
+
+/// A reason for forcing an immediate abort on panic.
+#[derive(Debug)]
+pub enum MustAbort {
+    // AlwaysAbort,
+    PanicInHook,
+}
+
+// Panic count for the current thread and whether a panic hook is currently
+// being executed.
+cpu_local! {
+    static LOCAL_PANIC_COUNT: Cell<(usize, bool)> = Cell::new((0, false));
+}
+
+static GLOBAL_PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+pub fn increase(run_panic_hook: bool) -> Option<MustAbort> {
+    LOCAL_PANIC_COUNT.with(|c| {
+        let (count, in_panic_hook) = c.get();
+        if in_panic_hook {
+            return Some(MustAbort::PanicInHook);
+        }
+        c.set((count + 1, run_panic_hook));
+        None
+    })
+}
+
+pub fn finished_panic_hook() {
+    LOCAL_PANIC_COUNT.with(|c| {
+        let (count, _) = c.get();
+        c.set((count, false));
+    });
+}
+
+pub fn decrease() {
+    GLOBAL_PANIC_COUNT.fetch_sub(1, Ordering::Relaxed);
+    LOCAL_PANIC_COUNT.with(|c| {
+        let (count, _) = c.get();
+        c.set((count - 1, false));
+    });
+}
+
+// Disregards ALWAYS_ABORT_FLAG
+#[must_use]
+#[inline]
+pub fn count_is_zero() -> bool {
+    if GLOBAL_PANIC_COUNT.load(Ordering::Relaxed) == 0 {
+        // Fast path: if `GLOBAL_PANIC_COUNT` is zero, all threads
+        // (including the current one) will have `LOCAL_PANIC_COUNT`
+        // equal to zero, so TLS access can be avoided.
+        //
+        // In terms of performance, a relaxed atomic load is similar to a normal
+        // aligned memory read (e.g., a mov instruction in x86), but with some
+        // compiler optimization restrictions. On the other hand, a TLS access
+        // might require calling a non-inlinable function (such as `__tls_get_addr`
+        // when using the GD TLS model).
+        true
+    } else {
+        is_zero_slow_path()
+    }
+}
+
+// Slow path is in a separate function to reduce the amount of code
+// inlined from `count_is_zero`.
+#[inline(never)]
+#[cold]
+fn is_zero_slow_path() -> bool {
+    LOCAL_PANIC_COUNT.with(|c| c.get().0 == 0)
+}


### PR DESCRIPTION
Just to make it more obvious that this crate isn't the `std` panic unwind impl