### PR TITLE
refactor: generalize interrupt controller 

### DIFF
--- a/kernel/src/arch/riscv64/device/cpu.rs
+++ b/kernel/src/arch/riscv64/device/cpu.rs
@@ -86,6 +86,12 @@ impl fmt::Display for Cpu {
 }
 
 impl Cpu {
+    pub fn interrupt_controller(&self) -> core::cell::RefMut<'_, dyn InterruptController> {
+        core::cell::RefMut::map(self.plic.borrow_mut(), |plic| {
+            plic as &mut dyn InterruptController
+        })
+    }
+
     pub fn new(devtree: &DeviceTree, cpuid: usize) -> crate::Result<Self> {
         let cpus = devtree
             .find_by_path("/cpus")

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -13,7 +13,6 @@ use crate::{TRAP_STACK_SIZE_PAGES, irq};
 use alloc::boxed::Box;
 use core::arch::{asm, naked_asm};
 use core::cell::Cell;
-use core::ops::DerefMut;
 use cpu_local::cpu_local;
 use riscv::scause::{Exception, Interrupt, Trap};
 use riscv::{load_fp, load_gp, save_fp, save_gp};
@@ -307,8 +306,7 @@ extern "C-unwind" fn default_trap_handler(
                 }
             }
             Trap::Interrupt(Interrupt::SupervisorExternal) => {
-                let mut plic = cpu_local().arch.cpu.plic.borrow_mut();
-                irq::trigger_irq(plic.deref_mut());
+                irq::trigger_irq(&mut *cpu_local().arch.cpu.interrupt_controller());
             }
             Trap::Exception(
                 Exception::LoadPageFault

--- a/kernel/src/irq.rs
+++ b/kernel/src/irq.rs
@@ -52,7 +52,11 @@ pub fn trigger_irq(irq_ctl: &mut dyn InterruptController) {
 }
 
 pub async fn next_event(irq_num: u32) -> Result<(), kasync::sync::Closed> {
-    cpu_local().arch.cpu.plic.borrow_mut().irq_unmask(irq_num);
+    cpu_local()
+        .arch
+        .cpu
+        .interrupt_controller()
+        .irq_unmask(irq_num);
 
     let wait = {
         let mut queues = QUEUES.write();
@@ -67,7 +71,11 @@ pub async fn next_event(irq_num: u32) -> Result<(), kasync::sync::Closed> {
 
     let res = wait.await;
 
-    cpu_local().arch.cpu.plic.borrow_mut().irq_mask(irq_num);
+    cpu_local()
+        .arch
+        .cpu
+        .interrupt_controller()
+        .irq_mask(irq_num);
 
     res
 }


### PR DESCRIPTION
## Summary

This PR refactors interrupt controller handling to use a generic, architecture-independent interface as part of the ongoing [x86_64 backend development](https://github.com/JonasKruckenberg/k23/pull/476).

### Problem

The IRQ handling code was directly accessing the RISC-V-specific PLIC (Platform-Level Interrupt Controller) through `cpu.plic.borrow_mut()`, making it impossible to support other architectures like x86_64 which use APIC instead.

### Solution

Created a generic interface that hides architecture-specific interrupt controllers behind a trait:

```rust
pub fn interrupt_controller(&self) -> RefMut<'_, dyn InterruptController>
```

### Changes Made

- ✅ **Added `interrupt_controller()` method** to CPU struct that returns a trait object
- ✅ **Updated `irq.rs`** to use the generic method instead of accessing PLIC directly
- ✅ **Updated trap handler** to use the generic interface with proper dereferencing
- ✅ **Preserved interior mutability** using `RefCell` and `RefMut::map`

### Architecture Benefits

- **Code Sharing**: IRQ handling code is now architecture-agnostic
- **x86_64 Ready**: Can easily add APIC support with the same interface
- **Clean Abstraction**: Interrupt controller details hidden behind trait
- **Type Safety**: Rust's type system ensures correct usage of mutable references

### Implementation Details

The key insight was using `RefMut::map` to convert from `RefCell<Plic>` to `RefMut<dyn InterruptController>`:

```rust
pub fn interrupt_controller(&self) -> RefMut<'_, dyn InterruptController> {
    RefMut::map(self.plic.borrow_mut(), |plic| {
        plic as &mut dyn InterruptController
    })
}
```

### Verification

- ✅ RISC-V kernel builds successfully
- ✅ RISC-V kernel boots and runs in QEMU
- ✅ Interrupt handling works correctly (tested with external interrupts)

### Context

This refactoring is part of the x86_64 backend development work to create generic interfaces that can be shared between different architectures. By abstracting interrupt controller access, we can support both RISC-V's PLIC and x86_64's APIC without duplicating the IRQ handling logic.

### Related Work

- Part of x86_64 backend effort: #476
- Follows similar pattern as trap interface refactoring: #477

🤖 Generated with [Claude Code](https://claude.ai/code)