### PR TITLE
feat: async oneshot channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,10 +129,12 @@ name = "async-exec"
 version = "0.1.0"
 dependencies = [
  "async-exec",
+ "bitflags",
  "cfg-if",
  "cpu-local",
  "criterion 0.6.0",
  "fastrand",
+ "futures",
  "lazy_static",
  "loom",
  "mpsc-queue",
@@ -140,10 +142,33 @@ dependencies = [
  "panic-unwind2",
  "spin",
  "static_assertions",
+ "tokio-test",
  "tracing 0.2.0",
  "tracing-subscriber 0.3.0",
  "unwind2",
  "util",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -194,6 +219,12 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 dependencies = [
  "allocator-api2",
 ]
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "camino"
@@ -705,6 +736,7 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -728,10 +760,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -751,11 +805,16 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -1755,6 +1814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1906,6 +1974,40 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "tokio"
+version = "1.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+dependencies = [
+ "backtrace 0.3.75",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/libs/async-exec/Cargo.toml
+++ b/libs/async-exec/Cargo.toml
@@ -9,6 +9,10 @@ license.workspace = true
 name = "spawn"
 harness = false
 
+[[bench]]
+name = "ping_pong"
+harness = false
+
 [dependencies]
 util.workspace = true
 spin.workspace = true

--- a/libs/async-exec/Cargo.toml
+++ b/libs/async-exec/Cargo.toml
@@ -23,12 +23,15 @@ cfg-if.workspace = true
 static_assertions.workspace = true
 mycelium-bitfield.workspace = true
 tracing.workspace = true
+bitflags.workspace = true
 
 [dev-dependencies]
 async-exec = { path = ".", features = ["std"] }
 tracing-subscriber = { workspace = true, default-features = true, features = ["env-filter"] }
 lazy_static.workspace = true
 criterion.workspace = true
+tokio-test = "0.4.4"
+futures = "0.3.31"
 
 [target.'cfg(loom)'.dependencies]
 loom.workspace = true

--- a/libs/async-exec/benches/ping_pong.rs
+++ b/libs/async-exec/benches/ping_pong.rs
@@ -1,0 +1,135 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use async_exec::executor::{Executor, Worker};
+use async_exec::new_executor;
+use async_exec::park::StdPark;
+use criterion::{Criterion, criterion_group, criterion_main};
+use fastrand::FastRand;
+
+fn ping_ping_10k_single_threaded(c: &mut Criterion) {
+    static EXEC: Executor<StdPark> = new_executor!(1);
+    let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+
+    const PINGS: usize = 10_000;
+
+    c.bench_function("ping_ping_10k_single_threaded", |b| {
+        b.iter(|| {
+            let h = EXEC
+                .try_spawn(async {
+                    for _ in 0..PINGS {
+                        async_exec::task::yield_now().await;
+                    }
+                })
+                .unwrap();
+            worker.block_on(h).unwrap();
+        });
+    });
+}
+
+fn ping_pong_10k_single_threaded(c: &mut Criterion) {
+    static EXEC: Executor<StdPark> = new_executor!(1);
+    let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+
+    const PINGS: usize = 10_000;
+
+    c.bench_function("ping_pong_10k_single_threaded", |b| {
+        b.iter(|| {
+            let h1 = EXEC
+                .try_spawn(async {
+                    for _ in 0..PINGS {
+                        async_exec::task::yield_now().await;
+                    }
+                })
+                .unwrap();
+
+            let h2 = EXEC
+                .try_spawn(async {
+                    for _ in 0..PINGS {
+                        async_exec::task::yield_now().await;
+                    }
+                })
+                .unwrap();
+
+            worker.block_on(futures::future::try_join(h1, h2)).unwrap();
+        });
+    });
+}
+
+fn ping_ping_10k_multi_threaded(c: &mut Criterion) {
+    static EXEC: Executor<StdPark> = new_executor!(1);
+    let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+
+    let h = std::thread::spawn(|| {
+        let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+        worker.run();
+    });
+
+    const PINGS: usize = 10_000;
+
+    c.bench_function("ping_ping_10k_multi_threaded", |b| {
+        b.iter(|| {
+            let h = EXEC
+                .try_spawn(async {
+                    for _ in 0..PINGS {
+                        async_exec::task::yield_now().await;
+                    }
+                })
+                .unwrap();
+            worker.block_on(h).unwrap();
+        });
+    });
+
+    EXEC.stop();
+    h.join().unwrap();
+}
+
+fn ping_pong_10k_multi_threaded(c: &mut Criterion) {
+    static EXEC: Executor<StdPark> = new_executor!(1);
+    let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+
+    let h = std::thread::spawn(|| {
+        let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+        worker.run();
+    });
+
+    const PINGS: usize = 10_000;
+
+    c.bench_function("ping_pong_10k_multi_threaded", |b| {
+        b.iter(|| {
+            let h1 = EXEC
+                .try_spawn(async {
+                    for _ in 0..PINGS {
+                        async_exec::task::yield_now().await;
+                    }
+                })
+                .unwrap();
+
+            let h2 = EXEC
+                .try_spawn(async {
+                    for _ in 0..PINGS {
+                        async_exec::task::yield_now().await;
+                    }
+                })
+                .unwrap();
+
+            worker.block_on(futures::future::try_join(h1, h2)).unwrap();
+        });
+    });
+
+    EXEC.stop();
+    h.join().unwrap();
+}
+
+criterion_group!(
+    ping_pong,
+    ping_ping_10k_single_threaded,
+    ping_pong_10k_single_threaded,
+    ping_ping_10k_multi_threaded,
+    ping_pong_10k_multi_threaded,
+);
+criterion_main!(ping_pong);

--- a/libs/async-exec/src/executor.rs
+++ b/libs/async-exec/src/executor.rs
@@ -84,6 +84,14 @@ where
         TaskBuilder::new()
     }
 
+    /// Attempt to spawn this [`Future`] onto the executor.
+    ///
+    /// This method returns a [`JoinHandle`] which can be used to await the futures output as
+    /// well as control some aspects of its runtime behaviour (such as cancelling it).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] when allocation of the task fails.
     #[inline]
     #[track_caller]
     pub fn try_spawn<F>(&'static self, future: F) -> Result<JoinHandle<F::Output>, AllocError>
@@ -96,6 +104,14 @@ where
         Ok(join)
     }
 
+    /// Attempt to spawn this [`Future`] onto the executor using a custom [`Allocator`].
+    ///
+    /// This method returns a [`JoinHandle`] which can be used to await the futures output as
+    /// well as control some aspects of its runtime behaviour (such as cancelling it).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AllocError`] when allocation of the task fails.
     #[inline]
     #[track_caller]
     pub fn try_spawn_in<F, A>(

--- a/libs/async-exec/src/sync.rs
+++ b/libs/async-exec/src/sync.rs
@@ -4,3 +4,25 @@
 // http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
+
+pub mod oneshot;
+pub mod wait_cell;
+
+pub use wait_cell::WaitCell;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Closed(());
+
+impl Closed {
+    pub(crate) const fn new() -> Self {
+        Self(())
+    }
+}
+
+impl core::fmt::Display for Closed {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.pad("closed")
+    }
+}
+
+impl core::error::Error for Closed {}

--- a/libs/async-exec/src/sync/oneshot.rs
+++ b/libs/async-exec/src/sync/oneshot.rs
@@ -1,0 +1,168 @@
+use crate::loom::cell::UnsafeCell;
+use crate::sync::WaitCell;
+use alloc::sync::Arc;
+use core::fmt;
+use core::pin::Pin;
+use core::task::{Context, Poll, ready};
+
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+    let inner = Arc::new(Inner {
+        value: UnsafeCell::new(None),
+        rx_waker: WaitCell::new(),
+    });
+
+    let tx = Sender {
+        inner: Some(inner.clone()),
+    };
+    let rx = Receiver { inner };
+
+    (tx, rx)
+}
+
+#[derive(Debug)]
+pub struct Sender<T> {
+    inner: Option<Arc<Inner<T>>>,
+}
+
+#[derive(Debug)]
+pub struct Receiver<T> {
+    inner: Arc<Inner<T>>,
+}
+
+#[derive(Debug)]
+struct Inner<T> {
+    value: UnsafeCell<Option<T>>,
+    rx_waker: WaitCell,
+}
+
+unsafe impl<T: Send> Send for Inner<T> {}
+unsafe impl<T: Send> Sync for Inner<T> {}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct RecvError(pub(super) ());
+
+// === impl Sender ===
+
+impl<T: fmt::Debug> Sender<T> {
+    pub fn is_closed(&self) -> bool {
+        let inner = self.inner.as_ref().unwrap();
+        inner.rx_waker.is_closed()
+    }
+
+    #[tracing::instrument]
+    pub fn send(mut self, value: T) -> Result<(), T> {
+        let inner = self.inner.take().unwrap();
+
+        if inner.rx_waker.is_closed() {
+            return Err(value);
+        }
+
+        inner.value.with_mut(|ptr| unsafe {
+            *ptr = Some(value);
+        });
+
+        inner.rx_waker.wake();
+
+        Ok(())
+    }
+}
+
+// === impl Receiver ===
+
+impl<T: fmt::Debug> Receiver<T> {
+    pub fn close(&mut self) {
+        self.inner.as_ref().rx_waker.close();
+    }
+
+    #[tracing::instrument]
+    pub fn poll_recv(&self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
+        let inner = &self.inner;
+
+        if let Some(value) = self.take_value() {
+            return Poll::Ready(Ok(value));
+        }
+
+        let res = inner.rx_waker.poll_wait(cx).map_err(|_| RecvError(()));
+        tracing::trace!(?res);
+        ready!(res)?;
+
+        let value = self.take_value().unwrap();
+
+        Poll::Ready(Ok(value))
+    }
+
+    fn take_value(&self) -> Option<T> {
+        self.inner.value.with_mut(|ptr| unsafe { (*ptr).take() })
+    }
+}
+
+impl<T: fmt::Debug> Future for Receiver<T> {
+    type Output = Result<T, RecvError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::{Executor, Worker};
+    use crate::loom;
+    use crate::loom::sync::atomic::{AtomicUsize, Ordering};
+    use crate::park::StdPark;
+    use fastrand::FastRand;
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::util::SubscriberInitExt;
+    // use tracing_subscriber::fmt::format::FmtSpan;
+    // use tracing_subscriber::util::SubscriberInitExt;
+    // use tracing_subscriber::EnvFilter;
+
+    loom::lazy_static! {
+        static ref EXEC: Executor<StdPark> = Executor::new(1);
+    }
+
+    #[test]
+    fn oneshot_ping_pong() {
+        #[cfg(loom)] // loom can do *fewer* pings, but in like a cutesy way
+        const NUM_PINGS: usize = 7;
+        #[cfg(not(loom))]
+        const NUM_PINGS: usize = 10_000;
+
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        loom::model(|| {
+            let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
+            let rem = Arc::new(AtomicUsize::new(NUM_PINGS));
+
+            let h = EXEC
+                .try_spawn(async {
+                    for _ in 0..NUM_PINGS {
+                        let rem = rem.clone();
+
+                        let (tx1, rx1) = channel();
+                        let (tx2, rx2) = channel();
+
+                        EXEC.try_spawn(async {
+                            rx1.await.unwrap();
+                            tx2.send(()).unwrap();
+                        })
+                        .unwrap();
+
+                        tx1.send(()).unwrap();
+                        rx2.await.unwrap();
+
+                        if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                            tracing::info!("done!");
+                        }
+                    }
+                })
+                .unwrap();
+
+            worker.block_on(h).unwrap();
+        });
+    }
+}

--- a/libs/async-exec/src/sync/wait_cell.rs
+++ b/libs/async-exec/src/sync/wait_cell.rs
@@ -1,0 +1,725 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::loom::cell::UnsafeCell;
+use crate::loom::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::Closed;
+use bitflags::bitflags;
+use core::panic::{RefUnwindSafe, UnwindSafe};
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+use core::{fmt, task};
+use static_assertions::const_assert_eq;
+use util::{CachePadded, loom_const_fn};
+
+/// An atomically registered [`Waker`].
+///
+/// This cell stores the [`Waker`] of a single task. A [`Waker`] is stored in
+/// the cell either by calling [`poll_wait`], or by polling a [`wait`]
+/// future. Once a task's [`Waker`] is stored in a `WaitCell`, it can be woken
+/// by calling [`wake`] on the `WaitCell`.
+///
+/// # Implementation Notes
+///
+/// This type is copied from [`maitake-sync`](https://github.com/hawkw/mycelium/blob/dd0020892564c77ee4c20ffbc2f7f5b046ad54c8/maitake-sync/src/wait_cell.rs)
+/// which is in turn inspired by the [`AtomicWaker`] type used in Tokio's
+/// synchronization primitives, with the following modifications:
+///
+/// - An additional bit of state is added to allow [setting a "close"
+///   bit](Self::close).
+/// - A `WaitCell` is always woken by value (for now).
+///
+/// [`AtomicWaker`]: https://github.com/tokio-rs/tokio/blob/09b770c5db31a1f35631600e1d239679354da2dd/tokio/src/sync/task/atomic_waker.rs
+/// [`Waker`]: Waker
+/// [`poll_wait`]: Self::poll_wait
+/// [`wait`]: Self::wait
+/// [`wake`]: Self::wake
+pub struct WaitCell {
+    state: CachePadded<AtomicUsize>,
+    waker: UnsafeCell<Option<Waker>>,
+}
+
+bitflags! {
+    #[derive(Debug, PartialEq, Eq)]
+    struct State: usize {
+        const WAITING = 0b0000;
+        const REGISTERING = 0b0001;
+        const WAKING = 0b0010;
+        const WOKEN = 0b0100;
+        const CLOSED = 0b1000;
+    }
+}
+// WAITING MUST be zero
+const_assert_eq!(State::WAITING.bits(), 0);
+
+/// Future returned from [`WaitCell::wait()`].
+///
+/// This future is fused, so once it has completed, any future calls to poll
+/// will immediately return [`Poll::Ready`].
+#[derive(Debug)]
+#[must_use = "futures do nothing unless `.await`ed or `poll`ed"]
+pub struct Wait<'a> {
+    /// The [`WaitCell`] being waited on.
+    cell: &'a WaitCell,
+
+    presubscribe: Poll<Result<(), Closed>>,
+}
+
+/// Future returned from [`WaitCell::subscribe()`].
+///
+/// See the documentation for [`WaitCell::subscribe()`] for details.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless `.await`ed or `poll`ed"]
+pub struct Subscribe<'a> {
+    /// The [`WaitCell`] being waited on.
+    cell: &'a WaitCell,
+}
+
+/// An error indicating that a [`WaitCell`] was closed or busy while
+/// attempting register a [`Waker`].
+///
+/// This error is returned by the [`WaitCell::poll_wait`] method.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum PollWaitError {
+    /// The [`Waker`] was not registered because the [`WaitCell`] has been
+    /// [closed](WaitCell::close).
+    Closed,
+
+    /// The [`Waker`] was not registered because another task was concurrently
+    /// storing its own [`Waker`] in the [`WaitCell`].
+    Busy,
+}
+
+// === impl WaitCell ===
+
+impl WaitCell {
+    loom_const_fn! {
+        pub const fn new() -> Self {
+            Self {
+                state: CachePadded(AtomicUsize::new(State::WAITING.bits())),
+                waker: UnsafeCell::new(None),
+            }
+        }
+    }
+
+    #[tracing::instrument]
+    pub fn poll_wait(&self, cx: &mut Context<'_>) -> Poll<Result<(), PollWaitError>> {
+        // this is based on tokio's AtomicWaker synchronization strategy
+        match self.compare_exchange(State::WAITING, State::REGISTERING, Ordering::Acquire) {
+            Err(actual) if actual.contains(State::CLOSED) => {
+                return Poll::Ready(Err(PollWaitError::Closed));
+            }
+            Err(actual) if actual.contains(State::WOKEN) => {
+                // take the wakeup
+                self.fetch_and(!State::WOKEN, Ordering::Release);
+                return Poll::Ready(Ok(()));
+            }
+            // someone else is notifying, so don't wait!
+            Err(actual) if actual.contains(State::WAKING) => {
+                return Poll::Ready(Ok(()));
+            }
+            Err(_) => return Poll::Ready(Err(PollWaitError::Busy)),
+            Ok(_) => {}
+        }
+
+        let waker = cx.waker();
+        tracing::trace!(wait_cell = ?self, ?waker, "registering waker");
+
+        // Safety: No one else is touching the waker right now, so it is safe to access it
+        // mutably
+        let prev_waker = self.waker.with_mut(|old_waker| unsafe {
+            match &mut *old_waker {
+                Some(old_waker) if waker.will_wake(old_waker) => None,
+                old => old.replace(waker.clone()),
+            }
+        });
+
+        if let Some(prev_waker) = prev_waker {
+            tracing::trace!("Replaced an old waker in cell, waking");
+            prev_waker.wake();
+        }
+
+        if let Err(actual) =
+            self.compare_exchange(State::REGISTERING, State::WAITING, Ordering::AcqRel)
+        {
+            // If the `compare_exchange` fails above, this means that we were notified for one of
+            // two reasons: either the cell was awoken, or the cell was closed.
+            //
+            // Bail out of the parking state, and determine what to report to the caller.
+            // Safety: No one else is touching the waker right now, so it is safe to access it
+            // mutably
+            tracing::trace!(state = ?actual, "was notified");
+            let waker = self.waker.with_mut(|waker| unsafe { (*waker).take() });
+
+            // Reset to the WAITING state by clearing everything *except*
+            // the closed bits (which must remain set). This `fetch_and`
+            // does *not* set the CLOSED bit if it is unset, it just doesn't
+            // clear it.
+            let state = self.fetch_and(State::CLOSED, Ordering::AcqRel);
+            // The only valid state transition while we were parking is to
+            // add the CLOSED bit.
+            debug_assert!(
+                state == actual || state == actual | State::CLOSED,
+                "state changed unexpectedly while parking!"
+            );
+
+            if let Some(waker) = waker {
+                waker.wake();
+            }
+
+            // Was the `CLOSED` bit set while we were clearing other bits?
+            // If so, the cell is closed. Otherwise, we must have been notified.
+            if state.contains(State::CLOSED) {
+                return Poll::Ready(Err(PollWaitError::Closed));
+            }
+
+            return Poll::Ready(Ok(()));
+        }
+
+        // Waker registered, time to yield!
+        Poll::Pending
+    }
+
+    /// Wait to be woken up by this cell.
+    ///
+    /// # Returns
+    ///
+    /// This future completes with the following values:
+    ///
+    /// - [`Ok`]`(())` if the future was woken by a call to [`wake`] or another
+    ///   task calling [`poll_wait`] or [`wait`] on this [`WaitCell`].
+    /// - [`Err`]`(`[`Closed`]`)` if the task was woken by a call to [`close`],
+    ///   or the [`WaitCell`] was already closed.
+    ///
+    /// **Note**: The calling task's [`Waker`] is not registered until AFTER the
+    /// first time the returned [`Wait`] future is polled. This means that if a
+    /// call to [`wake`] occurs between when [`wait`] is called and when the
+    /// future is first polled, the future will *not* complete. If the caller is
+    /// responsible for performing an operation which will result in an eventual
+    /// wakeup, prefer calling [`subscribe`] _before_ performing that operation
+    /// and `.await`ing the [`Wait`] future returned by [`subscribe`].
+    ///
+    /// [`wake`]: Self::wake
+    /// [`poll_wait`]: Self::poll_wait
+    /// [`wait`]: Self::wait
+    /// [`close`]: Self::close
+    /// [`subscribe`]: Self::subscribe
+    pub fn wait(&self) -> Wait<'_> {
+        Wait {
+            cell: self,
+            presubscribe: Poll::Pending,
+        }
+    }
+
+    /// Eagerly subscribe to notifications from this `WaitCell`.
+    ///
+    /// This method returns a [`Subscribe`] [`Future`], which outputs a [`Wait`]
+    /// [`Future`]. Awaiting the [`Subscribe`] future will eagerly register the
+    /// calling task to be woken by this [`WaitCell`], so that the returned
+    /// [`Wait`] future will be woken by any calls to [`wake`] (or [`close`])
+    /// that occur between when the [`Subscribe`] future completes and when the
+    /// returned [`Wait`] future is `.await`ed.
+    ///
+    /// This is primarily intended for scenarios where the task that waits on a
+    /// [`WaitCell`] is responsible for performing some operation that
+    /// ultimately results in the [`WaitCell`] being woken. If the task were to
+    /// simply perform the operation and then call [`wait`] on the [`WaitCell`],
+    /// a potential race condition could occur where the operation completes and
+    /// wakes the [`WaitCell`] *before* the [`Wait`] future is first `.await`ed.
+    /// Using `subscribe`, the task can ensure that it is ready to be woken by
+    /// the cell *before* performing an operation that could result in it being
+    /// woken.
+    ///
+    /// These scenarios occur when a wakeup is triggered by another thread/CPU
+    /// core in response to an operation performed in the task waiting on the
+    /// `WaitCell`, or when the wakeup is triggered by a hardware interrupt
+    /// resulting from operations performed in the task.
+    ///
+    /// [`wait`]: Self::wait
+    /// [`wake`]: Self::wake
+    /// [`close`]: Self::close
+    pub fn subscribe(&self) -> Subscribe<'_> {
+        Subscribe { cell: self }
+    }
+
+    /// Wake the [`Waker`] stored in this cell.
+    ///
+    /// # Returns
+    ///
+    /// - `true` if a waiting task was woken.
+    /// - `false` if no task was woken (no [`Waker`] was stored in the cell)
+    #[tracing::instrument]
+    pub fn wake(&self) -> bool {
+        if let Some(waker) = self.take_waker(false) {
+            waker.wake();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Close the [`WaitCell`].
+    ///
+    /// This wakes any waiting task with an error indicating the `WaitCell` is
+    /// closed. Subsequent calls to [`wait`] or [`poll_wait`] will return an
+    /// error indicating that the cell has been closed.
+    ///
+    /// [`wait`]: Self::wait
+    /// [`poll_wait`]: Self::poll_wait
+    #[tracing::instrument]
+    pub fn close(&self) -> bool {
+        if let Some(waker) = self.take_waker(true) {
+            waker.wake();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns `true` if this `WaitCell` is [closed](Self::close).
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.current_state() == State::CLOSED
+    }
+
+    /// Asynchronously poll the given function `f` until a condition occurs,
+    /// using the [`WaitCell`] to only re-poll when notified.
+    ///
+    /// This can be used to implement a "wait loop", turning a "try" function
+    /// (e.g. "try_recv" or "try_send") into an asynchronous function (e.g.
+    /// "recv" or "send").
+    ///
+    /// In particular, this function correctly *registers* interest in the [`WaitCell`]
+    /// prior to polling the function, ensuring that there is not a chance of a race
+    /// where the condition occurs AFTER checking but BEFORE registering interest
+    /// in the [`WaitCell`], which could lead to deadlock.
+    ///
+    /// This is intended to have similar behavior to `Condvar` in the standard library,
+    /// but asynchronous, and not requiring operating system intervention (or existence).
+    ///
+    /// In particular, this can be used in cases where interrupts or events are used
+    /// to signify readiness or completion of some task, such as the completion of a
+    /// DMA transfer, or reception of an ethernet frame. In cases like this, the interrupt
+    /// can wake the cell, allowing the polling function to check status fields for
+    /// partial progress or completion.
+    ///
+    /// Consider using [`Self::wait_for_value()`] if your function does return a value.
+    ///
+    // Consider using [`WaitQueue::wait_for()`](super::wait_queue::WaitQueue::wait_for)
+    // if you need multiple waiters.
+    ///
+    /// # Returns
+    ///
+    /// * [`Ok`]`(())` if the closure returns `true`.
+    /// * [`Err`]`(`[`Closed`]`)` if the [`WaitCell`] is closed.
+    pub async fn wait_for<F: FnMut() -> bool>(&self, mut f: F) -> Result<(), Closed> {
+        loop {
+            let wait = self.subscribe().await;
+            if f() {
+                return Ok(());
+            }
+            wait.await?;
+        }
+    }
+
+    // Asynchronously poll the given function `f` until a condition occurs,
+    /// using the [`WaitCell`] to only re-poll when notified.
+    ///
+    /// This can be used to implement a "wait loop", turning a "try" function
+    /// (e.g. "try_recv" or "try_send") into an asynchronous function (e.g.
+    /// "recv" or "send").
+    ///
+    /// In particular, this function correctly *registers* interest in the [`WaitCell`]
+    /// prior to polling the function, ensuring that there is not a chance of a race
+    /// where the condition occurs AFTER checking but BEFORE registering interest
+    /// in the [`WaitCell`], which could lead to deadlock.
+    ///
+    /// This is intended to have similar behavior to `Condvar` in the standard library,
+    /// but asynchronous, and not requiring operating system intervention (or existence).
+    ///
+    /// In particular, this can be used in cases where interrupts or events are used
+    /// to signify readiness or completion of some task, such as the completion of a
+    /// DMA transfer, or reception of an ethernet frame. In cases like this, the interrupt
+    /// can wake the cell, allowing the polling function to check status fields for
+    /// partial progress or completion, and also return the status flags at the same time.
+    ///
+    /// Consider using [`Self::wait_for()`] if your function does not return a value.
+    ///
+    // Consider using [`WaitQueue::wait_for_value()`](super::wait_queue::WaitQueue::wait_for_value) if you need multiple waiters.
+    ///
+    /// * [`Ok`]`(T)` if the closure returns [`Some`]`(T)`.
+    /// * [`Err`]`(`[`Closed`]`)` if the [`WaitCell`] is closed.
+    pub async fn wait_for_value<T, F: FnMut() -> Option<T>>(&self, mut f: F) -> Result<T, Closed> {
+        loop {
+            let wait = self.subscribe().await;
+            if let Some(t) = f() {
+                return Ok(t);
+            }
+            wait.await?;
+        }
+    }
+
+    #[tracing::instrument]
+    fn take_waker(&self, close: bool) -> Option<Waker> {
+        // Set the WAKING bit (to indicate that we're touching the waker) and
+        // the WOKEN bit (to indicate that we intend to wake it up).
+        let state = {
+            let mut bits = State::WAKING | State::WOKEN;
+            if close {
+                bits.0 |= State::CLOSED.0;
+            }
+            self.fetch_or(bits, Ordering::AcqRel)
+        };
+
+        // Is anyone else touching the waker?
+        if !state.contains(State::WAKING | State::REGISTERING | State::CLOSED) {
+            // Safety: No one else is touching the waker right now, so it is safe to access it
+            // mutably
+            let waker = self.waker.with_mut(|thread| unsafe { (*thread).take() });
+
+            // Release the lock.
+            self.fetch_and(!State::WAKING, Ordering::Release);
+
+            if let Some(waker) = waker {
+                tracing::trace!(wait_cell = ?self, ?close, ?waker, "notified");
+                return Some(waker);
+            }
+        }
+
+        None
+    }
+
+    #[inline(always)]
+    fn compare_exchange(&self, curr: State, new: State, success: Ordering) -> Result<State, State> {
+        self.state
+            .0
+            .compare_exchange(curr.bits(), new.bits(), success, Ordering::Acquire)
+            .map(State::from_bits_retain)
+            .map_err(State::from_bits_retain)
+    }
+
+    #[inline(always)]
+    fn fetch_and(&self, state: State, order: Ordering) -> State {
+        State::from_bits_retain(self.state.0.fetch_and(state.bits(), order))
+    }
+
+    #[inline(always)]
+    fn fetch_or(&self, state: State, order: Ordering) -> State {
+        State::from_bits_retain(self.state.0.fetch_or(state.bits(), order))
+    }
+
+    #[inline(always)]
+    fn current_state(&self) -> State {
+        State::from_bits_retain(self.state.0.load(Ordering::Acquire))
+    }
+}
+
+impl Default for WaitCell {
+    fn default() -> Self {
+        WaitCell::new()
+    }
+}
+
+impl RefUnwindSafe for WaitCell {}
+impl UnwindSafe for WaitCell {}
+
+// Safety: `WaitCell` synchronizes all accesses through atomic operations
+unsafe impl Send for WaitCell {}
+// Safety: `WaitCell` synchronizes all accesses through atomic operations
+unsafe impl Sync for WaitCell {}
+
+impl fmt::Debug for WaitCell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WaitCell")
+            .field("state", &self.current_state())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for WaitCell {
+    fn drop(&mut self) {
+        self.close();
+    }
+}
+
+// === impl Wait ===
+
+impl Future for Wait<'_> {
+    type Output = Result<(), Closed>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Did a wakeup occur while we were pre-registering the future?
+        if self.presubscribe.is_ready() {
+            return self.presubscribe;
+        }
+
+        // Okay, actually poll the cell, then.
+        match task::ready!(self.cell.poll_wait(cx)) {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(PollWaitError::Closed) => Poll::Ready(Err(Closed::new())),
+            Err(PollWaitError::Busy) => {
+                // If some other task was registering, yield and try to re-register
+                // our waker when that task is done.
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+}
+
+// === impl Subscribe ===
+
+impl<'cell> Future for Subscribe<'cell> {
+    type Output = Wait<'cell>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // Pre-register the waker in the cell.
+        let presubscribe = match self.cell.poll_wait(cx) {
+            Poll::Ready(Err(PollWaitError::Busy)) => {
+                // Someone else is in the process of registering. Yield now so we
+                // can wait until that task is done, and then try again.
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            Poll::Ready(Err(PollWaitError::Closed)) => Poll::Ready(Err(Closed::new())),
+            Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        };
+
+        Poll::Ready(Wait {
+            cell: self.cell,
+            presubscribe,
+        })
+    }
+}
+
+#[cfg(all(not(loom), test))]
+mod tests {
+    use super::*;
+    use alloc::sync::Arc;
+
+    use tokio_test::{assert_pending, assert_ready, assert_ready_ok, task};
+    use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::util::SubscriberInitExt;
+
+    #[test]
+    fn wait_smoke() {
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        let wait = Arc::new(WaitCell::new());
+
+        let mut task = task::spawn({
+            let wait = wait.clone();
+            async move { wait.wait().await }
+        });
+
+        assert_pending!(task.poll());
+
+        assert!(wait.wake());
+
+        assert!(task.is_woken());
+        assert_ready_ok!(task.poll());
+    }
+
+    /// Reproduces https://github.com/hawkw/mycelium/issues/449
+    #[test]
+    fn wait_spurious_poll() {
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        let cell = Arc::new(WaitCell::new());
+        let mut task = task::spawn({
+            let cell = cell.clone();
+            async move { cell.wait().await }
+        });
+
+        assert_pending!(task.poll(), "first poll should be pending");
+        assert_pending!(task.poll(), "second poll should be pending");
+
+        cell.wake();
+
+        assert_ready_ok!(task.poll(), "should have been woken");
+    }
+
+    #[test]
+    fn subscribe() {
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        futures::executor::block_on(async {
+            let cell = WaitCell::new();
+            let wait = cell.subscribe().await;
+            cell.wake();
+            wait.await.unwrap();
+        })
+    }
+
+    #[test]
+    fn wake_before_subscribe() {
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        let cell = Arc::new(WaitCell::new());
+        cell.wake();
+
+        let mut task = task::spawn({
+            let cell = cell.clone();
+            async move {
+                let wait = cell.subscribe().await;
+                wait.await.unwrap();
+            }
+        });
+
+        assert_ready!(task.poll(), "woken task should complete");
+
+        let mut task = task::spawn({
+            let cell = cell.clone();
+            async move {
+                let wait = cell.subscribe().await;
+                wait.await.unwrap();
+            }
+        });
+
+        assert_pending!(task.poll(), "wait cell hasn't been woken yet");
+        cell.wake();
+        assert!(task.is_woken());
+        assert_ready!(task.poll());
+    }
+
+    #[test]
+    fn wake_debounce() {
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        let cell = Arc::new(WaitCell::new());
+
+        let mut task = task::spawn({
+            let cell = cell.clone();
+            async move {
+                cell.wait().await.unwrap();
+            }
+        });
+
+        assert_pending!(task.poll());
+        cell.wake();
+        cell.wake();
+        assert!(task.is_woken());
+        assert_ready!(task.poll());
+
+        let mut task = task::spawn({
+            let cell = cell.clone();
+            async move {
+                cell.wait().await.unwrap();
+            }
+        });
+
+        assert_pending!(task.poll());
+        assert!(!task.is_woken());
+
+        cell.wake();
+        assert!(task.is_woken());
+        assert_ready!(task.poll());
+    }
+
+    #[test]
+    fn subscribe_doesnt_self_wake() {
+        let _trace = tracing_subscriber::fmt()
+            .with_env_filter(EnvFilter::from_default_env())
+            .with_thread_ids(true)
+            .set_default();
+
+        let cell = Arc::new(WaitCell::new());
+
+        let mut task = task::spawn({
+            let cell = cell.clone();
+            async move {
+                let wait = cell.subscribe().await;
+                wait.await.unwrap();
+                let wait = cell.subscribe().await;
+                wait.await.unwrap();
+            }
+        });
+        assert_pending!(task.poll());
+        assert!(!task.is_woken());
+
+        cell.wake();
+        assert!(task.is_woken());
+        assert_pending!(task.poll());
+
+        assert!(!task.is_woken());
+        assert_pending!(task.poll());
+
+        cell.wake();
+        assert!(task.is_woken());
+        assert_ready!(task.poll());
+    }
+}
+
+// #[cfg(all(loom, test))]
+// mod loom {
+//     use super::*;
+//     use crate::loom::{future, sync::Arc, thread};
+//
+//     #[test]
+//     fn basic() {
+//         crate::loom::model(|| {
+//             let wait = Arc::new(WaitCell::new());
+//
+//             let waker = wait.clone();
+//             let closer = wait.clone();
+//
+//             thread::spawn(move || {
+//                 tracing::info!("waking");
+//                 waker.wake();
+//                 tracing::info!("woken");
+//             });
+//             thread::spawn(move || {
+//                 tracing::info!("closing");
+//                 closer.close();
+//                 tracing::info!("closed");
+//             });
+//
+//             tracing::info!("waiting");
+//             let _ = future::block_on(wait.wait());
+//             tracing::info!("wait'd");
+//         });
+//     }
+//
+//     #[test]
+//     fn subscribe() {
+//         crate::loom::model(|| {
+//             future::block_on(async move {
+//                 let cell = Arc::new(WaitCell::new());
+//                 let wait = cell.subscribe().await;
+//
+//                 thread::spawn({
+//                     let waker = cell.clone();
+//                     move || {
+//                         tracing::info!("waking");
+//                         waker.wake();
+//                         tracing::info!("woken");
+//                     }
+//                 });
+//
+//                 tracing::info!("waiting");
+//                 wait.await.expect("wait should be woken, not closed");
+//                 tracing::info!("wait'd");
+//             });
+//         });
+//     }
+// }

--- a/libs/async-exec/src/task/state.rs
+++ b/libs/async-exec/src/task/state.rs
@@ -378,9 +378,8 @@ impl State {
     /// Cancel the task.
     ///
     /// Returns `true` if the task was successfully canceled.
+    #[tracing::instrument(level = "debug")]
     pub(super) fn cancel(&self) -> bool {
-        tracing::trace!("State::cancel");
-
         self.transition(|s| {
             // you can't cancel a task that has already been canceled, that doesn't make sense.
             if s.get(Snapshot::CANCELLED) {
@@ -393,9 +392,8 @@ impl State {
         })
     }
 
+    #[tracing::instrument(level = "debug")]
     pub(super) fn create_join_handle(&self) {
-        tracing::trace!("State::create_join_handle");
-
         self.transition(|s| {
             debug_assert!(
                 !s.get(Snapshot::HAS_JOIN_HANDLE),
@@ -406,9 +404,8 @@ impl State {
         });
     }
 
+    #[tracing::instrument(level = "debug")]
     pub(super) fn drop_join_handle(&self) {
-        tracing::trace!("State::drop_join_handle");
-
         const MASK: usize = !Snapshot::HAS_JOIN_HANDLE.raw_mask();
         let _prev = self.val.fetch_and(MASK, Ordering::Release);
         tracing::trace!(


### PR DESCRIPTION
This PR adds an async `oneshot` channel, which can be used to transfer ownership of a value from one task to another.