### PR TITLE
debug: Fix page allocator index calculation

### DIFF
--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -75,14 +75,6 @@ impl PageAllocator {
         while remaining_bytes > 0 {
             let page_idx = (virt_base - arch::KERNEL_ASPACE_BASE) / top_level_page_size;
 
-            if page_idx >= self.page_state.len() {
-                panic!(
-                    "index out of bounds: the len is {} but the index is {}",
-                    self.page_state.len(),
-                    page_idx
-                );
-            }
-
             self.page_state[page_idx] = true;
 
             virt_base = virt_base.checked_add(top_level_page_size).unwrap();


### PR DESCRIPTION
The original code used `usize::MAX << arch::VIRT_ADDR_BITS` to calculate the base of the kernel address space. This works by coincidence for RISC-V but fails for x86_64:

For RISC-V (38-bit virtual addresses):
```
riscv64::KERNEL_ASPACE_BASE = 0xffffffc000000000
riscv64::VIRT_ADDR_BITS = 38
usize::MAX << riscv64::VIRT_ADDR_BITS = 0xffffffc000000000 // same as KERNEL_ASPACE_BASE
```

For x86_64 (48-bit virtual addresses):
```
x86_64::KERNEL_ASPACE_BASE = 0xffffffc000000000
x86_64::VIRT_ADDR_BITS = 48
usize::MAX << x86_64::VIRT_ADDR_BITS = 0xffff000000000000 // different with KERNEL_ASPACE_BASE
```
 
