### PR TITLE
refactor: simplify cpu-local

### DIFF
--- a/kernel/src/arch/riscv64/device/cpu.rs
+++ b/kernel/src/arch/riscv64/device/cpu.rs
@@ -96,14 +96,14 @@ pub fn with_cpu<F, R>(f: F) -> R
 where
     F: FnOnce(&Cpu) -> R,
 {
-    CPU.with(|cpu_info| f(cpu_info.get().expect("CPU info not initialized")))
+    f(CPU.get().expect("CPU info not initialized"))
 }
 
 pub fn try_with_cpu<F, R>(f: F) -> crate::Result<R>
 where
     F: FnOnce(&Cpu) -> R,
 {
-    CPU.with(|cpu_info| cpu_info.get().context("CPU info not initialized").map(f))
+    CPU.get().context("CPU info not initialized").map(f)
 }
 
 #[cold]
@@ -167,8 +167,8 @@ pub fn init(devtree: &DeviceTree) -> crate::Result<()> {
         Ticks(timebase_frequency)
     );
 
-    CPU.with(|info| {
-        let info_ = Cpu {
+    CPU.set({
+        let info = Cpu {
             clock,
             extensions,
             cbop_block_size,
@@ -176,10 +176,10 @@ pub fn init(devtree: &DeviceTree) -> crate::Result<()> {
             cbom_block_size,
             plic: RefCell::new(plic),
         };
-        tracing::debug!("\n{info_}");
-
-        info.set(info_).unwrap();
-    });
+        tracing::debug!("\n{info}");
+        info
+    })
+    .unwrap();
 
     Ok(())
 }

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -30,7 +30,8 @@ pub fn init() {
     let trap_stack_top = unsafe {
         TRAP_STACK
             .as_ptr()
-            .byte_add(TRAP_STACK_SIZE_PAGES * PAGE_SIZE) as *mut u8
+            .byte_add(TRAP_STACK_SIZE_PAGES * PAGE_SIZE)
+            .cast_mut()
     };
 
     tracing::trace!("setting sscratch to {:p}", trap_stack_top);

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -223,7 +223,7 @@ impl Scheduler {
             static PARK: ParkToken = ParkToken::new(crate::CPUID.get());
         }
 
-        let waker = PARK.with(|park| park.clone().into_unpark().into_waker());
+        let waker = PARK.clone().into_unpark().into_waker();
         let mut cx = Context::from_waker(&waker);
 
         let mut future = pin!(future);
@@ -235,7 +235,7 @@ impl Scheduler {
 
             // If there is only one CPU in the system we cannot go to sleep
             if self.cores.len() > 1 {
-                PARK.with(|park| park.park());
+                PARK.park();
             }
         }
     }

--- a/kernel/src/tracing/mod.rs
+++ b/kernel/src/tracing/mod.rs
@@ -78,7 +78,7 @@ pub fn init(filter: Filter) {
 /// Perform late, per-CPU initialization. This will enable the proper printing of timestamps and
 /// should be called *after* per-CPU clocks have been brought online.
 pub fn per_cpu_init_late(time_base: Instant) {
-    TIME_BASE.set(Some(time_base));
+    TIME_BASE.replace(Some(time_base));
 }
 
 struct Subscriber {
@@ -302,7 +302,7 @@ fn write_timestamp<W>(w: &mut W) -> fmt::Result
 where
     W: Write + SetColor,
 {
-    let time_base = TIME_BASE.with_borrow(|time_base| *time_base);
+    let time_base = *TIME_BASE.borrow();
 
     w.write_char('[')?;
     if let Some(time_base) = time_base {

--- a/libs/cpu-local/src/collection.rs
+++ b/libs/cpu-local/src/collection.rs
@@ -563,7 +563,7 @@ cpu_local! {
 }
 
 fn cpuid() -> usize {
-    CPUID.with(|id| *id)
+    *CPUID
 }
 
 #[cfg(test)]

--- a/libs/ksharded-slab/src/tid.rs
+++ b/libs/ksharded-slab/src/tid.rs
@@ -62,11 +62,11 @@ impl<C: cfg::Config> Pack<C> for Tid<C> {
 impl<C: cfg::Config> Tid<C> {
     #[inline]
     pub(crate) fn current() -> Self {
-        REGISTRATION.with(Registration::current)
+        REGISTRATION.current()
     }
 
     pub(crate) fn is_current(self) -> bool {
-        REGISTRATION.with(|r| self == r.current::<C>())
+        self == REGISTRATION.current::<C>()
     }
 
     #[inline(always)]

--- a/libs/panic-unwind2/src/panic_count.rs
+++ b/libs/panic-unwind2/src/panic_count.rs
@@ -27,29 +27,23 @@ cpu_local! {
 static GLOBAL_PANIC_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 pub fn increase(run_panic_hook: bool) -> Option<MustAbort> {
-    LOCAL_PANIC_COUNT.with(|c| {
-        let (count, in_panic_hook) = c.get();
-        if in_panic_hook {
-            return Some(MustAbort::PanicInHook);
-        }
-        c.set((count + 1, run_panic_hook));
-        None
-    })
+    let (count, in_panic_hook) = LOCAL_PANIC_COUNT.get();
+    if in_panic_hook {
+        return Some(MustAbort::PanicInHook);
+    }
+    LOCAL_PANIC_COUNT.set((count + 1, run_panic_hook));
+    None
 }
 
 pub fn finished_panic_hook() {
-    LOCAL_PANIC_COUNT.with(|c| {
-        let (count, _) = c.get();
-        c.set((count, false));
-    });
+    let (count, _) = LOCAL_PANIC_COUNT.get();
+    LOCAL_PANIC_COUNT.set((count, false));
 }
 
 pub fn decrease() {
     GLOBAL_PANIC_COUNT.fetch_sub(1, Ordering::Relaxed);
-    LOCAL_PANIC_COUNT.with(|c| {
-        let (count, _) = c.get();
-        c.set((count - 1, false));
-    });
+    let (count, _) = LOCAL_PANIC_COUNT.get();
+    LOCAL_PANIC_COUNT.set((count - 1, false));
 }
 
 // Disregards ALWAYS_ABORT_FLAG
@@ -77,5 +71,5 @@ pub fn count_is_zero() -> bool {
 #[inline(never)]
 #[cold]
 fn is_zero_slow_path() -> bool {
-    LOCAL_PANIC_COUNT.with(|c| c.get().0 == 0)
+    LOCAL_PANIC_COUNT.get().0 == 0
 }

--- a/libs/wast/src/gensym.rs
+++ b/libs/wast/src/gensym.rs
@@ -5,15 +5,13 @@ use cpu_local::cpu_local;
 cpu_local!(static NEXT: Cell<u32> = Cell::new(0));
 
 pub fn reset() {
-    NEXT.with(|c| c.set(0));
+    NEXT.set(0);
 }
 
 pub fn generate(span: Span) -> Id<'static> {
-    NEXT.with(|next| {
-        let generation = next.get() + 1;
-        next.set(generation);
-        Id::gensym(span, generation)
-    })
+    let generation = NEXT.get() + 1;
+    NEXT.set(generation);
+    Id::gensym(span, generation)
 }
 
 pub fn fill<'a>(span: Span, slot: &mut Option<Id<'a>>) -> Id<'a> {


### PR DESCRIPTION
Now that `cpu-local` statics don't run destructors anymore (#411) I realized the whole `with` construction is pretty unnecessary, there is no need to constrain the lifetime to the callback scope, as soon as the static is initialized it will live for `'static`.

This PR simplifies the cpu-local crate even further by just having `LocalKey` implement `Deref`. 