### PR TITLE
docs: fix incorrect build and run commands

### DIFF
--- a/manual/src/building/how-to-build-and-run.md
+++ b/manual/src/building/how-to-build-and-run.md
@@ -11,9 +11,9 @@ The following tools are required to build and run k23:
 
 ## Running
 
-Type `just` to see the available actions to run. The one you are probably looking for is `just run-riscv64` which will
+Type `just` to see the available actions to run. The one you are probably looking for is `just run profile/riscv64/qemu.toml` which will
 build k23 for `riscv64` and run it inside QEMU. Note that this is currently just running a few basic tests and exits.
 Other actions include:
 
 - `just preflight` which will run all lints and checks
-- `just run` which will run k23 in QEMU
+- `just run profile/riscv64/qemu.toml` which will run k23 in QEMU


### PR DESCRIPTION
## Summary
- Fix incorrect `just run-riscv64` command to use the correct `just run profile/riscv64/qemu.toml`
- Update manual documentation to show proper QEMU run commands

## Test plan
- [x] Verify commands in justfile match documentation
- [ ] Test that updated commands work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)