### PR TITLE
fix: kasync benchmarks

### DIFF
--- a/libs/kasync/Cargo.toml
+++ b/libs/kasync/Cargo.toml
@@ -8,10 +8,12 @@ license.workspace = true
 [[bench]]
 name = "spawn"
 harness = false
+required-features = ["__bench"]
 
 [[bench]]
 name = "ping_pong"
 harness = false
+required-features = ["__bench"]
 
 [dependencies]
 util.workspace = true
@@ -31,9 +33,12 @@ bitflags.workspace = true
 pin-project.workspace = true
 arrayvec.workspace = true
 cordyceps.workspace = true
+lazy_static = { workspace = true, optional = true }
 
 [dev-dependencies]
-tracing-subscriber = { workspace = true, default-features = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, default-features = true, features = [
+    "env-filter",
+] }
 lazy_static.workspace = true
 criterion.workspace = true
 tokio-test = "0.4.4"
@@ -45,7 +50,7 @@ loom.workspace = true
 [features]
 unwind2 = ["dep:unwind2"]
 counters = []
-__bench = ["tracing/max_level_off"]
+__bench = ["tracing/max_level_off", "dep:lazy_static"]
 
 [lints]
 workspace = true

--- a/libs/kasync/benches/ping_pong.rs
+++ b/libs/kasync/benches/ping_pong.rs
@@ -5,14 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use async_exec::executor::{Executor, Worker};
-use async_exec::new_executor;
-use async_exec::park::StdPark;
 use criterion::{Criterion, criterion_group, criterion_main};
 use fastrand::FastRand;
+use kasync::executor::{Executor, Worker};
+use kasync::{StdPark, new_executor, std_clock};
 
 fn ping_ping_10k_single_threaded(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     const PINGS: usize = 10_000;
@@ -22,7 +21,7 @@ fn ping_ping_10k_single_threaded(c: &mut Criterion) {
             let h = EXEC
                 .try_spawn(async {
                     for _ in 0..PINGS {
-                        async_exec::task::yield_now().await;
+                        kasync::task::yield_now().await;
                     }
                 })
                 .unwrap();
@@ -32,7 +31,7 @@ fn ping_ping_10k_single_threaded(c: &mut Criterion) {
 }
 
 fn ping_pong_10k_single_threaded(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     const PINGS: usize = 10_000;
@@ -42,7 +41,7 @@ fn ping_pong_10k_single_threaded(c: &mut Criterion) {
             let h1 = EXEC
                 .try_spawn(async {
                     for _ in 0..PINGS {
-                        async_exec::task::yield_now().await;
+                        kasync::task::yield_now().await;
                     }
                 })
                 .unwrap();
@@ -50,7 +49,7 @@ fn ping_pong_10k_single_threaded(c: &mut Criterion) {
             let h2 = EXEC
                 .try_spawn(async {
                     for _ in 0..PINGS {
-                        async_exec::task::yield_now().await;
+                        kasync::task::yield_now().await;
                     }
                 })
                 .unwrap();
@@ -61,7 +60,7 @@ fn ping_pong_10k_single_threaded(c: &mut Criterion) {
 }
 
 fn ping_ping_10k_multi_threaded(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     let h = std::thread::spawn(|| {
@@ -76,7 +75,7 @@ fn ping_ping_10k_multi_threaded(c: &mut Criterion) {
             let h = EXEC
                 .try_spawn(async {
                     for _ in 0..PINGS {
-                        async_exec::task::yield_now().await;
+                        kasync::task::yield_now().await;
                     }
                 })
                 .unwrap();
@@ -89,7 +88,7 @@ fn ping_ping_10k_multi_threaded(c: &mut Criterion) {
 }
 
 fn ping_pong_10k_multi_threaded(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     let h = std::thread::spawn(|| {
@@ -104,7 +103,7 @@ fn ping_pong_10k_multi_threaded(c: &mut Criterion) {
             let h1 = EXEC
                 .try_spawn(async {
                     for _ in 0..PINGS {
-                        async_exec::task::yield_now().await;
+                        kasync::task::yield_now().await;
                     }
                 })
                 .unwrap();
@@ -112,7 +111,7 @@ fn ping_pong_10k_multi_threaded(c: &mut Criterion) {
             let h2 = EXEC
                 .try_spawn(async {
                     for _ in 0..PINGS {
-                        async_exec::task::yield_now().await;
+                        kasync::task::yield_now().await;
                     }
                 })
                 .unwrap();

--- a/libs/kasync/benches/spawn.rs
+++ b/libs/kasync/benches/spawn.rs
@@ -1,18 +1,18 @@
-use async_exec::executor::{Executor, Worker};
-use async_exec::new_executor;
-use async_exec::park::StdPark;
 use criterion::{Criterion, criterion_group, criterion_main};
 use fastrand::FastRand;
+use kasync::executor::{Executor, Worker};
+use kasync::new_executor;
+use kasync::{StdPark, std_clock};
 use std::hint::black_box;
 
 async fn work() -> usize {
     let val = 1 + 1;
-    async_exec::task::yield_now().await;
+    kasync::task::yield_now().await;
     black_box(val)
 }
 
 fn single_threaded_spawn(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     c.bench_function("single_threaded_spawn", |b| {
@@ -27,7 +27,7 @@ fn single_threaded_spawn(c: &mut Criterion) {
 }
 
 fn single_threaded_spawn10(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     c.bench_function("single_threaded_spawn10", |b| {
@@ -49,7 +49,7 @@ fn single_threaded_spawn10(c: &mut Criterion) {
 }
 
 fn multi_threaded_spawn(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
 
     let h = std::thread::spawn(|| {
         let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
@@ -72,7 +72,7 @@ fn multi_threaded_spawn(c: &mut Criterion) {
 }
 
 fn multi_threaded_spawn10(c: &mut Criterion) {
-    static EXEC: Executor<StdPark> = new_executor!(1);
+    static EXEC: Executor<StdPark> = new_executor!(std_clock!());
     let mut worker = Worker::new(&EXEC, 0, StdPark::for_current(), FastRand::from_seed(0));
 
     let h = std::thread::spawn(|| {

--- a/libs/kasync/src/executor.rs
+++ b/libs/kasync/src/executor.rs
@@ -208,7 +208,7 @@ where
 #[cfg(not(loom))]
 #[macro_export]
 macro_rules! new_executor {
-    ($num_threads:expr) => {{
+    ($clock:expr) => {{
         static STUB: $crate::task::TaskStub = $crate::task::TaskStub::new();
 
         // Safety: The intrusive MPSC queue that holds tasks uses a stub node as the initial element of the
@@ -218,7 +218,7 @@ macro_rules! new_executor {
         // not great.
         // By defining the static above inside this block we guarantee the stub cannot escape
         // and be used elsewhere thereby solving this problem.
-        unsafe { $crate::executor::Executor::new_with_static_stub($num_threads, &STUB) }
+        unsafe { $crate::executor::Executor::new_with_static_stub($clock, &STUB) }
     }};
 }
 
@@ -437,9 +437,8 @@ mod tests {
     use super::*;
     use crate::loom;
     use crate::test_util::StopOnPanic;
-    use crate::test_util::{StdPark, std_clock};
+    use crate::{StdPark, std_clock};
     use core::hint::black_box;
-    use core::time::Duration;
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::util::SubscriberInitExt;
 

--- a/libs/kasync/src/lib.rs
+++ b/libs/kasync/src/lib.rs
@@ -1,17 +1,19 @@
 //! Async executor and supporting infrastructure for k23 cooperative multitasking.
 //!
-//! This crate was heavily inspired by tokio and the (much better) maitake crates, to a small extend smol also influenced the design.  
+//! This crate was heavily inspired by tokio and the (much better) maitake crates, to a small extend smol also influenced the design.
 
-#![feature(allocator_api)]
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "__bench")), no_std)]
 #![cfg_attr(loom, feature(arbitrary_self_types))]
+#![feature(allocator_api)]
 #![feature(const_type_id)]
 #![feature(thread_local)]
 #![feature(debug_closure_helpers)]
+
 extern crate alloc;
 
 pub mod executor;
-mod loom;
+#[doc(hidden)] // only public for benchmarks
+pub mod loom;
 pub mod park;
 pub mod scheduler;
 pub mod sync;
@@ -19,3 +21,54 @@ pub mod task;
 #[cfg(test)]
 mod test_util;
 pub mod time;
+
+/// Returns a [`Clock`] with 1ms precision that is backed by the system clock
+#[cfg(any(test, feature = "__bench"))]
+#[macro_export]
+macro_rules! std_clock {
+    () => {{
+        $crate::loom::lazy_static! {
+            static ref TIME_ANCHOR: ::std::time::Instant = ::std::time::Instant::now();
+        }
+
+        $crate::time::Clock::new(::core::time::Duration::from_millis(1), move || {
+            $crate::time::Ticks(TIME_ANCHOR.elapsed().as_millis() as u64)
+        })
+    }};
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(any(test, feature = "__bench"))] {
+        pub struct StdPark(crate::loom::thread::Thread);
+
+        impl park::Park for StdPark {
+            fn park(&self) {
+                tracing::trace!("parking current thread ({:?})...", self.0);
+                crate::loom::thread::park();
+            }
+
+            #[cfg(not(loom))]
+            fn park_until(&self, deadline: crate::time::Deadline, clock: &crate::time::Clock) {
+                let instant = deadline.as_instant(clock);
+                let dur = instant.elapsed(clock);
+                crate::loom::thread::park_timeout(dur);
+            }
+
+            #[cfg(loom)]
+            fn park_until(&self, _deadline: Deadline, _clock: &Clock) {
+                unreachable!("loom doesn't support `park_timeout`");
+            }
+
+            fn unpark(&self) {
+                tracing::trace!("unparking thread {:?}...", self.0);
+                self.0.unpark();
+            }
+        }
+
+        impl StdPark {
+            pub fn for_current() -> Self {
+                Self(crate::loom::thread::current())
+            }
+        }
+    }
+}

--- a/libs/kasync/src/loom.rs
+++ b/libs/kasync/src/loom.rs
@@ -16,10 +16,10 @@ cfg_if! {
         pub(crate) use loom::thread;
         pub(crate) use loom::lazy_static;
     } else {
-        #[cfg(test)]
+        #[cfg(any(test, feature = "__bench"))]
         pub(crate) use std::thread;
-        #[cfg(test)]
-        pub(crate) use lazy_static::lazy_static;
+        #[cfg(any(test, feature = "__bench"))]
+        pub use lazy_static::lazy_static;
 
         #[cfg(test)]
         #[inline(always)]
@@ -30,7 +30,7 @@ cfg_if! {
         pub(crate) mod sync {
             pub use core::sync::*;
             pub use alloc::sync::*;
-            #[cfg(test)]
+            #[cfg(any(test, feature = "__bench"))]
             pub(crate) use std::sync::*;
         }
 

--- a/libs/kasync/src/park/parker.rs
+++ b/libs/kasync/src/park/parker.rs
@@ -152,12 +152,12 @@ impl<P: Park> UnparkToken<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StdPark;
     use crate::loom::sync::{
         atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     };
     use crate::loom::thread;
-    use crate::test_util::StdPark;
     use core::pin::{Pin, pin};
     use core::task::{Context, Poll, Waker};
 

--- a/libs/kasync/src/park/parking_lot.rs
+++ b/libs/kasync/src/park/parking_lot.rs
@@ -112,9 +112,9 @@ impl<P: Park + Send + Sync> ParkingLot<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::StdPark;
     use crate::loom::sync::{Arc, atomic::AtomicUsize};
     use crate::loom::thread;
-    use crate::test_util::StdPark;
     use alloc::vec::Vec;
     use spin::Backoff;
 

--- a/libs/kasync/src/sync/oneshot.rs
+++ b/libs/kasync/src/sync/oneshot.rs
@@ -113,7 +113,7 @@ mod tests {
     use crate::executor::{Executor, Worker};
     use crate::loom;
     use crate::loom::sync::atomic::{AtomicUsize, Ordering};
-    use crate::test_util::{StdPark, std_clock};
+    use crate::{StdPark, std_clock};
     use fastrand::FastRand;
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::util::SubscriberInitExt;

--- a/libs/kasync/src/test_util.rs
+++ b/libs/kasync/src/test_util.rs
@@ -5,55 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::park::Park;
-use crate::time::{Clock, Deadline};
-
-/// Returns a [`Clock`] with 1ms precision that is backed by the system clock
-macro_rules! std_clock {
-    () => {{
-        crate::loom::lazy_static! {
-            static ref TIME_ANCHOR: ::std::time::Instant = ::std::time::Instant::now();
-        }
-
-        $crate::time::Clock::new(::core::time::Duration::from_millis(1), move || {
-            $crate::time::Ticks(TIME_ANCHOR.elapsed().as_millis() as u64)
-        })
-    }};
-}
 use crate::executor::Executor;
-pub(crate) use std_clock;
-
-pub struct StdPark(crate::loom::thread::Thread);
-
-impl Park for StdPark {
-    fn park(&self) {
-        tracing::trace!("parking current thread ({:?})...", self.0);
-        crate::loom::thread::park();
-    }
-
-    #[cfg(not(loom))]
-    fn park_until(&self, deadline: Deadline, clock: &Clock) {
-        let instant = deadline.as_instant(clock);
-        let dur = instant.elapsed(clock);
-        crate::loom::thread::park_timeout(dur);
-    }
-
-    #[cfg(loom)]
-    fn park_until(&self, _deadline: Deadline, _clock: &Clock) {
-        unreachable!("loom doesn't support `park_timeout`");
-    }
-
-    fn unpark(&self) {
-        tracing::trace!("unparking thread {:?}...", self.0);
-        self.0.unpark();
-    }
-}
-
-impl StdPark {
-    pub fn for_current() -> Self {
-        Self(crate::loom::thread::current())
-    }
-}
+use crate::park::Park;
 
 #[must_use]
 pub struct StopOnPanic<'e, P: Park + Send + Sync> {

--- a/libs/kasync/src/time/sleep.rs
+++ b/libs/kasync/src/time/sleep.rs
@@ -159,7 +159,8 @@ mod tests {
     use crate::executor::Executor;
     use crate::executor::Worker;
     use crate::loom;
-    use crate::test_util::{StdPark, StopOnPanic, std_clock};
+    use crate::test_util::StopOnPanic;
+    use crate::{StdPark, std_clock};
     use alloc::vec::Vec;
     use core::time::Duration;
     use fastrand::FastRand;


### PR DESCRIPTION
This PR fixes the `kasync` benchmarks that were broken for the longest time.