### PR TITLE
refactor: arch-agnostic page level

### DIFF
--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -69,7 +69,7 @@ impl PageAllocator {
             virt_base.checked_add(remaining_bytes).unwrap()
         );
 
-        let top_level_page_size = arch::page_size_for_level(arch::PAGE_TABLE_LEVELS - 1);
+        let top_level_page_size = arch::page_size_for_level(2);
         debug_assert!(virt_base % top_level_page_size == 0);
 
         while remaining_bytes > 0 {
@@ -78,14 +78,14 @@ impl PageAllocator {
             self.page_state[page_idx] = true;
 
             virt_base = virt_base.checked_add(top_level_page_size).unwrap();
-            remaining_bytes -= top_level_page_size;
+            remaining_bytes = remaining_bytes.saturating_sub(top_level_page_size);
         }
     }
 
     pub fn allocate(&mut self, layout: Layout) -> Range<usize> {
         assert!(layout.align().is_power_of_two());
 
-        let top_level_page_size = arch::page_size_for_level(arch::PAGE_TABLE_LEVELS - 1);
+        let top_level_page_size = arch::page_size_for_level(2);
 
         // how many top-level pages are needed to map `size` bytes
         // and attempt to allocate them


### PR DESCRIPTION
The page allocator was implemented with RISC-V-specific assumptions, using 
the top-level page table entry size which works for RISC-V (3-level paging) 
but not for other architectures like x86-64 (4-level paging):
- RISC-V: 1GB at level 2 (top level)
```
pub fn page_size_for_level(level: usize) -> usize {
    assert!(level < PAGE_TABLE_LEVELS);
    let page_size = 1 << (PAGE_SHIFT + level * PAGE_ENTRY_SHIFT);
    debug_assert!(page_size == 4096 || page_size == 2097152 || page_size == 1073741824);
    page_size
}
```
- x86-64: 512GB at level 3 (top level)
```
pub fn page_size_for_level(level: usize) -> usize {
    assert!(level < PAGE_TABLE_LEVELS);
    match level {
        0 => 1 << 12, // 4KB PT level
        1 => 1 << 21, // 2MB PD level
        2 => 1 << 30, // 1GB PDPT level
        3 => 1 << 39, // 512GB PML4 level
        _ => unreachable!(),
    }
}
```
This PR ensures consistent 1GB page allocation across all architectures. 
