### PR TITLE
chore: `kwasm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "kwasm"
+version = "0.1.0"
+dependencies = [
+ "cfg-if",
+ "loom",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ dependencies = [
  "unwind2",
  "util",
  "vergen-git2",
- "wasmparser 0.228.0",
+ "wasmparser 0.235.0",
  "wasmtime-slab",
  "wast 228.0.0",
  "wavltree",
@@ -1072,9 +1072,18 @@ dependencies = [
 name = "kwasm"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
+ "cranelift-entity",
+ "gimli",
+ "hashbrown",
  "loom",
  "pin-project",
+ "smallvec",
+ "spin",
+ "tracing 0.2.0",
+ "wasmparser 0.235.0",
+ "wasmtime-slab",
 ]
 
 [[package]]
@@ -2330,15 +2339,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.228.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.232.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917739b33bb1eb0e9a49bcd2637a351931be4578d0cc4d37b908d7a797784fbb"
@@ -2378,7 +2378,7 @@ dependencies = [
  "memchr",
  "unicode-width",
  "wasm-encoder 0.232.0",
- "wasmparser 0.228.0",
+ "wasmparser 0.235.0",
  "wat",
 ]
 
@@ -2444,7 +2444,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1074,6 +1074,7 @@ version = "0.1.0"
 dependencies = [
  "cfg-if",
  "loom",
+ "pin-project",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ hashbrown = { version = "0.15", default-features = false, features = [
     "nightly",
     "default-hasher",
 ] }
-wasmparser = { version = "0.228", default-features = false, features = ["features", "validate", "simd"] }
+wasmparser = { version = "0.235", default-features = false, features = ["features", "validate", "simd"] }
 target-lexicon = { version = "0.13.2", default-features = false }
 cranelift-codegen = { git = "https://github.com/JonasKruckenberg/wasmtime.git", branch = "main", default-features = false, features = ["host-arch", "core"] }
 cranelift-frontend = { git = "https://github.com/JonasKruckenberg/wasmtime.git", branch = "main", default-features = false, features = ["core"] }

--- a/libs/kwasm/Cargo.toml
+++ b/libs/kwasm/Cargo.toml
@@ -8,6 +8,16 @@ license.workspace = true
 [dependencies]
 cfg-if.workspace = true
 pin-project.workspace = true
+anyhow.workspace = true
+gimli.workspace = true
+hashbrown.workspace = true
+smallvec.workspace = true
+tracing.workspace = true
+spin.workspace = true
+
+wasmparser.workspace = true
+cranelift-entity.workspace = true
+wasmtime-slab.workspace = true
 
 [target.'cfg(loom)'.dependencies]
 loom.workspace = true

--- a/libs/kwasm/Cargo.toml
+++ b/libs/kwasm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kwasm"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+cfg-if.workspace = true
+
+[target.'cfg(loom)'.dependencies]
+loom.workspace = true
+
+[lints]
+workspace = true

--- a/libs/kwasm/Cargo.toml
+++ b/libs/kwasm/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 cfg-if.workspace = true
+pin-project.workspace = true
 
 [target.'cfg(loom)'.dependencies]
 loom.workspace = true

--- a/libs/kwasm/src/engine.rs
+++ b/libs/kwasm/src/engine.rs
@@ -5,10 +5,47 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use crate::loom::sync::atomic::AtomicU64;
 use crate::loom::sync::Arc;
+use crate::type_registry::TypeRegistry;
 
 #[derive(Debug, Clone)]
 pub struct Engine(Arc<EngineInner>);
 
 #[derive(Debug)]
-struct EngineInner {}
+struct EngineInner {
+    type_registry: TypeRegistry,
+    epoch_counter: AtomicU64,
+}
+
+// ===== impl Engine =====
+
+impl Default for Engine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Engine {
+    pub fn new() -> Engine {
+        Engine(Arc::new(EngineInner {
+            type_registry: TypeRegistry::new(),
+            epoch_counter: AtomicU64::new(0),
+        }))
+    }
+}
+
+impl Engine {
+    pub fn same(lhs: &Engine, rhs: &Engine) -> bool {
+        Arc::ptr_eq(&lhs.0, &rhs.0)
+    }
+
+    /// Returns the type registry of this engine, used to canonicalize types.
+    pub fn type_registry(&self) -> &TypeRegistry {
+        &self.0.type_registry
+    }
+
+    pub fn epoch_counter(&self) -> &AtomicU64 {
+        &self.0.epoch_counter
+    }
+}

--- a/libs/kwasm/src/engine.rs
+++ b/libs/kwasm/src/engine.rs
@@ -5,11 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(not(test), no_std)]
+use crate::loom::sync::Arc;
 
-extern crate alloc;
+#[derive(Debug, Clone)]
+pub struct Engine(Arc<EngineInner>);
 
-mod loom;
-mod engine;
-
-pub use engine::Engine;
+#[derive(Debug)]
+struct EngineInner {}

--- a/libs/kwasm/src/indices.rs
+++ b/libs/kwasm/src/indices.rs
@@ -1,0 +1,176 @@
+use crate::utils::enum_accessors;
+use cranelift_entity::entity_impl;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TypeIndex(u32);
+entity_impl!(TypeIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FuncIndex(u32);
+entity_impl!(FuncIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefinedFuncIndex(u32);
+entity_impl!(DefinedFuncIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TableIndex(u32);
+entity_impl!(TableIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefinedTableIndex(u32);
+entity_impl!(DefinedTableIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct MemoryIndex(u32);
+entity_impl!(MemoryIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefinedMemoryIndex(u32);
+entity_impl!(DefinedMemoryIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct OwnedMemoryIndex(u32);
+entity_impl!(OwnedMemoryIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct GlobalIndex(u32);
+entity_impl!(GlobalIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefinedGlobalIndex(u32);
+entity_impl!(DefinedGlobalIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DefinedTagIndex(u32);
+entity_impl!(DefinedTagIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ElemIndex(u32);
+entity_impl!(ElemIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct DataIndex(u32);
+entity_impl!(DataIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FuncRefIndex(u32);
+entity_impl!(FuncRefIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LocalIndex(u32);
+entity_impl!(LocalIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct FieldIndex(u32);
+entity_impl!(FieldIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct TagIndex(u32);
+entity_impl!(TagIndex);
+
+/// A reference to a label in a function. Only used for associating label names.
+///
+/// NOTE: These indices are local to the function they used in, they are also
+/// **not** the same as the depth of their block. This means you cant just go
+/// and take the relative branch depth of a `br` instruction and the label stack
+/// height to get the label index.
+/// According to the proposal the labels are assigned indices in the order their
+/// blocks appear in the code.
+///
+/// Source:
+/// <https://github.com/WebAssembly/extended-name-section/blob/main/proposals/extended-name-section/Overview.md#label-names>
+///
+/// ALSO NOTE: No existing tooling appears to emit label names, so this just doesn't
+/// appear in the wild probably.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LabelIndex(u32);
+entity_impl!(LabelIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum EntityIndex {
+    Function(FuncIndex),
+    Table(TableIndex),
+    Memory(MemoryIndex),
+    Global(GlobalIndex),
+    Tag(TagIndex),
+}
+
+impl EntityIndex {
+    enum_accessors! {
+        e
+        (Function(FuncIndex) is_func func unwrap_func *e)
+        (Table(TableIndex) is_table table unwrap_table *e)
+        (Memory(MemoryIndex) is_memory memory unwrap_memory *e)
+        (Global(GlobalIndex) is_global global unwrap_global *e)
+        (Tag(TagIndex) is_tag tag unwrap_tag *e)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ModuleInternedTypeIndex(u32);
+entity_impl!(ModuleInternedTypeIndex);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ModuleInternedRecGroupIndex(u32);
+entity_impl!(ModuleInternedRecGroupIndex);
+
+#[repr(transparent)] // Used directly by JIT code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct VMSharedTypeIndex(u32);
+entity_impl!(VMSharedTypeIndex);
+
+impl Default for VMSharedTypeIndex {
+    #[inline]
+    fn default() -> Self {
+        Self(u32::MAX)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RecGroupRelativeTypeIndex(u32);
+entity_impl!(RecGroupRelativeTypeIndex);
+
+/// An index pointing to a type that is canonicalized either within just a `Module` (types start out this way),
+/// an entire `Engine` (required for runtime type checks) or a `RecGroup`
+/// (only used during hash-consing to get a stable representation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CanonicalizedTypeIndex {
+    /// An index within an engine, therefore canonicalized among all modules
+    /// that can share types with each other.
+    Engine(VMSharedTypeIndex),
+
+    /// An index within the current Wasm module, canonicalized within just this
+    /// current module.
+    Module(ModuleInternedTypeIndex),
+
+    /// An index within the containing type's rec group. This is only used when
+    /// hashing and canonicalizing rec groups, and should never appear outside
+    /// of the engine's type registry.
+    RecGroup(RecGroupRelativeTypeIndex),
+}
+
+impl From<VMSharedTypeIndex> for CanonicalizedTypeIndex {
+    fn from(index: VMSharedTypeIndex) -> Self {
+        Self::Engine(index)
+    }
+}
+impl From<ModuleInternedTypeIndex> for CanonicalizedTypeIndex {
+    fn from(index: ModuleInternedTypeIndex) -> Self {
+        Self::Module(index)
+    }
+}
+impl From<RecGroupRelativeTypeIndex> for CanonicalizedTypeIndex {
+    fn from(index: RecGroupRelativeTypeIndex) -> Self {
+        Self::RecGroup(index)
+    }
+}
+
+impl CanonicalizedTypeIndex {
+    enum_accessors! {
+        e
+        (Module(ModuleInternedTypeIndex) is_module_type_index as_module_type_index unwrap_module_type_index *e)
+        (Engine(VMSharedTypeIndex) is_engine_type_index as_engine_type_index unwrap_engine_type_index *e)
+        (RecGroup(RecGroupRelativeTypeIndex) is_rec_group_type_index as_rec_group_type_index unwrap_rec_group_type_index *e)
+    }
+}

--- a/libs/kwasm/src/lib.rs
+++ b/libs/kwasm/src/lib.rs
@@ -1,0 +1,12 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+mod loom;

--- a/libs/kwasm/src/lib.rs
+++ b/libs/kwasm/src/lib.rs
@@ -11,5 +11,7 @@ extern crate alloc;
 
 mod loom;
 mod engine;
+mod store;
 
 pub use engine::Engine;
+pub use store::Store;

--- a/libs/kwasm/src/lib.rs
+++ b/libs/kwasm/src/lib.rs
@@ -5,13 +5,33 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![cfg_attr(not(test), no_std)]
+#![no_std]
+// #![cfg_attr(not(test), no_std)]
 
 extern crate alloc;
 
 mod loom;
 mod engine;
 mod store;
+mod module;
+mod wasm;
+mod indices;
+mod utils;
+mod type_registry;
 
+pub type Result<T> = anyhow::Result<T>;
 pub use engine::Engine;
 pub use store::Store;
+pub use module::Module;
+
+/// The number of pages (for 32-bit modules) we can have before we run out of
+/// byte index space.
+pub const WASM32_MAX_PAGES: u64 = 1 << 16;
+/// The number of pages (for 64-bit modules) we can have before we run out of
+/// byte index space.
+pub const WASM64_MAX_PAGES: u64 = 1 << 48;
+/// Maximum size, in bytes, of 32-bit memories (4G).
+pub const WASM32_MAX_SIZE: u64 = 1 << 32;
+/// 2 GiB of guard pages
+/// TODO why does this help to eliminate bounds checks?
+pub const DEFAULT_OFFSET_GUARD_SIZE: u64 = 0x8000_0000;

--- a/libs/kwasm/src/loom.rs
+++ b/libs/kwasm/src/loom.rs
@@ -1,0 +1,103 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(loom)] {
+        pub(crate) use loom::sync;
+        pub(crate) use loom::cell;
+        pub(crate) use loom::model;
+    } else {
+        #[cfg(test)]
+        #[inline(always)]
+        pub(crate) fn model<R>(f: impl FnOnce() -> R) -> R {
+            f()
+        }
+
+        pub(crate) mod sync {
+            pub use core::sync::*;
+            pub use alloc::sync::*;
+        }
+
+        pub(crate) mod cell {
+            #[derive(Debug)]
+            pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
+
+            impl<T> UnsafeCell<T> {
+                pub(crate) const fn new(data: T) -> UnsafeCell<T> {
+                    UnsafeCell(core::cell::UnsafeCell::new(data))
+                }
+
+                #[inline(always)]
+                pub(crate) fn with<R>(&self, f: impl FnOnce(*const T) -> R) -> R {
+                    f(self.0.get())
+                }
+
+                #[inline(always)]
+                pub(crate) fn with_mut<R>(&self, f: impl FnOnce(*mut T) -> R) -> R {
+                    f(self.0.get())
+                }
+            }
+        }
+    }
+}
+
+//             #[derive(Debug)]
+//             #[pin_project::pin_project]
+//             pub(crate) struct TrackFuture<F> {
+//                 #[pin]
+//                 inner: F,
+//                 track: Arc<()>,
+//             }
+//
+//             impl<F: Future> Future for TrackFuture<F> {
+//                 type Output = TrackFuture<F::Output>;
+//                 fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+//                     let this = self.project();
+//                     this.inner.poll(cx).map(|inner| TrackFuture {
+//                         inner,
+//                         track: this.track.clone(),
+//                     })
+//                 }
+//             }
+//
+//             impl<F> TrackFuture<F> {
+//                 /// Wrap a `Future` in a `TrackFuture` that participates in Loom's
+//                 /// leak checking.
+//                 #[track_caller]
+//                 pub(crate) fn new(inner: F) -> Self {
+//                     Self {
+//                         inner,
+//                         track: Arc::new(()),
+//                     }
+//                 }
+//
+//                 /// Stop tracking this future, and return the inner value.
+//                 pub(crate) fn into_inner(self) -> F {
+//                     self.inner
+//                 }
+//             }
+//
+//             #[track_caller]
+//             pub(crate) fn track_future<F: Future>(inner: F) -> TrackFuture<F> {
+//                 TrackFuture::new(inner)
+//             }
+//
+//             // PartialEq impl so that `assert_eq!(..., Ok(...))` works
+//             impl<F: PartialEq> PartialEq for TrackFuture<F> {
+//                 fn eq(&self, other: &Self) -> bool {
+//                     self.inner == other.inner
+//                 }
+//             }
+//         }
+//     } else {
+
+//
+//
+//     }
+// }

--- a/libs/kwasm/src/module.rs
+++ b/libs/kwasm/src/module.rs
@@ -1,0 +1,80 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::indices::{EntityIndex, VMSharedTypeIndex};
+use crate::loom::sync::Arc;
+use crate::type_registry::RuntimeTypeCollection;
+use crate::wasm::{Import, ModuleParser, TranslatedModule};
+use crate::Engine;
+use core::ops::Deref;
+use wasmparser::{Validator, WasmFeatures};
+
+#[derive(Debug, Clone)]
+pub struct Module(Arc<ModuleInner>);
+
+#[derive(Debug)]
+struct ModuleInner {
+    engine: Engine,
+    translated: TranslatedModule,
+    required_features: WasmFeatures,
+    type_collection: RuntimeTypeCollection,
+}
+
+// ===== impl Module =====
+
+impl Module {
+    pub fn from_bytes(
+        engine: Engine,
+        validator: &mut Validator,
+        bytes: &[u8],
+    ) -> crate::Result<Self> {
+        let (translation, types) = ModuleParser::new(validator).translate(bytes)?;
+
+        let inner = ModuleInner {
+            // vmshape: VMShape::for_module(u8_size_of::<usize>(), &translation.module),
+            type_collection: engine.type_registry().register_module_types(&engine, types),
+            translated: translation.module,
+            required_features: translation.required_features,
+            engine,
+        };
+
+        Ok(Self(Arc::new(inner)))
+    }
+
+    /// Returns the modules name if present.
+    pub fn name(&self) -> Option<&str> {
+        self.0.translated.name.as_deref()
+    }
+
+    /// Returns the modules imports.
+    pub fn imports(&self) -> impl ExactSizeIterator<Item = &Import> {
+        self.0.translated.imports.iter()
+    }
+
+    /// Returns the modules exports.
+    pub fn exports(&self) -> impl ExactSizeIterator<Item = (&str, EntityIndex)> + '_ {
+        self.0
+            .translated
+            .exports
+            .iter()
+            .map(|(name, index)| (name.as_str(), *index))
+    }
+
+    /// WebAssembly features that are required to instantiate this [`Module`].
+    pub fn required_features(&self) -> WasmFeatures {
+        self.0.required_features
+    }
+
+    /// The [`Engine`] that this [`Module`] has been instantiated within.
+    pub(crate) fn engine(&self) -> &Engine {
+        &self.0.engine
+    }
+
+    pub(crate) fn type_ids(&self) -> &[VMSharedTypeIndex] {
+        self.0.type_collection.type_map().values().as_slice()
+    }
+}

--- a/libs/kwasm/src/store.rs
+++ b/libs/kwasm/src/store.rs
@@ -8,7 +8,6 @@
 mod stored;
 
 use alloc::boxed::Box;
-use core::marker::PhantomPinned;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use pin_project::pin_project;

--- a/libs/kwasm/src/store.rs
+++ b/libs/kwasm/src/store.rs
@@ -1,0 +1,83 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+mod stored;
+
+use alloc::boxed::Box;
+use core::marker::PhantomPinned;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use pin_project::pin_project;
+use stored::StoredData;
+
+pub use stored::Stored;
+use crate::Engine;
+
+#[derive(Debug)]
+pub struct Store<T>(Pin<Box<StoreInner<T>>>);
+
+#[derive(Debug)]
+#[pin_project]
+struct StoreInner<T> {
+    #[pin]
+    opaque: StoreOpaque,
+    data: T,
+}
+
+#[pin_project(!Unpin)]
+#[derive(Debug)]
+struct StoreOpaque {
+    engine: Engine,
+    stored: StoredData,
+}
+
+// ===== impl Store =====
+
+impl<T> Store<T> {
+    pub fn new(engine: Engine, data: T) -> Self {
+        let mut inner = Box::new(StoreInner {
+            opaque: StoreOpaque {
+                engine,
+                // alloc,
+                // vm_store_context: VMStoreContext::default(),
+                stored: StoredData::default(),
+                // default_caller: InstanceHandle::null(),
+                // wasm_vmval_storage: vec![],
+                // host_globals: vec![],
+                // host_tables: vec![],
+                // interpreter: Interpreter::new(),
+                // _pinned: PhantomPinned,
+            },
+            data,
+        });
+
+        // inner.opaque.default_caller = {
+        //     let mut instance = inner
+        //         .opaque
+        //         .alloc
+        //         .allocate_module(Module::new_stub(engine.clone()))
+        //         .expect("failed to allocate default callee");
+        //
+        //     instance
+        //         .instance_mut()
+        //         .set_store(Some(NonNull::from(&mut inner.opaque)));
+        //
+        //     instance
+        // };
+
+        Self(Box::into_pin(inner))
+    }
+}
+
+// ===== impl StoreOpaque =====
+
+impl StoreOpaque {
+    #[inline]
+    pub(super) fn engine(&self) -> &Engine {
+        &self.engine
+    }
+}

--- a/libs/kwasm/src/store/stored.rs
+++ b/libs/kwasm/src/store/stored.rs
@@ -1,0 +1,105 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use alloc::vec::Vec;
+use core::fmt;
+use core::marker::PhantomData;
+
+#[derive(Debug, Default)]
+pub struct StoredData {
+    // pub(super) instances: Vec<()>,
+    // pub(super) functions: Vec<()>,
+    // pub(super) tables: Vec<()>,
+    // pub(super) memories: Vec<()>,
+    // pub(super) globals: Vec<()>,
+    // pub(super) tags: Vec<()>,
+}
+
+pub struct Stored<T> {
+    index: usize,
+    _m: PhantomData<T>,
+}
+
+// ===== impl Stored =====
+
+impl<T> Stored<T> {
+    pub fn new(index: usize) -> Self {
+        Self {
+            index,
+            _m: PhantomData,
+        }
+    }
+}
+
+impl<T> Clone for Stored<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for Stored<T> {}
+
+impl<T> fmt::Debug for Stored<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Stored").field(&self.index).finish()
+    }
+}
+
+macro_rules! stored_impls {
+    ($bind:ident $(($ty:tt, $add:ident, $has:ident, $get:ident, $get_mut:ident, $field:expr))*) => {
+        $(
+            impl super::StoreOpaque {
+                pub(crate) fn $add(&mut self, val: $ty) -> Stored<$ty> {
+                    let $bind = self;
+                    let index = $field.len();
+                    $field.push(val);
+                    Stored::new(index)
+                }
+
+                pub(crate) fn $has(&self, index: Stored<$ty>) -> bool {
+                    let $bind = self;
+                    $field.get(index.index).is_some()
+                }
+
+                pub(crate) fn $get(&self, index: Stored<$ty>) -> Option<&$ty> {
+                    let $bind = self;
+                    $field.get(index.index)
+                }
+
+                pub(crate) fn $get_mut(&mut self, index: Stored<$ty>) -> Option<&mut $ty> {
+                    let $bind = self;
+                    $field.get_mut(index.index)
+                }
+            }
+
+            impl ::core::ops::Index<Stored<$ty>> for super::StoreOpaque {
+                type Output = $ty;
+
+                fn index(&self, index: Stored<$ty>) -> &Self::Output {
+                    self.$get(index).unwrap()
+                }
+            }
+
+            impl ::core::ops::IndexMut<Stored<$ty>> for super::StoreOpaque {
+                fn index_mut(&mut self, index: Stored<$ty>) -> &mut Self::Output {
+                    self.$get_mut(index).unwrap()
+                }
+            }
+        )*
+    };
+}
+
+stored_impls! {
+    s
+    // ((), add_function, has_function, get_function, get_function_mut, s.stored.functions)
+    // ((), add_instance, has_instance, get_instance, get_instance_mut, s.stored.instances)
+    // ((), add_table, has_table, get_table, get_table_mut, s.stored.tables)
+    // ((), add_memory, has_memory, get_memory, get_memory_mut, s.stored.memories)
+    // ((), add_global, has_global, get_global, get_global_mut, s.stored.globals)
+    // ((), add_tag, has_tag, get_tag, get_tag_mut, s.stored.tags)
+}
+

--- a/libs/kwasm/src/type_registry.rs
+++ b/libs/kwasm/src/type_registry.rs
@@ -1,0 +1,1209 @@
+use crate::indices::{
+    CanonicalizedTypeIndex, ModuleInternedTypeIndex, RecGroupRelativeTypeIndex, VMSharedTypeIndex,
+};
+use crate::loom::sync::atomic::Ordering;
+use crate::loom::sync::Arc;
+use crate::wasm::{
+    ModuleTypes, WasmCompositeType, WasmCompositeTypeInner, WasmRecGroup, WasmSubType,
+};
+use crate::Engine;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
+use core::hash::{Hash, Hasher};
+use core::ops::Range;
+use core::sync::atomic::{AtomicBool, AtomicUsize};
+use core::{fmt, iter};
+use cranelift_entity::packed_option::{PackedOption, ReservedValue};
+use cranelift_entity::{iter_entity_range, PrimaryMap, SecondaryMap};
+use hashbrown::HashSet;
+use wasmtime_slab::Slab;
+use spin::RwLock;
+
+pub trait TypeTrace {
+    /// Visit each edge.
+    ///
+    /// The function can break out of tracing by returning `Err(E)`.
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>;
+
+    /// Visit each edge, mutably.
+    ///
+    /// Allows updating edges.
+    ///
+    /// The function can break out of tracing by returning `Err(E)`.
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>;
+
+    /// Trace all `VMSharedTypeIndex` edges, ignoring other edges.
+    fn trace_engine_indices<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(VMSharedTypeIndex) -> Result<(), E>,
+    {
+        self.trace(&mut |idx| match idx {
+            CanonicalizedTypeIndex::Engine(idx) => func(idx),
+            CanonicalizedTypeIndex::Module(_) | CanonicalizedTypeIndex::RecGroup(_) => Ok(()),
+        })
+    }
+
+    fn canonicalize_for_runtime_usage<F>(&mut self, module_to_engine: &mut F)
+    where
+        F: FnMut(ModuleInternedTypeIndex) -> VMSharedTypeIndex,
+    {
+        self.trace_mut::<_, ()>(&mut |idx| match *idx {
+            CanonicalizedTypeIndex::Engine(_) => Ok(()),
+            CanonicalizedTypeIndex::RecGroup(_) => unreachable!(),
+            CanonicalizedTypeIndex::Module(module_index) => {
+                let index = module_to_engine(module_index);
+                *idx = CanonicalizedTypeIndex::Engine(index);
+                Ok(())
+            }
+        })
+        .unwrap();
+    }
+
+    fn is_canonicalized_for_runtime_usage(&self) -> bool {
+        self.trace(&mut |idx| match idx {
+            CanonicalizedTypeIndex::Engine(_) => Ok(()),
+            CanonicalizedTypeIndex::Module(_) | CanonicalizedTypeIndex::RecGroup(_) => Err(()),
+        })
+        .is_ok()
+    }
+
+    /// Canonicalize `self` by rewriting all type references inside `self` from
+    /// module-level interned type indices to either engine-level interned type
+    /// indices or recgroup-relative indices.
+    fn canonicalize_for_hash_consing<F>(
+        &mut self,
+        rec_group_range: Range<ModuleInternedTypeIndex>,
+        module_to_engine: &mut F,
+    ) where
+        F: FnMut(ModuleInternedTypeIndex) -> VMSharedTypeIndex,
+    {
+        self.trace_mut::<_, ()>(&mut |idx| {
+            match *idx {
+                CanonicalizedTypeIndex::Engine(_) => Ok(()),
+                CanonicalizedTypeIndex::RecGroup(_) => unreachable!(),
+                CanonicalizedTypeIndex::Module(module_index) => {
+                    *idx = if rec_group_range.start <= module_index {
+                        // Any module index within the recursion group gets
+                        // translated into a recgroup-relative index.
+                        debug_assert!(module_index < rec_group_range.end);
+                        let relative = module_index.as_u32() - rec_group_range.start.as_u32();
+                        let relative = RecGroupRelativeTypeIndex::from_u32(relative);
+                        CanonicalizedTypeIndex::RecGroup(relative)
+                    } else {
+                        // Cross-group indices are translated directly into
+                        // `VMSharedTypeIndex`es.
+                        debug_assert!(module_index < rec_group_range.start);
+                        CanonicalizedTypeIndex::Engine(module_to_engine(module_index))
+                    };
+                    Ok(())
+                }
+            }
+        })
+        .unwrap();
+    }
+
+    /// Is this type canonicalized for hash consing?
+    fn is_canonicalized_for_hash_consing(&self) -> bool {
+        self.trace(&mut |idx| match idx {
+            CanonicalizedTypeIndex::Engine(_) | CanonicalizedTypeIndex::RecGroup(_) => Ok(()),
+            CanonicalizedTypeIndex::Module(_) => Err(()),
+        })
+        .is_ok()
+    }
+}
+
+#[derive(Debug)]
+pub struct RuntimeTypeCollection {
+    engine: Engine,
+    rec_groups: Vec<RecGroupEntry>,
+    types: PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
+    trampolines: SecondaryMap<VMSharedTypeIndex, PackedOption<ModuleInternedTypeIndex>>,
+}
+
+pub struct RegisteredType {
+    engine: Engine,
+    entry: RecGroupEntry,
+    ty: Arc<WasmSubType>,
+    index: VMSharedTypeIndex,
+}
+
+#[derive(Debug, Clone)]
+struct RecGroupEntry(Arc<RecGroupEntryInner>);
+
+#[derive(Debug)]
+struct RecGroupEntryInner {
+    hash_consing_key: WasmRecGroup,
+    shared_type_indices: Box<[VMSharedTypeIndex]>,
+    registrations: AtomicUsize,
+    unregistered: AtomicBool,
+}
+
+#[derive(Debug, Default)]
+pub struct TypeRegistry( RwLock<TypeRegistryInner>);
+
+#[derive(Debug, Default)]
+struct TypeRegistryInner {
+    // A hash map from a canonicalized-for-hash-consing rec group to its
+    // `VMSharedTypeIndex`es.
+    //
+    // There is an entry in this map for every rec group we have already
+    // registered. Before registering new rec groups, we first check this map to
+    // see if we've already registered an identical rec group that we should
+    // reuse instead.
+    hash_consing_map: HashSet<RecGroupEntry>,
+    // A map from `VMSharedTypeIndex::bits()` to the type index's associated
+    // Wasm type.
+    //
+    // These types are always canonicalized for runtime usage.
+    //
+    // These are only `None` during the process of inserting a new rec group
+    // into the registry, where we need registered `VMSharedTypeIndex`es for
+    // forward type references within the rec group, but have not actually
+    // inserted all the types within the rec group yet.
+    types: Slab<Option<Arc<WasmSubType>>>,
+    // A map that lets you walk backwards from a `VMSharedTypeIndex` to its
+    // `RecGroupEntry`.
+    type_to_rec_group: SecondaryMap<VMSharedTypeIndex, Option<RecGroupEntry>>,
+    // A map from a registered type to its complete list of supertypes.
+    //
+    // The supertypes are ordered from super- to subtype, i.e. the immediate
+    // parent supertype is the last element and the least-upper-bound of all
+    // supertypes is the first element.
+    //
+    // Types without any supertypes are omitted from this map. This means that
+    // we never allocate any backing storage for this map when Wasm GC is not in
+    // use.
+    type_to_supertypes: SecondaryMap<VMSharedTypeIndex, Option<Box<[VMSharedTypeIndex]>>>,
+    // A map from each registered function type to its trampoline type.
+    //
+    // Note that when a function type is its own trampoline type, then we omit
+    // the entry in this map as a memory optimization. This means that if only
+    // core Wasm function types are ever used, then we will never allocate any
+    // backing storage for this map. As a nice bonus, this also avoids cycles (a
+    // function type referencing itself) that our naive reference counting
+    // doesn't play well with.
+    type_to_trampoline: SecondaryMap<VMSharedTypeIndex, PackedOption<VMSharedTypeIndex>>,
+    // An explicit stack of entries that we are in the middle of dropping. Used
+    // to avoid recursion when dropping a type that is holding the last
+    // reference to another type, etc...
+    drop_stack: Vec<RecGroupEntry>,
+}
+
+// === impl RuntimeTypeCollection ===
+
+impl RuntimeTypeCollection {
+    pub fn empty(engine: Engine) -> Self {
+        Self {
+            engine,
+            rec_groups: vec![],
+            types: PrimaryMap::default(),
+            trampolines: SecondaryMap::default(),
+        }
+    }
+
+    /// Gets the map from `ModuleInternedTypeIndex` to `VMSharedTypeIndex`
+    pub fn type_map(&self) -> &PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex> {
+        &self.types
+    }
+
+    /// Look up a shared type index by its module type index
+    #[inline]
+    pub fn lookup_shared_type(&self, index: ModuleInternedTypeIndex) -> Option<VMSharedTypeIndex> {
+        self.types.get(index).copied()
+    }
+
+    #[inline]
+    pub fn trampoline_type(&self, ty: VMSharedTypeIndex) -> Option<ModuleInternedTypeIndex> {
+        let trampoline_ty = self.trampolines[ty].expand();
+        tracing::trace!("TypeCollection::trampoline_type({ty:?}) -> {trampoline_ty:?}");
+        trampoline_ty
+    }
+}
+
+impl Drop for RuntimeTypeCollection {
+    fn drop(&mut self) {
+        if !self.rec_groups.is_empty() {
+            self.engine
+                .type_registry()
+                .0
+                .write()
+                .unregister_type_collection(self);
+        }
+    }
+}
+
+// === impl RegisteredType ===
+
+impl RegisteredType {
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+    pub fn index(&self) -> VMSharedTypeIndex {
+        self.index
+    }
+}
+
+impl fmt::Debug for RegisteredType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let RegisteredType {
+            engine: _,
+            entry: _,
+            ty,
+            index,
+        } = self;
+        f.debug_struct("RegisteredType")
+            .field("index", index)
+            .field("ty", ty)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Clone for RegisteredType {
+    fn clone(&self) -> Self {
+        self.entry.incr_ref_count("cloning RegisteredType");
+        RegisteredType {
+            engine: self.engine.clone(),
+            entry: self.entry.clone(),
+            ty: self.ty.clone(),
+            index: self.index,
+        }
+    }
+}
+
+impl Drop for RegisteredType {
+    fn drop(&mut self) {
+        if self.entry.decr_ref_count("dropping RegisteredType") {
+            self.engine
+                .type_registry()
+                .0
+                .write()
+                .unregister_entry(self.entry.clone());
+        }
+    }
+}
+
+impl core::ops::Deref for RegisteredType {
+    type Target = WasmSubType;
+
+    fn deref(&self) -> &Self::Target {
+        &self.ty
+    }
+}
+
+impl PartialEq for RegisteredType {
+    fn eq(&self, other: &Self) -> bool {
+        let eq = Arc::ptr_eq(&self.entry.0, &other.entry.0);
+
+        if cfg!(debug_assertions) {
+            if eq {
+                assert!(Engine::same(&self.engine, &other.engine));
+                assert_eq!(self.ty, other.ty);
+            } else {
+                assert!(self.ty != other.ty || !Engine::same(&self.engine, &other.engine));
+            }
+        }
+
+        eq
+    }
+}
+
+impl Eq for RegisteredType {}
+
+impl Hash for RegisteredType {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let ptr = Arc::as_ptr(&self.entry.0);
+        ptr.hash(state);
+    }
+}
+
+// === impl RecGroupEntry ===
+
+impl PartialEq for RecGroupEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.hash_consing_key == other.0.hash_consing_key
+    }
+}
+
+impl Eq for RecGroupEntry {}
+
+impl Hash for RecGroupEntry {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash_consing_key.hash(state);
+    }
+}
+
+impl Borrow<WasmRecGroup> for RecGroupEntry {
+    fn borrow(&self) -> &WasmRecGroup {
+        &self.0.hash_consing_key
+    }
+}
+
+impl RecGroupEntry {
+    fn incr_ref_count(&self, why: &str) {
+        let old_count = self.0.registrations.fetch_add(1, Ordering::AcqRel);
+        let new_count = old_count + 1;
+        tracing::trace!(
+            "increment registration count for {self:?} (registrations -> {new_count}): {why}",
+        );
+    }
+
+    #[must_use = "caller must remove entry from registry if `decref` returns `true`"]
+    fn decr_ref_count(&self, why: &str) -> bool {
+        let old_count = self.0.registrations.fetch_sub(1, Ordering::AcqRel);
+        let new_count = old_count - 1;
+        tracing::trace!(
+            "decrement registration count for {self:?} (registrations -> {new_count}): {why}",
+        );
+        old_count == 1
+    }
+}
+
+// === impl TypeRegistry ===
+
+impl TypeRegistry {
+    /// Creates a new shared type registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[inline]
+    pub fn debug_assert_contains(&self, index: VMSharedTypeIndex) {
+        if cfg!(debug_assertions) {
+            self.0.read().debug_assert_registered(index);
+        }
+    }
+
+    /// Looks up a function type from a shared type index.
+    ///
+    /// This does *NOT* prevent the type from being unregistered while you are
+    /// still using the resulting value! Use the `RegisteredType::root`
+    /// constructor if you need to ensure that property and you don't have some
+    /// other mechanism already keeping the type registered.
+    pub fn borrow(&self, index: VMSharedTypeIndex) -> Option<Arc<WasmSubType>> {
+        let id = shared_type_index_to_slab_id(index);
+        let inner = self.0.read();
+        inner.types.get(id).and_then(|ty| ty.clone())
+    }
+
+    pub fn register_module_types(
+        &self,
+        engine: &Engine,
+        module_types: ModuleTypes,
+    ) -> RuntimeTypeCollection {
+        let (rec_groups, types) = self.0.write().register_module_types(&module_types);
+
+        tracing::trace!("Begin building module's shared-to-module-trampoline-types map");
+        let mut trampolines = SecondaryMap::with_capacity(types.len());
+        for (module_ty, module_trampoline_ty) in module_types.trampoline_types() {
+            let shared_ty = types[module_ty];
+            let trampoline_shared_ty = self.get_trampoline_type(shared_ty);
+            trampolines[trampoline_shared_ty] = Some(module_trampoline_ty).into();
+            tracing::trace!(
+                "--> shared_to_module_trampolines[{trampoline_shared_ty:?}] = {module_trampoline_ty:?}"
+            );
+        }
+        tracing::trace!("Done building module's shared-to-module-trampoline-types map");
+
+        RuntimeTypeCollection {
+            engine: engine.clone(),
+            rec_groups,
+            types,
+            trampolines,
+        }
+    }
+
+    pub fn register_type(&self, engine: &Engine, ty: WasmSubType) -> RegisteredType {
+        self.0.write().register_type(engine, ty)
+    }
+
+    // pub fn get_type(&self, engine: &Engine, index: VMSharedTypeIndex) -> Option<RegisteredType> {
+    //     let id = shared_type_index_to_slab_id(index);
+    //     let inner = self.0.read();
+    //
+    //     let ty = inner.types.get(id)?.clone().unwrap();
+    //     let entry = inner.type_to_rec_group[index].clone().unwrap();
+    //
+    //     entry.incr_ref_count("TypeRegistry::get_type");
+    //
+    //     debug_assert!(entry.0.registrations.load(Acquire) != 0);
+    //     Some(RegisteredType {
+    //         engine: engine.clone(),
+    //         entry,
+    //         ty,
+    //         index,
+    //     })
+    // }
+
+    /// Get the trampoline type for the given function type index.
+    ///
+    /// Panics for non-function type indices.
+    pub fn get_trampoline_type(&self, index: VMSharedTypeIndex) -> VMSharedTypeIndex {
+        let id = shared_type_index_to_slab_id(index);
+        let inner = self.0.read();
+
+        let ty = inner.types[id].as_ref().unwrap();
+        debug_assert!(
+            ty.is_func(),
+            "cannot get the trampoline type of a non-function type: {index:?} = {ty:?}"
+        );
+
+        let trampoline_ty = match inner.type_to_trampoline.get(index).and_then(|x| x.expand()) {
+            Some(ty) => ty,
+            None => {
+                // The function type is its own trampoline type.
+                index
+            }
+        };
+        tracing::trace!("TypeRegistry::trampoline_type({index:?}) -> {trampoline_ty:?}");
+        trampoline_ty
+    }
+
+    /// Create an owning handle to the given index's associated type.
+    ///
+    /// This will prevent the associated type from being unregistered as long as
+    /// the returned `RegisteredType` is kept alive.
+    ///
+    /// Returns `None` if `index` is not registered in the given engine's
+    /// registry.
+    pub fn root(&self, engine: &Engine, index: VMSharedTypeIndex) -> Option<RegisteredType> {
+        debug_assert!(!index.is_reserved_value());
+        let (entry, ty) = {
+            let id = shared_type_index_to_slab_id(index);
+            let inner = self.0.read();
+
+            let ty = inner.types.get(id)?.clone().unwrap();
+            let entry = inner.type_to_rec_group[index].clone().unwrap();
+            // let layout = inner.type_to_gc_layout.get(index).and_then(|l| l.clone());
+
+            // NB: make sure to incref while the lock is held to prevent:
+            //
+            // * This thread: read locks registry, gets entry E, unlocks registry
+            // * Other thread: drops `RegisteredType` for entry E, decref
+            //   reaches zero, write locks registry, unregisters entry
+            // * This thread: increfs entry, but it isn't in the registry anymore
+            entry.incr_ref_count("TypeRegistry::root");
+
+            (entry, ty)
+        };
+
+        debug_assert!(entry.0.registrations.load(Ordering::Acquire) != 0);
+        Some(RegisteredType {
+            engine: engine.clone(),
+            entry,
+            ty,
+            index,
+        })
+    }
+
+    /// Is type `sub` a subtype of `sup`?
+    #[inline]
+    pub fn is_subtype(&self, sub: VMSharedTypeIndex, sup: VMSharedTypeIndex) -> bool {
+        if cfg!(debug_assertions) {
+            self.0.read().debug_assert_registered(sub);
+            self.0.read().debug_assert_registered(sup);
+        }
+
+        if sub == sup {
+            return true;
+        }
+
+        self.is_subtype_slow(sub, sup)
+    }
+
+    fn is_subtype_slow(&self, sub: VMSharedTypeIndex, sup: VMSharedTypeIndex) -> bool {
+        // Do the O(1) subtype checking trick:
+        //
+        // In a type system with single inheritance, the subtyping relationships
+        // between all types form a set of trees. The root of each tree is a
+        // type that has no supertype; each node's immediate children are the
+        // types that directly subtype that node.
+        //
+        // For example, consider these types:
+        //
+        //     class Base {}
+        //     class A subtypes Base {}
+        //     class B subtypes Base {}
+        //     class C subtypes A {}
+        //     class D subtypes A {}
+        //     class E subtypes C {}
+        //
+        // These types produce the following tree:
+        //
+        //                Base
+        //               /    \
+        //              A      B
+        //             / \
+        //            C   D
+        //           /
+        //          E
+        //
+        // Note the following properties:
+        //
+        // 1. If `sub` is a subtype of `sup` (either directly or transitively)
+        //    then `sup` *must* be on the path from `sub` up to the root of
+        //    `sub`'s tree.
+        //
+        // 2. Additionally, `sup` *must* be the `i`th node down from the root in
+        //    that path, where `i` is the length of the path from `sup` to its
+        //    tree's root.
+        //
+        // Therefore, if we have the path to the root for each type (we do) then
+        // we can simply check if `sup` is at index `supertypes(sup).len()`
+        // within `supertypes(sub)`.
+        let inner = self.0.read();
+        let sub_supertypes = inner.supertypes(sub);
+        let sup_supertypes = inner.supertypes(sup);
+        sub_supertypes.get(sup_supertypes.len()) == Some(&sup)
+    }
+}
+
+impl TypeRegistryInner {
+    #[inline]
+    #[track_caller]
+    fn debug_assert_registered(&self, index: VMSharedTypeIndex) {
+        debug_assert!(
+            !index.is_reserved_value(),
+            "should have an actual VMSharedTypeIndex, not the reserved value"
+        );
+        debug_assert!(
+            self.types.contains(shared_type_index_to_slab_id(index)),
+            "registry's slab should contain {index:?}",
+        );
+        debug_assert!(
+            self.types[shared_type_index_to_slab_id(index)].is_some(),
+            "registry's slab should actually contain a type for {index:?}",
+        );
+        debug_assert!(
+            self.type_to_rec_group[index].is_some(),
+            "{index:?} should have an associated rec group entry"
+        );
+    }
+
+    #[inline]
+    #[track_caller]
+    fn debug_assert_all_registered(&self, indices: impl IntoIterator<Item = VMSharedTypeIndex>) {
+        if cfg!(debug_assertions) {
+            for index in indices {
+                self.debug_assert_registered(index);
+            }
+        }
+    }
+
+    /// Is the given type canonicalized for runtime usage this registry?
+    fn assert_canonicalized_for_runtime_usage_in_this_registry(&self, ty: &WasmSubType) {
+        ty.trace::<_, ()>(&mut |index| match index {
+            CanonicalizedTypeIndex::RecGroup(_) | CanonicalizedTypeIndex::Module(_) => {
+                panic!("not canonicalized for runtime usage: {ty:?}")
+            }
+            CanonicalizedTypeIndex::Engine(idx) => {
+                self.debug_assert_registered(idx);
+                Ok(())
+            }
+        })
+        .unwrap();
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn register_module_types(
+        &mut self,
+        types: &ModuleTypes,
+    ) -> (
+        Vec<RecGroupEntry>,
+        PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
+    ) {
+        // The engine's type registry entries for these module types.
+        let mut entries = Vec::with_capacity(types.rec_groups().len());
+
+        // The map from a module type index to an engine type index for these
+        // module types.
+        let mut map = PrimaryMap::<ModuleInternedTypeIndex, VMSharedTypeIndex>::with_capacity(
+            types.wasm_types().len(),
+        );
+
+        for module_group in types.rec_groups().cloned() {
+            let entry = self.register_rec_group(
+                &map,
+                module_group.clone(),
+                iter_entity_range(module_group.clone())
+                    .map(|ty| types.get_wasm_type(ty).unwrap().clone()),
+            );
+
+            // Update the module-to-engine map with this rec group's
+            // newly-registered types.
+            for (module_ty, engine_ty) in
+                iter_entity_range(module_group.into()).zip(entry.0.shared_type_indices.iter())
+            {
+                let module_ty2 = map.push(*engine_ty);
+                assert_eq!(module_ty, module_ty2);
+            }
+
+            entries.push(entry);
+        }
+
+        (entries, map)
+    }
+
+    fn register_type(&mut self, engine: &Engine, ty: WasmSubType) -> RegisteredType {
+        let entry = self.register_singleton_rec_group(ty);
+
+        let index = entry.0.shared_type_indices[0];
+        let id = shared_type_index_to_slab_id(index);
+        let ty = self.types[id].clone().unwrap();
+        RegisteredType {
+            engine: engine.clone(),
+            entry,
+            ty,
+            index,
+        }
+    }
+
+    fn register_rec_group(
+        &mut self,
+        map: &PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
+        range: Range<ModuleInternedTypeIndex>,
+        types: impl ExactSizeIterator<Item = WasmSubType>,
+    ) -> RecGroupEntry {
+        debug_assert_eq!(iter_entity_range(range.clone()).len(), types.len());
+
+        // We need two different canonicalizations of this rec group: one for
+        // hash-consing and another for runtime usage within this
+        // engine. However, we only need the latter if this is a new rec group
+        // that hasn't been registered before. Therefore, we only eagerly create
+        // the hash-consing canonicalized version, and while we lazily
+        // canonicalize for runtime usage in this engine, we must still eagerly
+        // clone and set aside the original, non-canonicalized types for that
+        // potential engine canonicalization eventuality.
+        let mut non_canon_types = Vec::with_capacity(types.len());
+        let hash_consing_key = WasmRecGroup(
+            types
+                .zip(iter_entity_range(range.clone()))
+                .map(|(mut ty, module_index)| {
+                    non_canon_types.push((module_index, ty.clone()));
+                    ty.canonicalize_for_hash_consing(range.clone(), &mut |idx| {
+                        debug_assert!(idx < range.start);
+                        map[idx]
+                    });
+                    ty
+                })
+                .collect::<Box<[_]>>(),
+        );
+
+        // Any references in the hash-consing key to types outside of this rec
+        // group may only be to fully-registered types.
+        if cfg!(debug_assertions) {
+            hash_consing_key
+                .trace_engine_indices::<_, ()>(&mut |index| {
+                    self.debug_assert_registered(index);
+                    Ok(())
+                })
+                .unwrap();
+        }
+
+        // If we've already registered this rec group before, reuse it.
+        if let Some(entry) = self.hash_consing_map.get(&hash_consing_key) {
+            tracing::trace!("hash-consing map hit: reusing {entry:?}");
+            assert!(!entry.0.unregistered.load(Ordering::Acquire));
+            self.debug_assert_all_registered(entry.0.shared_type_indices.iter().copied());
+            entry.incr_ref_count("hash-consing map hit");
+            return entry.clone();
+        }
+
+        tracing::trace!("hash-consing map miss: making new registration");
+
+        // Inter-group edges: increment the referenced group's ref
+        // count, because these other rec groups shouldn't be dropped
+        // while this rec group is still alive.
+        hash_consing_key
+            .trace_engine_indices::<_, ()>(&mut |index| {
+                self.debug_assert_registered(index);
+                let other_entry = self.type_to_rec_group[index].as_ref().unwrap();
+                assert!(!other_entry.0.unregistered.load(Ordering::Acquire));
+                other_entry.incr_ref_count("new rec group's type references");
+                Ok(())
+            })
+            .unwrap();
+
+        // Register the individual types.
+        //
+        // Note that we can't update the reverse type-to-rec-group map until
+        // after we've constructed the `RecGroupEntry`, since that map needs the
+        // fully-constructed entry for its values.
+        let module_rec_group_start = range.start;
+        let shared_type_indices: Box<[_]> = non_canon_types
+            .iter()
+            .map(|(module_index, ty)| {
+                let engine_index = slab_id_to_shared_type_index(self.types.alloc(None));
+                tracing::trace!(
+                    "reserved {engine_index:?} for {module_index:?} = non-canonical {ty:?}"
+                );
+                engine_index
+            })
+            .collect();
+        for (engine_index, (module_index, mut ty)) in
+            shared_type_indices.iter().copied().zip(non_canon_types)
+        {
+            tracing::trace!("canonicalizing {engine_index:?} for runtime usage");
+            ty.canonicalize_for_runtime_usage(&mut |module_index| {
+                if module_index < module_rec_group_start {
+                    let engine_index = map[module_index];
+                    tracing::trace!("    cross-group {module_index:?} becomes {engine_index:?}");
+                    self.debug_assert_registered(engine_index);
+                    engine_index
+                } else {
+                    assert!(module_index < range.end);
+                    let rec_group_offset = module_index.as_u32() - module_rec_group_start.as_u32();
+                    let rec_group_offset = usize::try_from(rec_group_offset).unwrap();
+                    let engine_index = shared_type_indices[rec_group_offset];
+                    tracing::trace!("    intra-group {module_index:?} becomes {engine_index:?}");
+                    assert!(!engine_index.is_reserved_value());
+                    assert!(
+                        self.types
+                            .contains(shared_type_index_to_slab_id(engine_index))
+                    );
+                    engine_index
+                }
+            });
+            self.insert_one_type_from_rec_group(module_index, engine_index, ty);
+        }
+
+        // Although we haven't finished registering all their metadata, the
+        // types themselves should all be filled in now.
+        if cfg!(debug_assertions) {
+            for index in &shared_type_indices {
+                let id = shared_type_index_to_slab_id(*index);
+                debug_assert!(self.types.contains(id));
+                debug_assert!(self.types[id].is_some());
+            }
+        }
+        debug_assert_eq!(
+            shared_type_indices.len(),
+            shared_type_indices
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>()
+                .len(),
+            "should not have any duplicate type indices",
+        );
+
+        let entry = RecGroupEntry(Arc::new(RecGroupEntryInner {
+            hash_consing_key,
+            shared_type_indices,
+            registrations: AtomicUsize::new(1),
+            unregistered: AtomicBool::new(false),
+        }));
+        tracing::trace!("new {entry:?} -> count 1");
+
+        let is_new_entry = self.hash_consing_map.insert(entry.clone());
+        debug_assert!(is_new_entry);
+
+        // Now that we've constructed the entry, we can update the reverse
+        // type-to-rec-group map.
+        for ty in entry.0.shared_type_indices.iter().copied() {
+            debug_assert!(self.type_to_rec_group[ty].is_none());
+            self.type_to_rec_group[ty] = Some(entry.clone());
+        }
+        self.debug_assert_all_registered(entry.0.shared_type_indices.iter().copied());
+
+        // Finally, make sure to register the trampoline type for each function
+        // type in the rec group.
+        for shared_type_index in entry.0.shared_type_indices.iter().copied() {
+            let slab_id = shared_type_index_to_slab_id(shared_type_index);
+            let sub_ty = self.types[slab_id].as_ref().unwrap();
+            if let Some(f) = sub_ty.as_func() {
+                let trampoline = f.trampoline_type();
+                match &trampoline {
+                    Cow::Borrowed(_) if sub_ty.is_final && sub_ty.supertype.is_none() => {
+                        // The function type is its own trampoline type. Leave
+                        // its entry in `type_to_trampoline` empty to signal
+                        // this.
+                        tracing::trace!(
+                            "trampoline_type({shared_type_index:?}) = {shared_type_index:?}",
+                        );
+                    }
+                    Cow::Borrowed(_) | Cow::Owned(_) => {
+                        // This will recursively call into rec group
+                        // registration, but at most once since trampoline
+                        // function types are their own trampoline type.
+                        let trampoline_entry = self.register_singleton_rec_group(WasmSubType {
+                            is_final: true,
+                            supertype: None,
+                            composite_type: WasmCompositeType {
+                                shared: sub_ty.composite_type.shared,
+                                inner: WasmCompositeTypeInner::Func(trampoline.into_owned()),
+                            },
+                        });
+                        assert_eq!(trampoline_entry.0.shared_type_indices.len(), 1);
+                        let trampoline_index = trampoline_entry.0.shared_type_indices[0];
+                        tracing::trace!(
+                            "trampoline_type({shared_type_index:?}) = {trampoline_index:?}",
+                        );
+                        self.debug_assert_registered(trampoline_index);
+                        debug_assert_ne!(shared_type_index, trampoline_index);
+                        self.type_to_trampoline[shared_type_index] = Some(trampoline_index).into();
+                    }
+                }
+            }
+        }
+
+        entry
+    }
+
+    fn insert_one_type_from_rec_group(
+        &mut self,
+        module_index: ModuleInternedTypeIndex,
+        engine_index: VMSharedTypeIndex,
+        ty: WasmSubType,
+    ) {
+        // Despite being canonicalized for runtime usage, this type may still
+        // have forward references to other types in the rec group we haven't
+        // yet registered. Therefore, we can't use our usual
+        // `assert_canonicalized_for_runtime_usage_in_this_registry` helper here
+        // as that will see the forward references and think they must be
+        // references to types in other registries.
+        debug_assert!(
+            ty.is_canonicalized_for_runtime_usage(),
+            "type is not canonicalized for runtime usage: {ty:?}"
+        );
+
+        // Add the type to our slab.
+        let id = shared_type_index_to_slab_id(engine_index);
+        assert!(self.types.contains(id));
+        assert!(self.types[id].is_none());
+        self.types[id] = Some(Arc::new(ty));
+
+        // Create the supertypes list for this type.
+        if let Some(supertype) = self.types[id].as_ref().unwrap().supertype {
+            let supertype = supertype.unwrap_engine_type_index();
+            let supers_supertypes = self.supertypes(supertype);
+            let mut supertypes = Vec::with_capacity(supers_supertypes.len() + 1);
+            supertypes.extend(
+                supers_supertypes
+                    .iter()
+                    .copied()
+                    .chain(iter::once(supertype)),
+            );
+            self.type_to_supertypes[engine_index] = Some(supertypes.into_boxed_slice());
+        }
+
+        tracing::trace!(
+            "finished registering type {module_index:?} as {engine_index:?} = runtime-canonical {:?}",
+            self.types[id].as_ref().unwrap()
+        );
+    }
+
+    /// Get the supertypes list for the given type.
+    ///
+    /// The supertypes are listed in super-to-sub order. `ty` itself is not
+    /// included in the list.
+    fn supertypes(&self, ty: VMSharedTypeIndex) -> &[VMSharedTypeIndex] {
+        self.type_to_supertypes
+            .get(ty)
+            .and_then(|s| s.as_deref())
+            .unwrap_or(&[])
+    }
+
+    /// Register a rec group consisting of a single type.
+    ///
+    /// The type must already be canonicalized for runtime usage in this
+    /// registry.
+    ///
+    /// The returned entry will have already had its reference count incremented
+    /// on behalf of callers.
+    fn register_singleton_rec_group(&mut self, ty: WasmSubType) -> RecGroupEntry {
+        self.assert_canonicalized_for_runtime_usage_in_this_registry(&ty);
+
+        // This type doesn't have any module-level type references, since it is
+        // already canonicalized for runtime usage in this registry, so an empty
+        // map suffices.
+        let map = PrimaryMap::default();
+
+        // This must have `range.len() == 1`, even though we know this type
+        // doesn't have any intra-group type references, to satisfy
+        // `register_rec_group`'s preconditions.
+        let range = Range::from(
+            ModuleInternedTypeIndex::from_bits(u32::MAX - 1)
+                ..ModuleInternedTypeIndex::from_bits(u32::MAX),
+        );
+
+        self.register_rec_group(&map, range, iter::once(ty))
+    }
+
+    #[tracing::instrument(skip(self))]
+    fn unregister_type_collection(&mut self, collection: &RuntimeTypeCollection) {
+        for entry in &collection.rec_groups {
+            self.debug_assert_all_registered(entry.0.shared_type_indices.iter().copied());
+            if entry.decr_ref_count("TypeRegistryInner::unregister_type_collection") {
+                self.unregister_entry(entry.clone());
+            }
+        }
+    }
+
+    fn unregister_entry(&mut self, entry: RecGroupEntry) {
+        tracing::trace!("Attempting to unregister {entry:?}");
+        debug_assert!(self.drop_stack.is_empty());
+
+        // There are two races to guard against before we can unregister the
+        // entry, even though it was on the drop stack:
+        //
+        // 1. Although an entry has to reach zero registrations before it is
+        //    enqueued in the drop stack, we need to double check whether the
+        //    entry is *still* at zero registrations. This is because someone
+        //    else can resurrect the entry in between when the
+        //    zero-registrations count was first observed and when we actually
+        //    acquire the lock to unregister it. In this example, we have
+        //    threads A and B, an existing rec group entry E, and a rec group
+        //    entry E' that is a duplicate of E:
+        //
+        //    Thread A                        | Thread B
+        //    --------------------------------+-----------------------------
+        //    acquire(type registry lock)     |
+        //                                    |
+        //                                    | decref(E) --> 0
+        //                                    |
+        //                                    | block_on(type registry lock)
+        //                                    |
+        //    register(E') == incref(E) --> 1 |
+        //                                    |
+        //    release(type registry lock)     |
+        //                                    |
+        //                                    | acquire(type registry lock)
+        //                                    |
+        //                                    | unregister(E)         !!!!!!
+        //
+        //    If we aren't careful, we can unregister a type while it is still
+        //    in use!
+        //
+        //    The fix in this case is that we skip unregistering the entry if
+        //    its reference count is non-zero, since that means it was
+        //    concurrently resurrected and is now in use again.
+        //
+        // 2. In a slightly more convoluted version of (1), where an entry is
+        //    resurrected but then dropped *again*, someone might attempt to
+        //    unregister an entry a second time:
+        //
+        //    Thread A                        | Thread B
+        //    --------------------------------|-----------------------------
+        //    acquire(type registry lock)     |
+        //                                    |
+        //                                    | decref(E) --> 0
+        //                                    |
+        //                                    | block_on(type registry lock)
+        //                                    |
+        //    register(E') == incref(E) --> 1 |
+        //                                    |
+        //    release(type registry lock)     |
+        //                                    |
+        //    decref(E) --> 0                 |
+        //                                    |
+        //    acquire(type registry lock)     |
+        //                                    |
+        //    unregister(E)                   |
+        //                                    |
+        //    release(type registry lock)     |
+        //                                    |
+        //                                    | acquire(type registry lock)
+        //                                    |
+        //                                    | unregister(E)         !!!!!!
+        //
+        //    If we aren't careful, we can unregister a type twice, which leads
+        //    to panics and registry corruption!
+        //
+        //    To detect this scenario and avoid the double-unregistration bug,
+        //    we maintain an `unregistered` flag on entries. We set this flag
+        //    once an entry is unregistered and therefore, even if it is
+        //    enqueued in the drop stack multiple times, we only actually
+        //    unregister the entry the first time.
+        //
+        // A final note: we don't need to worry about any concurrent
+        // modifications during the middle of this function's execution, only
+        // between (a) when we first observed a zero-registrations count and
+        // decided to unregister the type, and (b) when we acquired the type
+        // registry's lock so that we could perform that unregistration. This is
+        // because this method has exclusive access to `&mut self` -- that is,
+        // we have a write lock on the whole type registry -- and therefore no
+        // one else can create new references to this zero-registration entry
+        // and bring it back to life (which would require finding it in
+        // `self.hash_consing_map`, which no one else has access to, because we
+        // now have an exclusive lock on `self`).
+
+        // Handle scenario (1) from above.
+        let registrations = entry.0.registrations.load(Ordering::Acquire);
+        if registrations != 0 {
+            tracing::trace!(
+                "    {entry:?} was concurrently resurrected and no longer has \
+                 zero registrations (registrations -> {registrations})",
+            );
+            assert!(!entry.0.unregistered.load(Ordering::Acquire));
+            return;
+        }
+
+        // Handle scenario (2) from above.
+        if entry.0.unregistered.load(Ordering::Acquire) {
+            tracing::trace!(
+                "    {entry:?} was concurrently resurrected, dropped again, \
+                 and already unregistered"
+            );
+            return;
+        }
+
+        // Okay, we are really going to unregister this entry. Enqueue it on the
+        // drop stack.
+        self.drop_stack.push(entry);
+
+        // Keep unregistering entries until the drop stack is empty. This is
+        // logically a recursive process where if we unregister a type that was
+        // the only thing keeping another type alive, we then recursively
+        // unregister that other type as well. However, we use this explicit
+        // drop stack to avoid recursion and the potential stack overflows that
+        // recursion implies.
+        while let Some(entry) = self.drop_stack.pop() {
+            tracing::trace!("Begin unregistering {entry:?}");
+            self.debug_assert_all_registered(entry.0.shared_type_indices.iter().copied());
+
+            // All entries on the drop stack should *really* be ready for
+            // unregistration, since no one can resurrect entries once we've
+            // locked the registry.
+            assert_eq!(entry.0.registrations.load(Ordering::Acquire), 0);
+            assert!(!entry.0.unregistered.load(Ordering::Acquire));
+
+            // We are taking responsibility for unregistering this entry, so
+            // prevent anyone else from attempting to do it again.
+            entry.0.unregistered.store(true, Ordering::Release);
+
+            // Decrement any other types that this type was shallowly
+            // (i.e. non-transitively) referencing and keeping alive. If this
+            // was the last thing keeping them registered, its okay to
+            // unregister them as well now.
+            debug_assert!(entry.0.hash_consing_key.is_canonicalized_for_hash_consing());
+            entry
+                .0
+                .hash_consing_key
+                .trace_engine_indices::<_, ()>(&mut |other_index| {
+                    self.debug_assert_registered(other_index);
+                    let other_entry = self.type_to_rec_group[other_index].as_ref().unwrap();
+                    if other_entry.decr_ref_count("dropping rec group's type references") {
+                        self.drop_stack.push(other_entry.clone());
+                    }
+                    Ok(())
+                })
+                .unwrap();
+
+            // Remove the entry from the hash-consing map. If we register a
+            // duplicate definition of this rec group again in the future, it
+            // will be as if it is the first time it has ever been registered,
+            // and it will be inserted into the hash-consing map again at that
+            // time.
+            let was_in_map = self.hash_consing_map.remove(&entry);
+            debug_assert!(was_in_map);
+
+            // Similarly, remove the rec group's types from the registry, as
+            // well as their entries from the reverse type-to-rec-group
+            // map. Additionally, stop holding a strong reference from each
+            // function type in the rec group to that function type's trampoline
+            // type.
+            debug_assert_eq!(
+                entry.0.shared_type_indices.len(),
+                entry
+                    .0
+                    .shared_type_indices
+                    .iter()
+                    .copied()
+                    .collect::<HashSet<_>>()
+                    .len(),
+                "should not have any duplicate type indices",
+            );
+            for ty in entry.0.shared_type_indices.iter().copied() {
+                tracing::trace!("removing {ty:?} from registry");
+
+                let removed_entry = self.type_to_rec_group[ty].take();
+                debug_assert_eq!(removed_entry.unwrap(), entry);
+
+                // Remove the associated trampoline type, if any.
+                if let Some(trampoline_ty) =
+                    self.type_to_trampoline.get(ty).and_then(|x| x.expand())
+                {
+                    self.debug_assert_registered(trampoline_ty);
+                    self.type_to_trampoline[ty] = None.into();
+                    let trampoline_entry = self.type_to_rec_group[trampoline_ty].as_ref().unwrap();
+                    if trampoline_entry
+                        .decr_ref_count("dropping rec group's trampoline-type references")
+                    {
+                        self.drop_stack.push(trampoline_entry.clone());
+                    }
+                }
+
+                // Remove the type's supertypes list, if any. Take care to guard
+                // this assignment so that we don't accidentally force the
+                // secondary map to allocate even when we never actually use
+                // Wasm GC.
+                if self.type_to_supertypes.get(ty).is_some() {
+                    self.type_to_supertypes[ty] = None;
+                }
+
+                let id = shared_type_index_to_slab_id(ty);
+                let deallocated_ty = self.types.dealloc(id);
+                assert!(deallocated_ty.is_some());
+            }
+
+            tracing::trace!("End unregistering {entry:?}");
+        }
+    }
+}
+
+// `TypeRegistryInner` implements `Drop` in debug builds to assert that
+// all types have been unregistered for the registry.
+#[cfg(debug_assertions)]
+impl Drop for TypeRegistryInner {
+    fn drop(&mut self) {
+        tracing::trace!("Dropping type registry: {self:#?}");
+        let TypeRegistryInner {
+            hash_consing_map,
+            types,
+            type_to_rec_group,
+            type_to_supertypes,
+            type_to_trampoline,
+            drop_stack,
+        } = self;
+        assert!(
+            hash_consing_map.is_empty(),
+            "type registry not empty: hash consing map is not empty: {hash_consing_map:#?}"
+        );
+        assert!(
+            types.is_empty(),
+            "type registry not empty: types slab is not empty: {types:#?}"
+        );
+        assert!(
+            type_to_rec_group.is_empty() || type_to_rec_group.values().all(|x| x.is_none()),
+            "type registry not empty: type-to-rec-group map is not empty: {type_to_rec_group:#?}"
+        );
+        assert!(
+            type_to_supertypes.is_empty() || type_to_supertypes.values().all(|x| x.is_none()),
+            "type registry not empty: type-to-supertypes map is not empty: {type_to_supertypes:#?}"
+        );
+        assert!(
+            type_to_trampoline.is_empty() || type_to_trampoline.values().all(|x| x.is_none()),
+            "type registry not empty: type-to-trampoline map is not empty: {type_to_trampoline:#?}"
+        );
+        assert!(
+            drop_stack.is_empty(),
+            "type registry not empty: drop stack is not empty: {drop_stack:#?}"
+        );
+    }
+}
+
+#[inline]
+fn shared_type_index_to_slab_id(index: VMSharedTypeIndex) -> wasmtime_slab::Id {
+    wasmtime_slab::Id::from_raw(index.as_u32())
+}
+
+#[inline]
+fn slab_id_to_shared_type_index(id: wasmtime_slab::Id) -> VMSharedTypeIndex {
+    VMSharedTypeIndex::from_u32(id.into_raw())
+}

--- a/libs/kwasm/src/utils.rs
+++ b/libs/kwasm/src/utils.rs
@@ -1,0 +1,147 @@
+/// Helper macro to generate accessors for an enum.
+macro_rules! enum_accessors {
+    (@$bind:ident, $variant:ident, $ty:ty, $is:ident, $get:ident, $unwrap:ident, $cvt:expr) => {
+        ///  Returns true when the enum is the correct variant.
+        pub fn $is(&self) -> bool {
+            matches!(self, Self::$variant(_))
+        }
+
+        ///  Returns the variant's value, returning None if it is not the correct type.
+        #[inline]
+        pub fn $get(&self) -> Option<$ty> {
+            if let Self::$variant($bind) = self {
+                Some($cvt)
+            } else {
+                None
+            }
+        }
+
+        /// Returns the variant's value, panicking if it is not the correct type.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `self` is not of the right type.
+        #[inline]
+        pub fn $unwrap(&self) -> $ty {
+            self.$get().expect(concat!("expected ", stringify!($ty)))
+        }
+    };
+    ($bind:ident $(($variant:ident($ty:ty) $is:ident $get:ident $unwrap:ident $cvt:expr))*) => ($(enum_accessors!{@$bind, $variant, $ty, $is, $get, $unwrap, $cvt})*)
+}
+
+/// Like `enum_accessors!`, but generated methods take ownership of `self`.
+macro_rules! owned_enum_accessors {
+    ($bind:ident $(($variant:ident($ty:ty) $get:ident $cvt:expr))*) => ($(
+        /// Attempt to access the underlying value of this `Val`, returning
+        /// `None` if it is not the correct type.
+        #[inline]
+        pub fn $get(self) -> Option<$ty> {
+            if let Self::$variant($bind) = self {
+                Some($cvt)
+            } else {
+                None
+            }
+        }
+    )*)
+}
+
+/// Like `offset_of!`, but returns a `u32`.
+///
+/// # Panics
+///
+/// Panics if the offset is too large to fit in a `u32`.
+macro_rules! u32_offset_of {
+    ($ty:ident, $field:ident) => {
+        u32::try_from(core::mem::offset_of!($ty, $field)).unwrap()
+    };
+}
+
+use core::any::type_name;
+use core::cmp;
+pub(crate) use {enum_accessors, owned_enum_accessors, u32_offset_of};
+
+/// Like `mem::size_of` but returns `u8` instead of `usize`
+/// # Panics
+///
+/// Panics if the size of `T` is greater than `u8::MAX`.
+pub fn u8_size_of<T: Sized>() -> u8 {
+    u8::try_from(size_of::<T>()).expect("type size is too large to be represented as a u8")
+}
+
+pub trait IteratorExt {
+    fn zip_eq<U>(self, other: U) -> ZipEq<Self, <U as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator;
+}
+
+impl<I> IteratorExt for I
+where
+    I: Iterator,
+{
+    fn zip_eq<U>(self, other: U) -> ZipEq<Self, <U as IntoIterator>::IntoIter>
+    where
+        Self: Sized,
+        U: IntoIterator,
+    {
+        ZipEq {
+            a: self,
+            b: other.into_iter(),
+        }
+    }
+}
+
+/// like Iterator::zip but panics if one iterator ends before
+/// the other. The `param_predicate` is required to select exactly as many
+/// elements of `params` as there are elements in `arguments`.
+pub struct ZipEq<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<A, B> Iterator for ZipEq<A, B>
+where
+    A: Iterator,
+    B: Iterator,
+{
+    type Item = (A::Item, B::Item);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.a.next(), self.b.next()) {
+            (Some(a), Some(b)) => Some((a, b)),
+            (None, None) => None,
+            (None, _) => panic!(
+                "iterators had different lengths. {} was shorter than {}",
+                type_name::<A>(),
+                type_name::<B>()
+            ),
+            (_, None) => panic!(
+                "iterators had different lengths. {} was shorter than {}",
+                type_name::<B>(),
+                type_name::<A>()
+            ),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a_min, a_max) = self.a.size_hint();
+        let (b_min, b_max) = self.a.size_hint();
+        (
+            cmp::min(a_min, b_min),
+            a_max
+                .and_then(|a| Some((a, b_max?)))
+                .map(|(a, b)| cmp::min(a, b)),
+        )
+    }
+}
+
+impl<A, B> ExactSizeIterator for ZipEq<A, B>
+where
+    A: ExactSizeIterator,
+    B: ExactSizeIterator,
+{
+    fn len(&self) -> usize {
+        debug_assert_eq!(self.a.len(), self.b.len());
+        self.a.len()
+    }
+}

--- a/libs/kwasm/src/wasm.rs
+++ b/libs/kwasm/src/wasm.rs
@@ -1,0 +1,454 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+mod const_expr;
+mod module_parser;
+mod module_types;
+mod type_convert;
+mod types;
+
+use crate::indices::{
+    CanonicalizedTypeIndex, DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex,
+    DefinedTableIndex, DefinedTagIndex, ElemIndex, EntityIndex, FieldIndex, FuncIndex,
+    FuncRefIndex, GlobalIndex, LabelIndex, LocalIndex, MemoryIndex, ModuleInternedTypeIndex
+    , TableIndex, TagIndex, TypeIndex,
+};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use cranelift_entity::packed_option::ReservedValue;
+use cranelift_entity::{EntitySet, PrimaryMap};
+use hashbrown::HashMap;
+use wasmparser::collections::IndexMap;
+
+pub use const_expr::{ConstExpr, ConstOp};
+pub use module_parser::ModuleParser;
+pub use module_types::ModuleTypes;
+pub use types::{
+    WasmArrayType, WasmCompositeType, WasmCompositeTypeInner, WasmEntityType, WasmFieldType,
+    WasmFuncType, WasmGlobalType, WasmHeapType, WasmHeapTypeInner, WasmIndexType, WasmMemoryType,
+    WasmRecGroup, WasmRefType, WasmStorageType, WasmStructType, WasmSubType, WasmTableType,
+    WasmTagType, WasmValType,
+};
+pub use wasmparser::WasmFeatures;
+
+#[derive(Default)]
+pub struct ModuleTranslation<'wasm> {
+    /// The translated module.
+    pub module: TranslatedModule,
+    /// Information about the module's functions.
+    pub function_bodies: PrimaryMap<DefinedFuncIndex, FunctionBodyData<'wasm>>,
+    /// DWARF and other debug information parsed from the module.
+    pub debug_info: DebugInfo<'wasm>,
+    /// Required WASM features (proposals etc.) as self-reported by the module through the `wasm-features` custom section.
+    /// Later on this could be used to determine which compiler/runtime features to enable, but
+    /// for now we just use it to assert compatibility.
+    pub required_features: WasmFeatures,
+}
+
+/// A translated WebAssembly module.
+#[derive(Debug, Default)]
+pub struct TranslatedModule {
+    /// The name of this wasm module, if found,
+    pub name: Option<String>,
+    /// The types declared in this module.
+    pub types: PrimaryMap<TypeIndex, ModuleInternedTypeIndex>,
+
+    /// The functions declared in this module. Note that this only contains the
+    /// function's signature index, not the actual function body. For that, see `Translation.function_bodies`.
+    pub functions: PrimaryMap<FuncIndex, Function>,
+    /// The tables declared in this module.
+    pub tables: PrimaryMap<TableIndex, WasmTableType>,
+    /// The memories declared in this module.
+    pub memories: PrimaryMap<MemoryIndex, WasmMemoryType>,
+    /// The globals declared in this module.
+    pub globals: PrimaryMap<GlobalIndex, WasmGlobalType>,
+    /// The tags declared in this module.
+    pub tags: PrimaryMap<TagIndex, WasmTagType>,
+
+    /// The index of the start function if defined.
+    /// This function will be called during module initialization.
+    pub start: Option<FuncIndex>,
+    /// Imports declared in this module.
+    pub imports: Vec<Import>,
+    /// Exports declared in this module.
+    pub exports: IndexMap<String, EntityIndex>,
+
+    /// Initialization expressions for globals defined in this module.
+    pub global_initializers: PrimaryMap<DefinedGlobalIndex, ConstExpr>,
+    /// Initializers for tables defined or imported in this module.
+    pub table_initializers: TableInitializers,
+    /// Initializers for memories defined or imported in this module.
+    pub memory_initializers: Vec<MemoryInitializer>,
+
+    /// Passive table initializers that can be access by `table.init` instructions.
+    pub passive_table_initializers: HashMap<ElemIndex, TableSegmentElements>,
+    /// Passive memory initializers that can be access by `memory.init` instructions.
+    pub passive_memory_initializers: HashMap<DataIndex, Vec<u8>>,
+    /// `ElemIndex`es of active table initializers that should be treated as "dropped" at runtime.
+    pub active_table_initializers: EntitySet<ElemIndex>,
+    /// `DataIndex`es of active memory initializers that should be treated as "dropped" at runtime.
+    pub active_memory_initializers: EntitySet<DataIndex>,
+    /// The number of imported functions. The first `num_imported_functions` functions in the `functions`
+    /// table are imported functions.
+    pub num_imported_functions: u32,
+    /// The number of imported tables. The first `num_imported_tables` tables in the `tables` table are imported tables.
+    pub num_imported_tables: u32,
+    /// The number of imported memories. The first `num_imported_memories` memories in the `memories` table are imported memories.
+    pub num_imported_memories: u32,
+    /// The number of imported globals. The first `num_imported_globals` globals in the `globals` table are imported globals.
+    pub num_imported_globals: u32,
+    /// The number of imported tags. The first `num_imported_tags` globals in the `tags` table are imported tags.
+    pub num_imported_tags: u32,
+    /// The number of imported functions. This is used to compile host->wasm trampolines later.
+    pub num_escaped_functions: u32,
+}
+
+#[derive(Debug)]
+pub struct Function {
+    /// The index of the function signature in the type section.
+    pub signature: CanonicalizedTypeIndex,
+    pub func_ref: FuncRefIndex,
+}
+
+pub struct FunctionBodyData<'wasm> {
+    pub body: wasmparser::FunctionBody<'wasm>,
+    pub validator: wasmparser::FuncToValidate<wasmparser::ValidatorResources>,
+}
+
+#[derive(Debug, Default)]
+pub struct TableInitializers {
+    /// The initial values for table elements.
+    pub initial_values: PrimaryMap<DefinedTableIndex, TableInitialValue>,
+    pub segments: Vec<TableSegment>,
+}
+
+/// The initial value of a table.
+#[derive(Debug)]
+pub enum TableInitialValue {
+    /// The table is initialized with null references.
+    RefNull,
+    /// The table is initialized with the result of a const expression.
+    ConstExpr(ConstExpr),
+}
+
+#[derive(Debug)]
+pub struct TableSegment {
+    /// The index of the table being initialized.
+    pub table_index: TableIndex,
+    /// The offset at which to start filling.
+    pub offset: ConstExpr,
+    /// The elements to a slice of the table with.
+    pub elements: TableSegmentElements,
+}
+
+#[derive(Debug, Clone)]
+pub enum TableSegmentElements {
+    /// The elements are a list of function indices.
+    Functions(Box<[FuncIndex]>),
+    /// The elements are produced by a list of constant expressions.
+    Expressions(Box<[ConstExpr]>),
+}
+
+#[derive(Debug)]
+pub struct MemoryInitializer {
+    /// The index of the memory being initialized.
+    pub memory_index: MemoryIndex,
+    /// The offset at which to start filling.
+    pub offset: ConstExpr,
+    /// The data to fill the memory with.
+    /// This is an index into the `Translation.data` array.
+    pub data: Vec<u8>,
+}
+
+/// A WebAssembly import.
+#[derive(Debug)]
+pub struct Import {
+    /// The module or namespace being imported.
+    pub module: String,
+    /// The name of the item being imported.
+    pub name: String,
+    /// Where the imported entity will be placed, this also holds the type of the import.
+    pub ty: WasmEntityType,
+}
+
+#[derive(Debug, Default)]
+pub struct DebugInfo<'wasm> {
+    /// The names of various entities in the module.
+    pub names: Names<'wasm>,
+    /// Information about tools involved in the creation of the WASM module.
+    pub producers: Producers<'wasm>,
+    /// The offset of the code section in the original wasm file, used to calculate lookup values into the DWARF.
+    pub code_section_offset: u64,
+    pub dwarf: gimli::Dwarf<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+    pub debug_loc: gimli::DebugLoc<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+    pub debug_loclists: gimli::DebugLocLists<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+    pub debug_ranges: gimli::DebugRanges<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+    pub debug_rnglists: gimli::DebugRngLists<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+    pub debug_cu_index: gimli::DebugCuIndex<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+    pub debug_tu_index: gimli::DebugTuIndex<gimli::EndianSlice<'wasm, gimli::LittleEndian>>,
+}
+
+#[derive(Debug, Default)]
+pub struct Names<'wasm> {
+    pub funcs: HashMap<FuncIndex, &'wasm str>,
+    pub locals: HashMap<FuncIndex, HashMap<LocalIndex, &'wasm str>>,
+    pub globals: HashMap<GlobalIndex, &'wasm str>,
+    pub data: HashMap<DataIndex, &'wasm str>,
+    pub labels: HashMap<FuncIndex, HashMap<LabelIndex, &'wasm str>>,
+    pub types: HashMap<TypeIndex, &'wasm str>,
+    pub tables: HashMap<TableIndex, &'wasm str>,
+    pub memories: HashMap<MemoryIndex, &'wasm str>,
+    pub elements: HashMap<ElemIndex, &'wasm str>,
+    pub fields: HashMap<FuncIndex, HashMap<FieldIndex, &'wasm str>>,
+    pub tags: HashMap<TagIndex, &'wasm str>,
+}
+
+#[derive(Debug, Default)]
+pub struct Producers<'wasm> {
+    pub language: Vec<ProducersLanguageField<'wasm>>,
+    pub processed_by: Vec<ProducersToolField<'wasm>>,
+    pub sdk: Vec<ProducersSdkField<'wasm>>,
+}
+
+#[derive(Debug)]
+pub struct ProducersLanguageField<'wasm> {
+    pub name: ProducersLanguage<'wasm>,
+    pub version: &'wasm str,
+}
+
+#[derive(Debug)]
+pub enum ProducersLanguage<'wasm> {
+    Wat,
+    C,
+    Cpp,
+    Rust,
+    JavaScript,
+    Other(&'wasm str),
+}
+
+#[derive(Debug)]
+pub struct ProducersToolField<'wasm> {
+    pub name: ProducersTool<'wasm>,
+    pub version: &'wasm str,
+}
+
+#[derive(Debug)]
+pub enum ProducersTool<'wasm> {
+    Wabt,
+    Llvm,
+    Clang,
+    Lld,
+    Binaryen,
+    Rustc,
+    WasmBindgen,
+    WasmPack,
+    Webassemblyjs,
+    WasmSnip,
+    Javy,
+    Other(&'wasm str),
+}
+
+#[derive(Debug)]
+pub struct ProducersSdkField<'wasm> {
+    pub name: ProducersSdk<'wasm>,
+    pub version: &'wasm str,
+}
+
+#[derive(Debug)]
+pub enum ProducersSdk<'wasm> {
+    Emscripten,
+    Webpack,
+    Other(&'wasm str),
+}
+
+// === impl Module ===
+
+impl TranslatedModule {
+    #[inline]
+    pub fn func_index(&self, index: DefinedFuncIndex) -> FuncIndex {
+        FuncIndex::from_u32(self.num_imported_functions + index.as_u32())
+    }
+
+    #[inline]
+    pub fn defined_func_index(&self, index: FuncIndex) -> Option<DefinedFuncIndex> {
+        if self.is_imported_func(index) {
+            None
+        } else {
+            Some(DefinedFuncIndex::from_u32(
+                index.as_u32() - self.num_imported_functions,
+            ))
+        }
+    }
+
+    #[inline]
+    pub fn is_imported_func(&self, index: FuncIndex) -> bool {
+        index.as_u32() < self.num_imported_functions
+    }
+
+    #[inline]
+    pub fn table_index(&self, index: DefinedTableIndex) -> TableIndex {
+        TableIndex::from_u32(self.num_imported_tables + index.as_u32())
+    }
+
+    #[inline]
+    pub fn defined_table_index(&self, index: TableIndex) -> Option<DefinedTableIndex> {
+        if self.is_imported_table(index) {
+            None
+        } else {
+            Some(DefinedTableIndex::from_u32(
+                index.as_u32() - self.num_imported_tables,
+            ))
+        }
+    }
+
+    #[inline]
+    pub fn is_imported_table(&self, index: TableIndex) -> bool {
+        index.as_u32() < self.num_imported_tables
+    }
+
+    #[inline]
+    pub fn defined_memory_index(&self, index: MemoryIndex) -> Option<DefinedMemoryIndex> {
+        if self.is_imported_memory(index) {
+            None
+        } else {
+            Some(DefinedMemoryIndex::from_u32(
+                index.as_u32() - self.num_imported_memories,
+            ))
+        }
+    }
+
+    // #[inline]
+    // pub fn owned_memory_index(&self, memory: DefinedMemoryIndex) -> OwnedMemoryIndex {
+    //     assert!(
+    //         memory.index() < self.memories.len(),
+    //         "non-shared memory must have an owned index"
+    //     );
+    //
+    //     // Once we know that the memory index is not greater than the number of
+    //     // plans, we can iterate through the plans up to the memory index and
+    //     // count how many are not shared (i.e., owned).
+    //     let owned_memory_index = self
+    //         .memories
+    //         .iter()
+    //         .skip(self.num_imported_memories as usize)
+    //         .take(memory.index())
+    //         .filter(|(_, mp)| !mp.shared)
+    //         .count();
+    //     OwnedMemoryIndex::new(owned_memory_index)
+    // }
+
+    #[inline]
+    pub fn is_imported_memory(&self, index: MemoryIndex) -> bool {
+        index.as_u32() < self.num_imported_memories
+    }
+
+    #[inline]
+    pub fn global_index(&self, index: DefinedGlobalIndex) -> GlobalIndex {
+        GlobalIndex::from_u32(self.num_imported_globals + index.as_u32())
+    }
+
+    #[inline]
+    pub fn defined_global_index(&self, index: GlobalIndex) -> Option<DefinedGlobalIndex> {
+        if self.is_imported_global(index) {
+            None
+        } else {
+            Some(DefinedGlobalIndex::from_u32(
+                index.as_u32() - self.num_imported_globals,
+            ))
+        }
+    }
+
+    #[inline]
+    pub fn is_imported_global(&self, index: GlobalIndex) -> bool {
+        index.as_u32() < self.num_imported_globals
+    }
+
+    #[inline]
+    pub fn tag_index(&self, index: DefinedTagIndex) -> TagIndex {
+        TagIndex::from_u32(self.num_imported_tags + index.as_u32())
+    }
+
+    #[inline]
+    pub fn defined_tag_index(&self, index: TagIndex) -> Option<DefinedTagIndex> {
+        if self.is_imported_tag(index) {
+            None
+        } else {
+            Some(DefinedTagIndex::from_u32(
+                index.as_u32() - self.num_imported_tags,
+            ))
+        }
+    }
+
+    #[inline]
+    pub fn is_imported_tag(&self, index: TagIndex) -> bool {
+        index.as_u32() < self.num_imported_tags
+    }
+
+    pub fn num_imported_functions(&self) -> u32 {
+        self.num_imported_functions
+    }
+    pub fn num_imported_tables(&self) -> u32 {
+        self.num_imported_tables
+    }
+    pub fn num_imported_memories(&self) -> u32 {
+        self.num_imported_memories
+    }
+    pub fn num_imported_globals(&self) -> u32 {
+        self.num_imported_globals
+    }
+    pub fn num_defined_tables(&self) -> u32 {
+        self.num_tables() - self.num_imported_tables
+    }
+    pub fn num_defined_memories(&self) -> u32 {
+        self.num_memories() - self.num_imported_memories
+    }
+    pub fn num_defined_globals(&self) -> u32 {
+        self.num_globals() - self.num_imported_globals
+    }
+    pub fn num_defined_tags(&self) -> u32 {
+        self.num_tags() - self.num_imported_tags
+    }
+    pub fn num_functions(&self) -> u32 {
+        u32::try_from(self.functions.len()).unwrap()
+    }
+    pub fn num_tables(&self) -> u32 {
+        u32::try_from(self.tables.len()).unwrap()
+    }
+    pub fn num_memories(&self) -> u32 {
+        u32::try_from(self.memories.len()).unwrap()
+    }
+    pub fn num_globals(&self) -> u32 {
+        u32::try_from(self.globals.len()).unwrap()
+    }
+    pub fn num_tags(&self) -> u32 {
+        u32::try_from(self.tags.len()).unwrap()
+    }
+
+    pub fn num_escaped_funcs(&self) -> u32 {
+        self.num_escaped_functions
+    }
+}
+
+// === impl Function ===
+
+impl Function {
+    pub fn is_escaping(&self) -> bool {
+        !self.func_ref.is_reserved_value()
+    }
+}
+
+// === impl TableSegmentElements ===
+
+impl TableSegmentElements {
+    pub fn len(&self) -> usize {
+        match self {
+            TableSegmentElements::Functions(f) => f.len(),
+            TableSegmentElements::Expressions(e) => e.len(),
+        }
+    }
+}

--- a/libs/kwasm/src/wasm/const_expr.rs
+++ b/libs/kwasm/src/wasm/const_expr.rs
@@ -1,0 +1,145 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::indices::{FuncIndex, GlobalIndex, TypeIndex};
+use anyhow::bail;
+use smallvec::SmallVec;
+
+/// A constant expression.
+///
+/// These are used to initialize globals, table elements, etc...
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ConstExpr {
+    ops: SmallVec<[ConstOp; 2]>,
+}
+
+/// The subset of Wasm opcodes that are constant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum ConstOp {
+    I32Const(i32),
+    I64Const(i64),
+    F32Const(u32),
+    F64Const(u64),
+    V128Const(u128),
+    GlobalGet(GlobalIndex),
+    RefI31,
+    RefNull,
+    RefFunc(FuncIndex),
+    I32Add,
+    I32Sub,
+    I32Mul,
+    I64Add,
+    I64Sub,
+    I64Mul,
+    StructNew {
+        struct_type_index: TypeIndex,
+    },
+    StructNewDefault {
+        struct_type_index: TypeIndex,
+    },
+    ArrayNew {
+        array_type_index: TypeIndex,
+    },
+    ArrayNewDefault {
+        array_type_index: TypeIndex,
+    },
+    ArrayNewFixed {
+        array_type_index: TypeIndex,
+        array_size: u32,
+    },
+}
+
+// === impl ConstExpr ===
+
+impl ConstExpr {
+    /// Create a new const expression from a `wasmparser` const expression.
+    ///
+    /// Returns the new const expression as well as the escaping function
+    /// indices that appeared in `ref.func` instructions, if any.
+    pub fn from_wasmparser(
+        expr: &wasmparser::ConstExpr<'_>,
+    ) -> crate::Result<(Self, SmallVec<[FuncIndex; 1]>)> {
+        let mut iter = expr
+            .get_operators_reader()
+            .into_iter_with_offsets()
+            .peekable();
+
+        let mut ops = SmallVec::<[ConstOp; 2]>::new();
+        let mut escaped = SmallVec::<[FuncIndex; 1]>::new();
+        while let Some(res) = iter.next() {
+            let (op, offset) = res?;
+
+            // If we reach an `end` instruction, and there are no more
+            // instructions after that, then we are done reading this const
+            // expression.
+            if matches!(op, wasmparser::Operator::End) && iter.peek().is_none() {
+                break;
+            }
+
+            // Track any functions that appear in `ref.func` so that callers can
+            // make sure to flag them as escaping.
+            if let wasmparser::Operator::RefFunc { function_index } = &op {
+                escaped.push(FuncIndex::from_u32(*function_index));
+            }
+
+            ops.push(ConstOp::from_wasmparser(op, offset)?);
+        }
+        Ok((Self { ops }, escaped))
+    }
+
+    pub fn ops(&self) -> impl ExactSizeIterator<Item = ConstOp> + use<'_> {
+        self.ops.iter().copied()
+    }
+}
+
+// === impl ConstOp ===
+
+impl ConstOp {
+    /// Convert a `wasmparser::Operator` to a `ConstOp`.
+    pub fn from_wasmparser(op: wasmparser::Operator<'_>, offset: usize) -> crate::Result<Self> {
+        use wasmparser::Operator as O;
+        Ok(match op {
+            O::I32Const { value } => Self::I32Const(value),
+            O::I64Const { value } => Self::I64Const(value),
+            O::F32Const { value } => Self::F32Const(value.bits()),
+            O::F64Const { value } => Self::F64Const(value.bits()),
+            O::V128Const { value } => Self::V128Const(u128::from_le_bytes(*value.bytes())),
+            O::RefNull { hty: _ } => Self::RefNull,
+            O::RefFunc { function_index } => Self::RefFunc(FuncIndex::from_u32(function_index)),
+            O::GlobalGet { global_index } => Self::GlobalGet(GlobalIndex::from_u32(global_index)),
+            O::RefI31 => Self::RefI31,
+            O::I32Add => Self::I32Add,
+            O::I32Sub => Self::I32Sub,
+            O::I32Mul => Self::I32Mul,
+            O::I64Add => Self::I64Add,
+            O::I64Sub => Self::I64Sub,
+            O::I64Mul => Self::I64Mul,
+            O::StructNew { struct_type_index } => Self::StructNew {
+                struct_type_index: TypeIndex::from_u32(struct_type_index),
+            },
+            O::StructNewDefault { struct_type_index } => Self::StructNewDefault {
+                struct_type_index: TypeIndex::from_u32(struct_type_index),
+            },
+            O::ArrayNew { array_type_index } => Self::ArrayNew {
+                array_type_index: TypeIndex::from_u32(array_type_index),
+            },
+            O::ArrayNewDefault { array_type_index } => Self::ArrayNewDefault {
+                array_type_index: TypeIndex::from_u32(array_type_index),
+            },
+            O::ArrayNewFixed {
+                array_type_index,
+                array_size,
+            } => Self::ArrayNewFixed {
+                array_type_index: TypeIndex::from_u32(array_type_index),
+                array_size,
+            },
+            op => {
+                bail!("unsupported opcode in const expression at offset {offset:#x}: {op:?}");
+            }
+        })
+    }
+}

--- a/libs/kwasm/src/wasm/module_parser.rs
+++ b/libs/kwasm/src/wasm/module_parser.rs
@@ -1,0 +1,973 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::indices::{
+    CanonicalizedTypeIndex, DataIndex, ElemIndex, EntityIndex, FieldIndex, FuncIndex, FuncRefIndex,
+    GlobalIndex, LabelIndex, LocalIndex, MemoryIndex, TableIndex, TagIndex, TypeIndex,
+};
+use crate::loom::sync::Arc;
+use crate::wasm::module_types::ModuleTypesBuilder;
+use crate::wasm::type_convert::WasmparserTypeConverter;
+use crate::wasm::{
+    ConstExpr, WasmEntityType, Function, FunctionBodyData, WasmGlobalType, Import, WasmMemoryType, MemoryInitializer,
+    ModuleTranslation, ModuleTypes, ProducersLanguage, ProducersLanguageField, ProducersSdk,
+    ProducersSdkField, ProducersTool, ProducersToolField, WasmTableType, TableInitialValue, TableSegment,
+    TableSegmentElements, WasmTagType,
+};
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use cranelift_entity::packed_option::ReservedValue;
+use hashbrown::HashMap;
+use wasmparser::{
+    BinaryReader, CustomSectionReader, DataKind, DataSectionReader, ElementItems, ElementKind,
+    ElementSectionReader, ExportSectionReader, ExternalKind, FunctionSectionReader,
+    GlobalSectionReader, ImportSectionReader, IndirectNameMap, MemorySectionReader, Name, NameMap,
+    NameSectionReader, Parser, Payload, ProducersFieldValue, ProducersSectionReader, TableInit,
+    TableSectionReader, TagKind, TagSectionReader, TypeRef, TypeSectionReader, Validator,
+    WasmFeatures,
+};
+
+/// A translator for converting the output of `wasmparser` into types used by this crate.
+pub struct ModuleParser<'a, 'data> {
+    result: ModuleTranslation<'data>,
+    validator: &'a mut Validator,
+    types: ModuleTypesBuilder,
+}
+
+impl<'a, 'data> ModuleParser<'a, 'data> {
+    /// Creates a new `ModuleTranslator` with the given `Validator`.
+    pub fn new(validator: &'a mut Validator) -> Self {
+        Self {
+            types: ModuleTypesBuilder::new(validator),
+            validator,
+            result: ModuleTranslation::default(),
+        }
+    }
+
+    /// Translate raw WASM bytes into a `ModuleTranslation`.
+    ///
+    /// Returns the translation along with it's interned types.
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    pub fn translate(
+        mut self,
+        data: &'data [u8],
+    ) -> crate::Result<(ModuleTranslation<'data>, ModuleTypes)> {
+        let mut parser = Parser::default();
+        parser.set_features(*self.validator.features());
+
+        for payload in parser.parse_all(data) {
+            self.translate_payload(payload?)?;
+        }
+
+        self.validator.reset();
+
+        debug_assert!(self.result.module.num_tables() >= self.result.module.num_imported_tables);
+        debug_assert!(
+            self.result.module.num_memories() >= self.result.module.num_imported_memories
+        );
+        debug_assert!(self.result.module.num_globals() >= self.result.module.num_imported_globals);
+
+        Ok((self.result, self.types.finish()))
+    }
+
+    /// Translates a single payload (essentially a section) of a WASM module.
+    fn translate_payload(&mut self, payload: Payload<'data>) -> crate::Result<()> {
+        match payload {
+            Payload::Version {
+                num,
+                encoding,
+                range,
+            } => {
+                self.validator.version(num, encoding, &range)?;
+            }
+            Payload::TypeSection(types) => {
+                self.validator.type_section(&types)?;
+                self.translate_type_section(types);
+            }
+            Payload::ImportSection(imports) => {
+                self.validator.import_section(&imports)?;
+                self.translate_import_section(imports)?;
+            }
+            Payload::FunctionSection(functions) => {
+                self.validator.function_section(&functions)?;
+                self.translate_function_section(functions)?;
+            }
+            Payload::TableSection(tables) => {
+                self.validator.table_section(&tables)?;
+                self.translate_table_section(tables)?;
+            }
+            Payload::MemorySection(memories) => {
+                self.validator.memory_section(&memories)?;
+                self.translate_memory_section(memories)?;
+            }
+            Payload::TagSection(tags) => {
+                self.validator.tag_section(&tags)?;
+                self.parse_tag_section(tags)?;
+            }
+            Payload::GlobalSection(globals) => {
+                self.validator.global_section(&globals)?;
+                self.translate_global_section(globals)?;
+            }
+            Payload::ExportSection(exports) => {
+                self.validator.export_section(&exports)?;
+                self.translate_export_section(exports)?;
+            }
+            Payload::StartSection { func, range } => {
+                self.validator.start_section(func, &range)?;
+                self.result.module.start = Some(FuncIndex::from_u32(func));
+            }
+            Payload::ElementSection(elements) => {
+                self.validator.element_section(&elements)?;
+                self.translate_element_section(elements)?;
+            }
+            Payload::DataCountSection { count, range } => {
+                self.validator.data_count_section(count, &range)?;
+            }
+            Payload::DataSection(data) => {
+                self.validator.data_section(&data)?;
+                self.translate_data_section(data)?;
+            }
+            Payload::CodeSectionStart { count, range, .. } => {
+                self.validator.code_section_start(&range)?;
+                self.result.function_bodies.reserve_exact(count as usize);
+                self.result.debug_info.code_section_offset = range.start as u64;
+            }
+            Payload::CodeSectionEntry(body) => {
+                let validator = self.validator.code_section_entry(&body)?;
+                self.result
+                    .function_bodies
+                    .push(FunctionBodyData { body, validator });
+            }
+            Payload::CustomSection(section) => match section.name() {
+                "target_features" => self.parse_target_feature_section(&section),
+                "name" => {
+                    self.translate_name_section(NameSectionReader::new(BinaryReader::new(
+                        section.data(),
+                        section.data_offset(),
+                    )))?;
+                }
+                "producers" => {
+                    self.translate_producers_section(ProducersSectionReader::new(
+                        BinaryReader::new_features(
+                            section.data(),
+                            section.data_offset(),
+                            *self.validator.features(),
+                        ),
+                    )?)?;
+                }
+                name => {
+                    tracing::trace!("custom section {name}");
+                    if name.trim_end_matches(".dwo").starts_with(".debug_") {
+                        self.translate_dwarf_section(name, &section);
+                    } else {
+                        tracing::warn!("unhandled custom section {section:?}");
+                    }
+                }
+            },
+            Payload::End(offset) => {
+                self.validator.end(offset)?;
+            }
+
+            // Payload::ModuleSection { .. }
+            // | Payload::InstanceSection(_)
+            // | Payload::CoreTypeSection(_)
+            // | Payload::ComponentSection { .. }
+            // | Payload::ComponentInstanceSection(_)
+            // | Payload::ComponentAliasSection(_)
+            // | Payload::ComponentTypeSection(_)
+            // | Payload::ComponentCanonicalSection(_)
+            // | Payload::ComponentStartSection { .. }
+            // | Payload::ComponentImportSection(_)
+            // | Payload::ComponentExportSection(_) => {
+            //     return Err(wasm_unsupported!("component model is unsupported"));
+            // }
+            p => tracing::warn!("unknown section {p:?}"),
+        }
+        Ok(())
+    }
+
+    fn flag_func_as_escaped(&mut self, func_index: FuncIndex) {
+        let ty = &mut self.result.module.functions[func_index];
+        if ty.is_escaping() {
+            return;
+        }
+        let index = self.result.module.num_escaped_functions;
+        ty.func_ref = FuncRefIndex::from_u32(index);
+        self.result.module.num_escaped_functions += 1;
+    }
+
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "translate_ methods consume their readers"
+    )]
+    fn translate_type_section(&mut self, types: TypeSectionReader) {
+        let count = types.count();
+        self.result
+            .module
+            .types
+            .reserve(usize::try_from(count).unwrap());
+
+        let mut type_index = 0;
+        for _ in 0..count {
+            let validator_types = self.validator.types(0).unwrap();
+
+            let core_type_id = validator_types.core_type_at_in_module(type_index);
+            tracing::trace!(
+                "about to intern rec group for {core_type_id:?} = {:?}",
+                validator_types[core_type_id]
+            );
+            let rec_group_id = validator_types.rec_group_id_of(core_type_id);
+            debug_assert_eq!(
+                validator_types
+                    .rec_group_elements(rec_group_id)
+                    .position(|id| id == core_type_id),
+                Some(0)
+            );
+
+            let interned =
+                self.types
+                    .intern_rec_group(&self.result.module, validator_types, rec_group_id);
+
+            let elems = self.types.types.rec_group_elements(interned);
+            let len = elems.len();
+            self.result.module.types.reserve(len);
+            for ty in elems {
+                self.result.module.types.push(ty);
+            }
+
+            // Advance `type_index` to the start of the next rec group.
+            type_index += u32::try_from(len).unwrap();
+        }
+    }
+
+    fn translate_import_section(
+        &mut self,
+        imports: ImportSectionReader<'data>,
+    ) -> crate::Result<()> {
+        self.result
+            .module
+            .imports
+            .reserve_exact(imports.count() as usize);
+
+        for import in imports {
+            let import = import?;
+
+            let index = match import.ty {
+                TypeRef::Func(index) => {
+                    self.result.module.num_imported_functions += 1;
+
+                    let signature = TypeIndex::from_u32(index);
+                    let interned_index = self.result.module.types[signature];
+                    self.result.module.functions.push(Function {
+                        signature: CanonicalizedTypeIndex::Module(interned_index),
+                        func_ref: FuncRefIndex::reserved_value(),
+                    });
+                    WasmEntityType::Function(CanonicalizedTypeIndex::Module(interned_index))
+                }
+                TypeRef::Table(ty) => {
+                    self.result.module.num_imported_tables += 1;
+
+                    let ty_convert =
+                        WasmparserTypeConverter::new(&self.types.types, &self.result.module);
+
+                    let table = WasmTableType::from_wasmparser(ty, &ty_convert);
+                    self.result.module.tables.push(table.clone());
+                    WasmEntityType::Table(table)
+                }
+                TypeRef::Memory(ty) => {
+                    self.result.module.num_imported_memories += 1;
+
+                    let memory = WasmMemoryType::from_wasmparser(ty);
+                    self.result.module.memories.push(memory.clone());
+                    WasmEntityType::Memory(memory)
+                }
+                TypeRef::Global(ty) => {
+                    self.result.module.num_imported_globals += 1;
+
+                    let ty_convert =
+                        WasmparserTypeConverter::new(&self.types.types, &self.result.module);
+
+                    let global = WasmGlobalType {
+                        content_type: ty_convert.convert_val_type(ty.content_type),
+                        mutable: ty.mutable,
+                        shared: ty.shared,
+                    };
+                    self.result.module.globals.push(global.clone());
+                    WasmEntityType::Global(global)
+                }
+                TypeRef::Tag(ty) => {
+                    self.result.module.num_imported_tags += 1;
+
+                    let signature = TypeIndex::from_u32(ty.func_type_idx);
+                    let interned_index = self.result.module.types[signature];
+                    WasmEntityType::Tag(CanonicalizedTypeIndex::Module(interned_index))
+                }
+            };
+
+            self.result.module.imports.push(Import {
+                module: import.module.to_string(),
+                name: import.name.to_string(),
+                ty: index,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn translate_function_section(
+        &mut self,
+        functions: FunctionSectionReader<'data>,
+    ) -> crate::Result<()> {
+        self.result
+            .module
+            .functions
+            .reserve_exact(functions.count() as usize);
+
+        for index in functions {
+            let signature = TypeIndex::from_u32(index?);
+            let signature = self.result.module.types[signature];
+            self.result.module.functions.push(Function {
+                signature: CanonicalizedTypeIndex::Module(signature),
+                func_ref: FuncRefIndex::reserved_value(),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn translate_table_section(&mut self, tables: TableSectionReader<'data>) -> crate::Result<()> {
+        self.result
+            .module
+            .tables
+            .reserve_exact(tables.count() as usize);
+        self.result
+            .module
+            .table_initializers
+            .initial_values
+            .reserve_exact(tables.count() as usize);
+
+        for table in tables {
+            let table = table?;
+
+            let ty_convert = WasmparserTypeConverter::new(&self.types.types, &self.result.module);
+
+            let plan = WasmTableType::from_wasmparser(table.ty, &ty_convert);
+            self.result.module.tables.push(plan);
+
+            let init = match table.init {
+                TableInit::RefNull => TableInitialValue::RefNull,
+                TableInit::Expr(expr) => {
+                    let (expr, escaped) = ConstExpr::from_wasmparser(&expr)?;
+                    for func in escaped {
+                        self.flag_func_as_escaped(func);
+                    }
+                    TableInitialValue::ConstExpr(expr)
+                }
+            };
+            self.result
+                .module
+                .table_initializers
+                .initial_values
+                .push(init);
+        }
+
+        Ok(())
+    }
+
+    fn translate_memory_section(
+        &mut self,
+        memories: MemorySectionReader<'data>,
+    ) -> crate::Result<()> {
+        self.result
+            .module
+            .memories
+            .reserve_exact(memories.count() as usize);
+
+        for ty in memories {
+            self.result
+                .module
+                .memories
+                .push(WasmMemoryType::from_wasmparser(ty?));
+        }
+
+        Ok(())
+    }
+
+    fn parse_tag_section(&mut self, tags: TagSectionReader<'data>) -> crate::Result<()> {
+        self.result.module.tags.reserve_exact(tags.count() as usize);
+
+        for tag in tags {
+            let tag = tag?;
+            assert_eq!(tag.kind, TagKind::Exception);
+
+            let signature = TypeIndex::from_u32(tag.func_type_idx);
+            let signature = self.result.module.types[signature];
+
+            self.result.module.tags.push(WasmTagType {
+                signature: CanonicalizedTypeIndex::Module(signature),
+            });
+        }
+
+        Ok(())
+    }
+
+    fn translate_global_section(
+        &mut self,
+        globals: GlobalSectionReader<'data>,
+    ) -> crate::Result<()> {
+        self.result
+            .module
+            .globals
+            .reserve_exact(globals.count() as usize);
+        self.result
+            .module
+            .global_initializers
+            .reserve_exact(globals.count() as usize);
+
+        for global in globals {
+            let global = global?;
+
+            let ty_convert = WasmparserTypeConverter::new(&self.types.types, &self.result.module);
+
+            self.result.module.globals.push(WasmGlobalType {
+                content_type: ty_convert.convert_val_type(global.ty.content_type),
+                mutable: global.ty.mutable,
+                shared: global.ty.shared,
+            });
+
+            let (init_expr, escaped) = ConstExpr::from_wasmparser(&global.init_expr)?;
+            for func in escaped {
+                self.flag_func_as_escaped(func);
+            }
+            self.result.module.global_initializers.push(init_expr);
+        }
+
+        Ok(())
+    }
+
+    fn translate_export_section(
+        &mut self,
+        exports: ExportSectionReader<'data>,
+    ) -> crate::Result<()> {
+        for export in exports {
+            let export = export?;
+            let index = match export.kind {
+                ExternalKind::Func => {
+                    let index = FuncIndex::from_u32(export.index);
+                    self.flag_func_as_escaped(index);
+                    self.result
+                        .debug_info
+                        .names
+                        .funcs
+                        .insert(index, export.name);
+                    EntityIndex::Function(index)
+                }
+                ExternalKind::Table => {
+                    let index = TableIndex::from_u32(export.index);
+                    self.result
+                        .debug_info
+                        .names
+                        .tables
+                        .insert(index, export.name);
+                    EntityIndex::Table(index)
+                }
+                ExternalKind::Memory => {
+                    let index = MemoryIndex::from_u32(export.index);
+                    self.result
+                        .debug_info
+                        .names
+                        .memories
+                        .insert(index, export.name);
+                    EntityIndex::Memory(index)
+                }
+                ExternalKind::Tag => {
+                    let index = TagIndex::from_u32(export.index);
+                    self.result.debug_info.names.tags.insert(index, export.name);
+                    EntityIndex::Tag(index)
+                }
+                ExternalKind::Global => {
+                    let index = GlobalIndex::from_u32(export.index);
+                    self.result
+                        .debug_info
+                        .names
+                        .globals
+                        .insert(index, export.name);
+                    EntityIndex::Global(index)
+                }
+            };
+
+            self.result
+                .module
+                .exports
+                .insert(export.name.to_string(), index);
+        }
+
+        Ok(())
+    }
+
+    fn translate_element_section(
+        &mut self,
+        elements: ElementSectionReader<'data>,
+    ) -> crate::Result<()> {
+        for (elem_index, element) in elements.into_iter().enumerate() {
+            let element = element?;
+            let elem_index = ElemIndex::from_u32(u32::try_from(elem_index).unwrap());
+
+            let elements = match element.items {
+                ElementItems::Functions(funcs) => {
+                    let mut out = Vec::with_capacity(funcs.count() as usize);
+                    for func_idx in funcs {
+                        out.push(FuncIndex::from_u32(func_idx?));
+                    }
+                    TableSegmentElements::Functions(out.into_boxed_slice())
+                }
+                ElementItems::Expressions(_, exprs) => {
+                    let mut out = Vec::with_capacity(exprs.count() as usize);
+
+                    for expr in exprs {
+                        let (expr, escaped) = ConstExpr::from_wasmparser(&expr?)?;
+                        for func in escaped {
+                            self.flag_func_as_escaped(func);
+                        }
+                        out.push(expr);
+                    }
+                    TableSegmentElements::Expressions(out.into_boxed_slice())
+                }
+            };
+
+            match element.kind {
+                ElementKind::Active {
+                    table_index,
+                    offset_expr,
+                } => {
+                    let table_index = TableIndex::from_u32(table_index.unwrap_or(0));
+                    let (offset, escaped) = ConstExpr::from_wasmparser(&offset_expr)?;
+                    debug_assert!(escaped.is_empty());
+
+                    self.result
+                        .module
+                        .table_initializers
+                        .segments
+                        .push(TableSegment {
+                            table_index,
+                            offset,
+                            elements,
+                        });
+                    self.result
+                        .module
+                        .active_table_initializers
+                        .insert(elem_index);
+                }
+                ElementKind::Passive => {
+                    self.result
+                        .module
+                        .passive_table_initializers
+                        .insert(elem_index, elements);
+                }
+                ElementKind::Declared => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    fn translate_data_section(&mut self, section: DataSectionReader<'data>) -> crate::Result<()> {
+        for (data_index, entry) in section.into_iter().enumerate() {
+            let entry = entry?;
+            let data_index = DataIndex::from_u32(u32::try_from(data_index).unwrap());
+
+            match entry.kind {
+                DataKind::Active {
+                    memory_index,
+                    offset_expr,
+                } => {
+                    let memory_index = MemoryIndex::from_u32(memory_index);
+                    let (offset, escaped) = ConstExpr::from_wasmparser(&offset_expr)?;
+                    debug_assert!(escaped.is_empty());
+
+                    self.result
+                        .module
+                        .memory_initializers
+                        .push(MemoryInitializer {
+                            memory_index,
+                            offset,
+                            data: entry.data.to_vec(),
+                        });
+                    self.result
+                        .module
+                        .active_memory_initializers
+                        .insert(data_index);
+                }
+                DataKind::Passive => {
+                    self.result
+                        .module
+                        .passive_memory_initializers
+                        .insert(data_index, entry.data.to_vec());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn parse_target_feature_section(&mut self, section: &CustomSectionReader<'data>) {
+        let mut r = BinaryReader::new_features(
+            section.data(),
+            section.data_offset(),
+            *self.validator.features(),
+        );
+
+        let _count = r.read_u8().unwrap();
+
+        let mut required_features = WasmFeatures::empty();
+
+        while !r.eof() {
+            let prefix = r.read_u8().unwrap();
+            assert_eq!(prefix, 0x2b, "only the `+` prefix is supported");
+
+            let len = r.read_var_u64().unwrap();
+            let feature = r.read_bytes(usize::try_from(len).unwrap()).unwrap();
+            let feature = core::str::from_utf8(feature).unwrap();
+
+            match feature {
+                "atomics" => required_features.insert(WasmFeatures::THREADS),
+                "bulk-memory" => required_features.insert(WasmFeatures::BULK_MEMORY),
+                "exception-handling" => required_features.insert(WasmFeatures::EXCEPTIONS),
+                "multivalue" => required_features.insert(WasmFeatures::MULTI_VALUE),
+                "mutable-globals" => required_features.insert(WasmFeatures::MUTABLE_GLOBAL),
+                "nontrapping-fptoint" => {
+                    required_features.insert(WasmFeatures::SATURATING_FLOAT_TO_INT);
+                }
+                "sign-ext" => required_features.insert(WasmFeatures::SIGN_EXTENSION),
+                "simd128" => required_features.insert(WasmFeatures::SIMD),
+                "tail-call" => required_features.insert(WasmFeatures::TAIL_CALL),
+                "reference-types" => required_features.insert(WasmFeatures::REFERENCE_TYPES),
+                "gc" => required_features.insert(WasmFeatures::GC),
+                "memory64" => required_features.insert(WasmFeatures::MEMORY64),
+                "relaxed-simd" => required_features.insert(WasmFeatures::RELAXED_SIMD),
+                "extended-const" => required_features.insert(WasmFeatures::EXTENDED_CONST),
+                "multimemory" => required_features.insert(WasmFeatures::MULTI_MEMORY),
+                "shared-everything" => {
+                    required_features.insert(WasmFeatures::SHARED_EVERYTHING_THREADS);
+                }
+                _ => tracing::warn!("unknown required WASM feature `{feature}`"),
+            }
+        }
+
+        self.result.required_features = required_features;
+    }
+
+    #[expect(clippy::too_many_lines, reason = "big match statement")]
+    fn translate_name_section(&mut self, reader: NameSectionReader<'data>) -> crate::Result<()> {
+        for subsection in reader {
+            fn for_each_direct_name<'data>(
+                names: NameMap<'data>,
+                mut f: impl FnMut(u32, &'data str),
+            ) -> crate::Result<()> {
+                for name in names {
+                    let name = name?;
+
+                    f(name.index, name.name);
+                }
+
+                Ok(())
+            }
+
+            fn for_each_indirect_name<'data, I>(
+                names: IndirectNameMap<'data>,
+                mut f1: impl FnMut(&mut HashMap<I, &'data str>, u32, &'data str),
+                mut f2: impl FnMut(HashMap<I, &'data str>, u32),
+            ) -> crate::Result<()> {
+                for naming in names {
+                    let name = naming?;
+                    let mut result = HashMap::default();
+
+                    for name in name.names {
+                        let name = name?;
+
+                        f1(&mut result, name.index, name.name);
+                    }
+
+                    f2(result, name.index);
+                }
+
+                Ok(())
+            }
+
+            match subsection? {
+                Name::Module { name, .. } => {
+                    self.result.module.name = Some(name.to_string());
+                }
+                Name::Function(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        // Skip this naming if it's naming a function that
+                        // doesn't actually exist.
+                        if idx < self.result.module.num_functions() {
+                            self.result
+                                .debug_info
+                                .names
+                                .funcs
+                                .insert(FuncIndex::from_u32(idx), name);
+                        }
+                    })?;
+                }
+                Name::Local(names) => {
+                    for_each_indirect_name(
+                        names,
+                        |result, idx, name| {
+                            result.insert(LocalIndex::from_u32(idx), name);
+                        },
+                        |result, idx| {
+                            // Skip this naming if it's naming a function that
+                            // doesn't actually exist.
+                            if idx < self.result.module.num_functions() {
+                                self.result
+                                    .debug_info
+                                    .names
+                                    .locals
+                                    .insert(FuncIndex::from_u32(idx), result);
+                            }
+                        },
+                    )?;
+                }
+                Name::Global(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .globals
+                            .insert(GlobalIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Data(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .data
+                            .insert(DataIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Type(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .types
+                            .insert(TypeIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Label(names) => {
+                    for_each_indirect_name(
+                        names,
+                        |result, idx, name| {
+                            result.insert(LabelIndex::from_u32(idx), name);
+                        },
+                        |result, idx| {
+                            // Skip this naming if it's naming a function that
+                            // doesn't actually exist.
+                            if idx < self.result.module.num_functions() {
+                                self.result
+                                    .debug_info
+                                    .names
+                                    .labels
+                                    .insert(FuncIndex::from_u32(idx), result);
+                            }
+                        },
+                    )?;
+                }
+                Name::Table(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .tables
+                            .insert(TableIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Memory(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .memories
+                            .insert(MemoryIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Element(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .elements
+                            .insert(ElemIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Field(names) => {
+                    for_each_indirect_name(
+                        names,
+                        |result, idx, name| {
+                            // Skip this naming if it's naming a function that
+                            // doesn't actually exist.
+                            if idx < self.result.module.num_functions() {
+                                result.insert(FieldIndex::from_u32(idx), name);
+                            }
+                        },
+                        |result, idx| {
+                            self.result
+                                .debug_info
+                                .names
+                                .fields
+                                .insert(FuncIndex::from_u32(idx), result);
+                        },
+                    )?;
+                }
+                Name::Tag(names) => {
+                    for_each_direct_name(names, |idx, name| {
+                        self.result
+                            .debug_info
+                            .names
+                            .tags
+                            .insert(TagIndex::from_u32(idx), name);
+                    })?;
+                }
+                Name::Unknown { .. } => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    fn translate_producers_section(
+        &mut self,
+        section: ProducersSectionReader<'data>,
+    ) -> crate::Result<()> {
+        for field in section {
+            let field = field?;
+            match field.name {
+                "language" => {
+                    for value in field.values {
+                        let ProducersFieldValue { name, version } = value?;
+                        let name = match name {
+                            "wat" => ProducersLanguage::Wat,
+                            "C" => ProducersLanguage::C,
+                            "C++" => ProducersLanguage::Cpp,
+                            "Rust" => ProducersLanguage::Rust,
+                            "JavaScript" => ProducersLanguage::JavaScript,
+                            _ => ProducersLanguage::Other(name),
+                        };
+
+                        self.result
+                            .debug_info
+                            .producers
+                            .language
+                            .push(ProducersLanguageField { name, version });
+                    }
+                }
+                "processed-by" => {
+                    for value in field.values {
+                        let ProducersFieldValue { name, version } = value?;
+                        let name = match name {
+                            "wabt" => ProducersTool::Wabt,
+                            "LLVM" => ProducersTool::Llvm,
+                            "clang" => ProducersTool::Clang,
+                            "lld" => ProducersTool::Lld,
+                            "Binaryen" => ProducersTool::Binaryen,
+                            "rustc" => ProducersTool::Rustc,
+                            "wasm-bindgen" => ProducersTool::WasmBindgen,
+                            "wasm-pack" => ProducersTool::WasmPack,
+                            "webassemblyjs" => ProducersTool::Webassemblyjs,
+                            "wasm-snip" => ProducersTool::WasmSnip,
+                            "Javy" => ProducersTool::Javy,
+                            _ => ProducersTool::Other(name),
+                        };
+
+                        self.result
+                            .debug_info
+                            .producers
+                            .processed_by
+                            .push(ProducersToolField { name, version });
+                    }
+                }
+                "sdk" => {
+                    for value in field.values {
+                        let ProducersFieldValue { name, version } = value?;
+                        let name = match name {
+                            "Emscripten" => ProducersSdk::Emscripten,
+                            "Webpack" => ProducersSdk::Webpack,
+                            _ => ProducersSdk::Other(name),
+                        };
+
+                        self.result
+                            .debug_info
+                            .producers
+                            .sdk
+                            .push(ProducersSdkField { name, version });
+                    }
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn translate_dwarf_section(&mut self, name: &'data str, section: &CustomSectionReader<'data>) {
+        let endian = gimli::LittleEndian;
+        let data = section.data();
+        let slice = gimli::EndianSlice::new(data, endian);
+
+        let mut dwarf = gimli::Dwarf::default();
+        let info = &mut self.result.debug_info;
+
+        match name {
+            // `gimli::Dwarf` fields.
+            ".debug_abbrev" => dwarf.debug_abbrev = gimli::DebugAbbrev::new(data, endian),
+            ".debug_addr" => dwarf.debug_addr = gimli::DebugAddr::from(slice),
+            ".debug_info" => {
+                dwarf.debug_info = gimli::DebugInfo::new(data, endian);
+            }
+            ".debug_line" => dwarf.debug_line = gimli::DebugLine::new(data, endian),
+            ".debug_line_str" => dwarf.debug_line_str = gimli::DebugLineStr::from(slice),
+            ".debug_str" => dwarf.debug_str = gimli::DebugStr::new(data, endian),
+            ".debug_str_offsets" => dwarf.debug_str_offsets = gimli::DebugStrOffsets::from(slice),
+            ".debug_str_sup" => {
+                let dwarf_sup = gimli::Dwarf {
+                    debug_str: gimli::DebugStr::from(slice),
+                    ..Default::default()
+                };
+                dwarf.sup = Some(Arc::new(dwarf_sup));
+            }
+            ".debug_types" => dwarf.debug_types = gimli::DebugTypes::from(slice),
+
+            // Additional fields.
+            ".debug_loc" => info.debug_loc = gimli::DebugLoc::from(slice),
+            ".debug_loclists" => info.debug_loclists = gimli::DebugLocLists::from(slice),
+            ".debug_ranges" => info.debug_ranges = gimli::DebugRanges::new(data, endian),
+            ".debug_rnglists" => info.debug_rnglists = gimli::DebugRngLists::new(data, endian),
+
+            // DWARF package fields
+            ".debug_cu_index" => info.debug_cu_index = gimli::DebugCuIndex::new(data, endian),
+            ".debug_tu_index" => info.debug_tu_index = gimli::DebugTuIndex::new(data, endian),
+
+            // We don't use these at the moment.
+            ".debug_aranges" | ".debug_pubnames" | ".debug_pubtypes" => return,
+            other => {
+                tracing::warn!("unknown debug section `{}`", other);
+                return;
+            }
+        }
+
+        dwarf.ranges = gimli::RangeLists::new(info.debug_ranges, info.debug_rnglists);
+        dwarf.locations = gimli::LocationLists::new(info.debug_loc, info.debug_loclists);
+
+        info.dwarf = dwarf;
+    }
+}

--- a/libs/kwasm/src/wasm/module_types.rs
+++ b/libs/kwasm/src/wasm/module_types.rs
@@ -1,0 +1,263 @@
+use crate::indices::{ModuleInternedRecGroupIndex, ModuleInternedTypeIndex};
+use crate::wasm::type_convert::WasmparserTypeConverter;
+use crate::wasm::{WasmCompositeTypeInner, WasmFuncType, TranslatedModule, WasmSubType};
+use core::fmt;
+use core::ops::Range;
+use cranelift_entity::packed_option::PackedOption;
+use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
+use hashbrown::HashMap;
+use wasmparser::{Validator, ValidatorId};
+
+/// Types defined within a single WebAssembly module.
+#[derive(Debug, Default)]
+pub struct ModuleTypes {
+    /// WASM types (functions for MVP as well as arrays and structs when the GC proposal is enabled).
+    wasm_types: PrimaryMap<ModuleInternedTypeIndex, WasmSubType>,
+    /// Recursion groups defined within this module (only used when the GC proposal is enabled).
+    rec_groups: PrimaryMap<ModuleInternedRecGroupIndex, Range<ModuleInternedTypeIndex>>,
+    /// Signatures of trampolines
+    trampoline_types: SecondaryMap<ModuleInternedTypeIndex, PackedOption<ModuleInternedTypeIndex>>,
+    /// Types that have already been interned.
+    pub(super) seen_types: HashMap<wasmparser::types::CoreTypeId, ModuleInternedTypeIndex>,
+}
+
+impl fmt::Display for ModuleTypes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, ty) in self.wasm_types() {
+            writeln!(f, "{index:?}: {ty}")?;
+        }
+        Ok(())
+    }
+}
+
+impl ModuleTypes {
+    /// Returns an iterator over all the WASM types (functions, arrays, and structs) defined in this module.
+    pub fn wasm_types(&self) -> impl ExactSizeIterator<Item = (ModuleInternedTypeIndex, &WasmSubType)> {
+        self.wasm_types.iter()
+    }
+
+    /// Returns the number of types WASM types defined in this module.
+    pub fn len_types(&self) -> usize {
+        self.wasm_types.len()
+    }
+
+    /// Get the WASM type specified by `index` if it exists.
+    pub fn get_wasm_type(&self, ty: ModuleInternedTypeIndex) -> Option<&WasmSubType> {
+        self.wasm_types.get(ty)
+    }
+
+    /// Get the elements within a defined recursion group.
+    pub fn rec_group_elements(
+        &self,
+        rec_group: ModuleInternedRecGroupIndex,
+    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> + use<'_> {
+        let range = &self.rec_groups[rec_group];
+        (range.start.as_u32()..range.end.as_u32()).map(ModuleInternedTypeIndex::from_u32)
+    }
+
+    pub fn rec_groups(&self) -> impl ExactSizeIterator<Item = &'_ Range<ModuleInternedTypeIndex>> {
+        self.rec_groups.values()
+    }
+
+    /// The trampoline function types that this module requires.
+    ///
+    /// Yields pairs of (1) a function type and (2) its associated trampoline
+    /// type. They might be the same.
+    pub fn trampoline_types(
+        &self,
+    ) -> impl Iterator<Item = (ModuleInternedTypeIndex, ModuleInternedTypeIndex)> + '_ {
+        self.trampoline_types
+            .iter()
+            .filter_map(|(k, v)| v.expand().map(|v| (k, v)))
+    }
+
+    pub fn trampoline_type(&self, ty: ModuleInternedTypeIndex) -> ModuleInternedTypeIndex {
+        debug_assert!(self.wasm_types[ty].is_func());
+        self.trampoline_types[ty].unwrap()
+    }
+}
+
+/// A recursion group that is currently being defined.
+struct RecGroupInProgress {
+    /// The index of this recursion group.
+    rec_group_index: ModuleInternedRecGroupIndex,
+    /// Index into the `wasm_types` list where this recursion group starts.
+    start: ModuleInternedTypeIndex,
+    /// Index into the `wasm_types` list where this recursion group ends.
+    end: ModuleInternedTypeIndex,
+}
+
+pub struct ModuleTypesBuilder {
+    /// The `wasmparser` validator ID this builder has been crated with. Mixing types from
+    /// different validators since defined IDs are only unique within a single validator.
+    validator_id: ValidatorId,
+    /// The types being built.
+    pub types: ModuleTypes,
+    /// Recursion groups that have already interned.
+    seen_rec_groups: HashMap<wasmparser::types::RecGroupId, ModuleInternedRecGroupIndex>,
+    /// The recursion group currently being defined.
+    rec_group_in_progress: Option<RecGroupInProgress>,
+}
+
+impl ModuleTypesBuilder {
+    pub fn new(validator: &Validator) -> Self {
+        Self {
+            validator_id: validator.id(),
+            types: ModuleTypes::default(),
+            seen_rec_groups: HashMap::default(),
+            rec_group_in_progress: None,
+        }
+    }
+
+    /// Finish building the module types.
+    pub fn finish(self) -> ModuleTypes {
+        self.types
+    }
+
+    /// Define a new recursion group that we haven't already interned.
+    fn define_new_rec_group(
+        &mut self,
+        module: &TranslatedModule,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        rec_group_id: wasmparser::types::RecGroupId,
+    ) -> ModuleInternedRecGroupIndex {
+        self.start_rec_group(
+            validator_types,
+            validator_types.rec_group_elements(rec_group_id),
+        );
+
+        for id in validator_types.rec_group_elements(rec_group_id) {
+            let ty = &validator_types[id];
+            let wasm_ty = WasmparserTypeConverter::new(&self.types, module)
+                .with_rec_group(validator_types, rec_group_id)
+                .convert_sub_type(ty);
+            self.wasm_sub_type_in_rec_group(id, wasm_ty);
+        }
+
+        let rec_group_index = self.end_rec_group(rec_group_id);
+
+        rec_group_index
+    }
+
+    /// Start defining a new recursion group.
+    fn start_rec_group(
+        &mut self,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        elems: impl ExactSizeIterator<Item = wasmparser::types::CoreTypeId>,
+    ) {
+        tracing::trace!("Starting rec group of length {}", elems.len());
+
+        assert!(self.rec_group_in_progress.is_none());
+        assert_eq!(validator_types.id(), self.validator_id);
+
+        let len = elems.len();
+        for (i, wasmparser_id) in elems.enumerate() {
+            let interned = ModuleInternedTypeIndex::new(self.types.len_types() + i);
+            tracing::trace!(
+                "Reserving {interned:?} for {wasmparser_id:?} = {:?}",
+                validator_types[wasmparser_id]
+            );
+
+            let old_entry = self.types.seen_types.insert(wasmparser_id, interned);
+            debug_assert_eq!(
+                old_entry, None,
+                "should not have already inserted {wasmparser_id:?}"
+            );
+        }
+
+        self.rec_group_in_progress = Some(RecGroupInProgress {
+            rec_group_index: self.next_rec_group_index(),
+            start: self.next_type_index(),
+            end: ModuleInternedTypeIndex::new(self.types.len_types() + len),
+        });
+    }
+
+    /// Finish defining a recursion group returning it's index.
+    fn end_rec_group(
+        &mut self,
+        rec_group_id: wasmparser::types::RecGroupId,
+    ) -> ModuleInternedRecGroupIndex {
+        let RecGroupInProgress {
+            rec_group_index,
+            start,
+            end,
+        } = self
+            .rec_group_in_progress
+            .take()
+            .expect("should be defining a rec group");
+
+        tracing::trace!("Ending rec group {start:?}..{end:?}");
+
+        debug_assert!(start.index() < self.types.len_types());
+        debug_assert_eq!(
+            end,
+            self.next_type_index(),
+            "should have defined the number of types declared in `start_rec_group`"
+        );
+
+        let idx = self.push_rec_group(Range::from(start..end));
+        debug_assert_eq!(idx, rec_group_index);
+
+        self.seen_rec_groups.insert(rec_group_id, rec_group_index);
+        rec_group_index
+    }
+
+    /// Define a new type within the current recursion group.
+    fn wasm_sub_type_in_rec_group(&mut self, id: wasmparser::types::CoreTypeId, ty: WasmSubType) {
+        assert!(
+            self.rec_group_in_progress.is_some(),
+            "must be defining a rec group to define new types"
+        );
+
+        let module_interned_index = self.push_type(ty);
+        debug_assert_eq!(
+            self.types.seen_types.get(&id),
+            Some(&module_interned_index),
+            "should have reserved the right module-interned index for this wasmparser type already"
+        );
+    }
+
+    /// Define a new recursion group, or return the existing one's index if it's already been defined.
+    pub fn intern_rec_group(
+        &mut self,
+        module: &TranslatedModule,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        rec_group_id: wasmparser::types::RecGroupId,
+    ) -> ModuleInternedRecGroupIndex {
+        assert_eq!(validator_types.id(), self.validator_id);
+
+        if let Some(interned) = self.seen_rec_groups.get(&rec_group_id) {
+            return *interned;
+        }
+
+        self.define_new_rec_group(module, validator_types, rec_group_id)
+    }
+
+    /// Returns the next return value of `push_rec_group`.
+    fn next_rec_group_index(&self) -> ModuleInternedRecGroupIndex {
+        self.types.rec_groups.next_key()
+    }
+
+    /// Returns the next return value of `push`.
+    pub fn next_ty(&self) -> ModuleInternedTypeIndex {
+        self.types.wasm_types.next_key()
+    }
+
+    /// Adds a new recursion group.
+    pub fn push_rec_group(
+        &mut self,
+        range: Range<ModuleInternedTypeIndex>,
+    ) -> ModuleInternedRecGroupIndex {
+        self.types.rec_groups.push(range)
+    }
+
+    /// Returns the next return value of `push_type`.
+    fn next_type_index(&self) -> ModuleInternedTypeIndex {
+        self.types.wasm_types.next_key()
+    }
+
+    /// Adds a new type to this interned list of types.
+    fn push_type(&mut self, wasm_sub_type: WasmSubType) -> ModuleInternedTypeIndex {
+        self.types.wasm_types.push(wasm_sub_type)
+    }
+}

--- a/libs/kwasm/src/wasm/type_convert.rs
+++ b/libs/kwasm/src/wasm/type_convert.rs
@@ -1,0 +1,266 @@
+use crate::indices::{CanonicalizedTypeIndex, ModuleInternedTypeIndex, TypeIndex};
+use crate::wasm::{
+    WasmArrayType, WasmCompositeType, WasmCompositeTypeInner, WasmFieldType, WasmFuncType, WasmHeapType, WasmHeapTypeInner,
+    WasmRefType, WasmStorageType, WasmStructType, WasmSubType, WasmValType,
+};
+use crate::wasm::{TranslatedModule, ModuleTypes};
+use alloc::vec::Vec;
+use cranelift_entity::EntityRef;
+use wasmparser::UnpackedIndex;
+
+/// A type that knows how to convert from `wasmparser` types to types in this crate.
+pub struct WasmparserTypeConverter<'a> {
+    types: &'a ModuleTypes,
+    module: &'a TranslatedModule,
+    rec_group_context: Option<(
+        wasmparser::types::TypesRef<'a>,
+        wasmparser::types::RecGroupId,
+    )>,
+}
+
+impl<'a> WasmparserTypeConverter<'a> {
+    pub fn new(types: &'a ModuleTypes, module: &'a TranslatedModule) -> Self {
+        Self {
+            types,
+            module,
+            rec_group_context: None,
+        }
+    }
+
+    /// Configure this converter to be within the context of defining the
+    /// current rec group.
+    pub fn with_rec_group(
+        &mut self,
+        wasmparser_types: wasmparser::types::TypesRef<'a>,
+        rec_group: wasmparser::types::RecGroupId,
+    ) -> &Self {
+        self.rec_group_context = Some((wasmparser_types, rec_group));
+        self
+    }
+
+    pub fn convert_val_type(&self, ty: wasmparser::ValType) -> WasmValType {
+        match ty {
+            wasmparser::ValType::I32 => WasmValType::I32,
+            wasmparser::ValType::I64 => WasmValType::I64,
+            wasmparser::ValType::F32 => WasmValType::F32,
+            wasmparser::ValType::F64 => WasmValType::F64,
+            wasmparser::ValType::V128 => WasmValType::V128,
+            wasmparser::ValType::Ref(ty) => WasmValType::Ref(self.convert_ref_type(ty)),
+        }
+    }
+
+    pub fn convert_ref_type(&self, ty: wasmparser::RefType) -> WasmRefType {
+        WasmRefType {
+            nullable: ty.is_nullable(),
+            heap_type: self.convert_heap_type(ty.heap_type()),
+        }
+    }
+
+    pub fn convert_heap_type(&self, ty: wasmparser::HeapType) -> WasmHeapType {
+        match ty {
+            wasmparser::HeapType::Concrete(index) => self.lookup_heap_type(index),
+            wasmparser::HeapType::Abstract { shared, ty } => {
+                use crate::wasm::types::WasmHeapTypeInner::*;
+
+                use wasmparser::AbstractHeapType;
+                let ty = match ty {
+                    AbstractHeapType::Func => Func,
+                    AbstractHeapType::Extern => Extern,
+                    AbstractHeapType::Any => Any,
+                    AbstractHeapType::None => None,
+                    AbstractHeapType::NoExtern => NoExtern,
+                    AbstractHeapType::NoFunc => NoFunc,
+                    AbstractHeapType::Eq => Eq,
+                    AbstractHeapType::Struct => Struct,
+                    AbstractHeapType::Array => Array,
+                    AbstractHeapType::I31 => I31,
+                    AbstractHeapType::Exn => Exn,
+                    AbstractHeapType::NoExn => NoExn,
+                    AbstractHeapType::Cont => Cont,
+                    AbstractHeapType::NoCont => NoCont,
+                };
+
+                WasmHeapType { shared, inner: ty }
+            }
+        }
+    }
+
+    pub fn convert_sub_type(&self, ty: &wasmparser::SubType) -> WasmSubType {
+        WasmSubType {
+            is_final: ty.is_final,
+            supertype: ty.supertype_idx.map(|index| {
+                CanonicalizedTypeIndex::Module(self.lookup_type_index(index.unpack()))
+            }),
+            composite_type: self.convert_composite_type(&ty.composite_type),
+        }
+    }
+
+    pub fn convert_composite_type(&self, ty: &wasmparser::CompositeType) -> WasmCompositeType {
+        use wasmparser::CompositeInnerType;
+        match &ty.inner {
+            CompositeInnerType::Func(func) => {
+                WasmCompositeType::new_func(ty.shared, self.convert_func_type(func))
+            }
+            CompositeInnerType::Array(array) => {
+                WasmCompositeType::new_array(ty.shared, self.convert_array_type(*array))
+            }
+            CompositeInnerType::Struct(strct) => {
+                WasmCompositeType::new_struct(ty.shared, self.convert_struct_type(strct))
+            }
+            CompositeInnerType::Cont(_) => todo!(),
+        }
+    }
+
+    pub fn convert_func_type(&self, ty: &wasmparser::FuncType) -> WasmFuncType {
+        let mut params = Vec::with_capacity(ty.params().len());
+        let mut results = Vec::with_capacity(ty.results().len());
+
+        for param in ty.params() {
+            params.push(self.convert_val_type(*param));
+        }
+
+        for result in ty.results() {
+            results.push(self.convert_val_type(*result));
+        }
+
+        WasmFuncType {
+            params: params.into_boxed_slice(),
+            results: results.into_boxed_slice(),
+        }
+    }
+
+    pub fn convert_array_type(&self, ty: wasmparser::ArrayType) -> WasmArrayType {
+        WasmArrayType(self.convert_field_type(ty.0))
+    }
+
+    pub fn convert_struct_type(&self, ty: &wasmparser::StructType) -> WasmStructType {
+        let fields: Vec<_> = ty
+            .fields
+            .iter()
+            .map(|ty| self.convert_field_type(*ty))
+            .collect();
+        WasmStructType {
+            fields: fields.into_boxed_slice(),
+        }
+    }
+
+    pub fn convert_field_type(&self, ty: wasmparser::FieldType) -> WasmFieldType {
+        WasmFieldType {
+            mutable: ty.mutable,
+            element_type: self.convert_storage_type(ty.element_type),
+        }
+    }
+
+    pub fn convert_storage_type(&self, ty: wasmparser::StorageType) -> WasmStorageType {
+        match ty {
+            wasmparser::StorageType::I8 => WasmStorageType::I8,
+            wasmparser::StorageType::I16 => WasmStorageType::I16,
+            wasmparser::StorageType::Val(ty) => WasmStorageType::Val(self.convert_val_type(ty)),
+        }
+    }
+
+    fn lookup_type_index(&self, index: UnpackedIndex) -> ModuleInternedTypeIndex {
+        match index {
+            UnpackedIndex::Module(index) => {
+                let module_index = TypeIndex::from_u32(index);
+                self.module.types[module_index]
+            }
+            UnpackedIndex::Id(id) => self.types.seen_types[&id],
+            UnpackedIndex::RecGroup(_) => unreachable!(),
+        }
+    }
+
+    fn lookup_heap_type(&self, index: UnpackedIndex) -> WasmHeapType {
+        match index {
+            UnpackedIndex::Id(id) => {
+                let interned = self.types.seen_types[&id];
+                let index = CanonicalizedTypeIndex::Module(interned);
+
+                // If this is a forward reference to a type in this type's rec
+                // group that we haven't converted yet, then we won't have an
+                // entry in `wasm_types` yet. In this case, fallback to a
+                // different means of determining whether this is a concrete
+                // array vs struct vs func reference. In this case, we can use
+                // the validator's type context.
+                if let Some(ty) = self.types.get_wasm_type(interned) {
+                    let inner = match &ty.composite_type.inner {
+                        WasmCompositeTypeInner::Array(_) => WasmHeapTypeInner::ConcreteArray(index),
+                        WasmCompositeTypeInner::Func(_) => WasmHeapTypeInner::ConcreteFunc(index),
+                        WasmCompositeTypeInner::Struct(_) => WasmHeapTypeInner::ConcreteStruct(index),
+                    };
+
+                    WasmHeapType::new(ty.composite_type.shared, inner)
+                } else if let Some((wasmparser_types, _)) = self.rec_group_context.as_ref() {
+                    let wasmparser_ty = &wasmparser_types[id].composite_type;
+                    let inner = match &wasmparser_ty.inner {
+                        wasmparser::CompositeInnerType::Array(_) => {
+                            WasmHeapTypeInner::ConcreteArray(index)
+                        }
+                        wasmparser::CompositeInnerType::Func(_) => {
+                            WasmHeapTypeInner::ConcreteFunc(index)
+                        }
+                        wasmparser::CompositeInnerType::Struct(_) => {
+                            WasmHeapTypeInner::ConcreteStruct(index)
+                        }
+                        wasmparser::CompositeInnerType::Cont(_) => {
+                            panic!("unimplemented continuation types")
+                        }
+                    };
+
+                    WasmHeapType::new(wasmparser_ty.shared, inner)
+                } else {
+                    panic!("forward reference to type outside of rec group?")
+                }
+            }
+
+            UnpackedIndex::Module(module_index) => {
+                let module_index = TypeIndex::from_u32(module_index);
+                let interned = self.module.types[module_index];
+                let index = CanonicalizedTypeIndex::Module(interned);
+
+                // See comment above about `wasm_types` maybe not having the
+                // converted sub-type yet. However, in this case we don't have a
+                // `wasmparser::types::CoreTypeId` on hand, so we have to
+                // indirectly get one by looking it up inside the current rec
+                // group.
+                if let Some(ty) = self.types.get_wasm_type(interned) {
+                    let inner = match &ty.composite_type.inner {
+                        WasmCompositeTypeInner::Array(_) => WasmHeapTypeInner::ConcreteArray(index),
+                        WasmCompositeTypeInner::Func(_) => WasmHeapTypeInner::ConcreteFunc(index),
+                        WasmCompositeTypeInner::Struct(_) => WasmHeapTypeInner::ConcreteStruct(index),
+                    };
+
+                    WasmHeapType::new(ty.composite_type.shared, inner)
+                } else if let Some((parser_types, rec_group)) = self.rec_group_context.as_ref() {
+                    let rec_group_index = interned.index() - self.types.len_types();
+                    let id = parser_types
+                        .rec_group_elements(*rec_group)
+                        .nth(rec_group_index)
+                        .unwrap();
+                    let wasmparser_ty = &parser_types[id].composite_type;
+
+                    let inner = match &wasmparser_ty.inner {
+                        wasmparser::CompositeInnerType::Array(_) => {
+                            WasmHeapTypeInner::ConcreteArray(index)
+                        }
+                        wasmparser::CompositeInnerType::Func(_) => {
+                            WasmHeapTypeInner::ConcreteFunc(index)
+                        }
+                        wasmparser::CompositeInnerType::Struct(_) => {
+                            WasmHeapTypeInner::ConcreteStruct(index)
+                        }
+                        wasmparser::CompositeInnerType::Cont(_) => {
+                            panic!("unimplemented continuation types")
+                        }
+                    };
+
+                    WasmHeapType::new(wasmparser_ty.shared, inner)
+                } else {
+                    panic!("forward reference to type outside of rec group?")
+                }
+            }
+
+            UnpackedIndex::RecGroup(_) => unreachable!(),
+        }
+    }
+}

--- a/libs/kwasm/src/wasm/types.rs
+++ b/libs/kwasm/src/wasm/types.rs
@@ -1,0 +1,998 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! "raw" types of WebAssembly constructs
+
+use crate::indices::CanonicalizedTypeIndex;
+use crate::type_registry::TypeTrace;
+use crate::utils::enum_accessors;
+use crate::wasm::type_convert::WasmparserTypeConverter;
+use crate::DEFAULT_OFFSET_GUARD_SIZE;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use core::fmt;
+
+/// Represents the types of values in a WebAssembly module.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WasmValType {
+    /// The value type is i32.
+    I32,
+    /// The value type is i64.
+    I64,
+    /// The value type is f32.
+    F32,
+    /// The value type is f64.
+    F64,
+    /// The value type is v128.
+    V128,
+    /// The value type is a reference.
+    Ref(WasmRefType),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct WasmRefType {
+    pub nullable: bool,
+    pub heap_type: WasmHeapType,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct WasmHeapType {
+    pub shared: bool,
+    pub inner: WasmHeapTypeInner,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum WasmHeapTypeInner {
+    // External types.
+    Extern,
+    NoExtern,
+
+    // Function types.
+    Func,
+    ConcreteFunc(CanonicalizedTypeIndex),
+    NoFunc,
+
+    // Internal types.
+    Any,
+    Eq,
+    I31,
+    Array,
+    ConcreteArray(CanonicalizedTypeIndex),
+    Struct,
+    ConcreteStruct(CanonicalizedTypeIndex),
+    None,
+
+    Exn,
+    NoExn,
+
+    Cont,
+    ConcreteCont(CanonicalizedTypeIndex),
+    NoCont,
+}
+
+/// A concrete, user-defined (or host-defined) Wasm type.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmSubType {
+    /// Whether this type is forbidden from being the supertype of any other
+    /// type.
+    pub is_final: bool,
+
+    /// This type's supertype, if any.
+    pub supertype: Option<CanonicalizedTypeIndex>,
+
+    /// The array, function, or struct that is defined.
+    pub composite_type: WasmCompositeType,
+}
+
+/// A function, array, or struct type.
+///
+/// Introduced by the GC proposal.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmCompositeType {
+    pub inner: WasmCompositeTypeInner,
+    /// Is the composite type shared? This is part of the
+    /// shared-everything-threads proposal.
+    pub shared: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum WasmCompositeTypeInner {
+    /// The type is a regular function.
+    Func(WasmFuncType),
+    /// The type is a GC-proposal array.
+    Array(WasmArrayType),
+    /// The type is a GC-proposal struct.
+    Struct(WasmStructType),
+}
+
+/// A WebAssembly function type.
+///
+/// This is the equivalent of `wasmparser::FuncType`.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmFuncType {
+    pub params: Box<[WasmValType]>,
+    pub results: Box<[WasmValType]>,
+}
+
+/// A WebAssembly GC-proposal struct type.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmStructType {
+    pub fields: Box<[WasmFieldType]>,
+}
+
+/// A WebAssembly GC-proposal Array type.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmArrayType(pub WasmFieldType);
+
+/// The type of struct field or array element.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmFieldType {
+    /// Whether this field can be mutated or not.
+    pub mutable: bool,
+    /// The field's element type.
+    pub element_type: WasmStorageType,
+}
+
+/// A WebAssembly GC-proposal storage type for Array and Struct fields.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub enum WasmStorageType {
+    /// The storage type is i8.
+    I8,
+    /// The storage type is i16.
+    I16,
+    /// The storage type is a value type.
+    Val(WasmValType),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct WasmRecGroup(pub(crate) Box<[WasmSubType]>);
+
+/// The size range of resizeable storage associated with [Memory] types and [Table] types.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[allow(missing_docs, reason = "self-describing fields")]
+pub struct WasmLimits {
+    pub min: u64,
+    pub max: Option<u64>,
+}
+
+/// The type that can be used to index into [Memory] and [Table].
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[allow(missing_docs, reason = "self-describing variants")]
+pub enum WasmIndexType {
+    I32,
+    I64,
+}
+
+#[derive(Debug, Clone, Hash)]
+pub struct WasmTableType {
+    /// The table's element type.
+    pub element_type: WasmRefType,
+    pub index_type: WasmIndexType,
+    pub limits: WasmLimits,
+    /// Whether this table is shared indicating that it should be send-able across threads and the maximum field is always present for valid types.
+    ///
+    /// This is included the shared-everything-threads proposal.
+    pub shared: bool,
+}
+
+#[derive(Debug, Clone, Hash)]
+pub struct WasmMemoryType {
+    pub limits: WasmLimits,
+    pub index_type: WasmIndexType,
+    /// The size in bytes of the offset guard region.
+    pub offset_guard_size: u64,
+    /// The log2 of this memory's page size, in bytes.
+    ///
+    /// By default, the page size is 64KiB (0x10000; 2**16; 1<<16; 65536) but the
+    /// custom-page-sizes proposal allows opting into a page size of `1`.
+    pub page_size_log2: u8,
+    /// Whether or not this is a “shared” memory, indicating that it should be send-able across threads and the maximum field is always present for valid types.
+    ///
+    /// This is part of the threads proposal in WebAssembly.
+    pub shared: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct WasmGlobalType {
+    /// The type of value stored in this global.
+    pub content_type: WasmValType,
+    /// Whether this global is mutable.
+    pub mutable: bool,
+    /// Whether this global is shared, indicating that it should be send-able across threads.
+    pub shared: bool,
+}
+
+/// WebAssembly exception and control tag.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct WasmTagType {
+    /// The tag signature type.
+    pub signature: CanonicalizedTypeIndex,
+}
+
+#[derive(Debug, Clone)]
+pub enum WasmEntityType {
+    Function(CanonicalizedTypeIndex),
+    Table(WasmTableType),
+    Memory(WasmMemoryType),
+    Global(WasmGlobalType),
+    Tag(CanonicalizedTypeIndex),
+}
+
+// === impl WasmValType ===
+
+impl WasmValType {
+    pub fn is_i32(&self) -> bool {
+        matches!(self, Self::I32)
+    }
+    pub fn is_i64(&self) -> bool {
+        matches!(self, Self::I64)
+    }
+    pub fn is_f32(&self) -> bool {
+        matches!(self, Self::F32)
+    }
+    pub fn is_f64(&self) -> bool {
+        matches!(self, Self::F64)
+    }
+    pub fn is_v128(&self) -> bool {
+        matches!(self, Self::V128)
+    }
+    enum_accessors!(
+        e
+        (Ref(&WasmRefType) is_ref get_ref unwrap_ref e)
+    );
+
+    fn trampoline_type(&self) -> Self {
+        match self {
+            WasmValType::Ref(r) => WasmValType::Ref(WasmRefType {
+                nullable: true,
+                heap_type: r.heap_type.top(),
+            }),
+            WasmValType::I32
+            | WasmValType::I64
+            | WasmValType::F32
+            | WasmValType::F64
+            | WasmValType::V128 => *self,
+        }
+    }
+}
+
+impl fmt::Display for WasmValType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            WasmValType::I32 => write!(f, "i32"),
+            WasmValType::I64 => write!(f, "i64"),
+            WasmValType::F32 => write!(f, "f32"),
+            WasmValType::F64 => write!(f, "f64"),
+            WasmValType::V128 => write!(f, "v128"),
+            WasmValType::Ref(rt) => write!(f, "{rt}"),
+        }
+    }
+}
+
+impl TypeTrace for WasmValType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        if let Self::Ref(ref_type) = self {
+            ref_type.trace(func)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        if let Self::Ref(ref_type) = self {
+            ref_type.trace_mut(func)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// === impl ValRefType ===
+
+impl WasmRefType {
+    pub const EXTERNREF: Self = Self {
+        nullable: true,
+        heap_type: WasmHeapType::new(false, WasmHeapTypeInner::Extern),
+    };
+    pub const FUNCREF: Self = Self {
+        nullable: true,
+        heap_type: WasmHeapType::new(false, WasmHeapTypeInner::Func),
+    };
+}
+
+impl fmt::Display for WasmRefType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Self::FUNCREF => write!(f, "funcref"),
+            Self::EXTERNREF => write!(f, "externref"),
+            _ => {
+                if self.nullable {
+                    write!(f, "(ref null {})", self.heap_type)
+                } else {
+                    write!(f, "(ref {})", self.heap_type)
+                }
+            }
+        }
+    }
+}
+
+impl TypeTrace for WasmRefType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        self.heap_type.trace(func)
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        self.heap_type.trace_mut(func)
+    }
+}
+
+// === impl WasmHeapType ===
+
+impl WasmHeapType {
+    pub const fn new(shared: bool, ty: WasmHeapTypeInner) -> Self {
+        Self { shared, inner: ty }
+    }
+
+    /// Get the top type of this heap type's type hierarchy.
+    ///
+    /// The returned heap type is a supertype of all types in this heap type's
+    /// type hierarchy.
+    pub fn top(&self) -> Self {
+        let inner = match self.inner {
+            WasmHeapTypeInner::Func
+            | WasmHeapTypeInner::ConcreteFunc(_)
+            | WasmHeapTypeInner::NoFunc => WasmHeapTypeInner::Func,
+
+            WasmHeapTypeInner::Extern | WasmHeapTypeInner::NoExtern => WasmHeapTypeInner::Extern,
+
+            WasmHeapTypeInner::Any
+            | WasmHeapTypeInner::Eq
+            | WasmHeapTypeInner::I31
+            | WasmHeapTypeInner::Array
+            | WasmHeapTypeInner::ConcreteArray(_)
+            | WasmHeapTypeInner::Struct
+            | WasmHeapTypeInner::ConcreteStruct(_)
+            | WasmHeapTypeInner::None => WasmHeapTypeInner::Any,
+
+            WasmHeapTypeInner::Exn | WasmHeapTypeInner::NoExn => WasmHeapTypeInner::Exn,
+            WasmHeapTypeInner::Cont
+            | WasmHeapTypeInner::ConcreteCont(_)
+            | WasmHeapTypeInner::NoCont => WasmHeapTypeInner::Cont,
+        };
+
+        WasmHeapType::new(self.shared, inner)
+    }
+
+    /// Is this the top type within its type hierarchy?
+    #[inline]
+    pub fn is_top(&self) -> bool {
+        matches!(
+            self.inner,
+            WasmHeapTypeInner::Any
+                | WasmHeapTypeInner::Extern
+                | WasmHeapTypeInner::Func
+                | WasmHeapTypeInner::Exn
+                | WasmHeapTypeInner::Cont
+        )
+    }
+
+    /// Get the bottom type of this heap type's type hierarchy.
+    ///
+    /// The returned heap type is a subtype of all types in this heap type's
+    /// type hierarchy.
+    #[inline]
+    pub fn bottom(&self) -> WasmHeapType {
+        let inner = match self.inner {
+            WasmHeapTypeInner::Extern | WasmHeapTypeInner::NoExtern => WasmHeapTypeInner::NoExtern,
+
+            WasmHeapTypeInner::Func
+            | WasmHeapTypeInner::ConcreteFunc(_)
+            | WasmHeapTypeInner::NoFunc => WasmHeapTypeInner::NoFunc,
+
+            WasmHeapTypeInner::Any
+            | WasmHeapTypeInner::Eq
+            | WasmHeapTypeInner::I31
+            | WasmHeapTypeInner::Array
+            | WasmHeapTypeInner::ConcreteArray(_)
+            | WasmHeapTypeInner::Struct
+            | WasmHeapTypeInner::ConcreteStruct(_)
+            | WasmHeapTypeInner::None => WasmHeapTypeInner::None,
+
+            WasmHeapTypeInner::Exn | WasmHeapTypeInner::NoExn => WasmHeapTypeInner::NoExn,
+            WasmHeapTypeInner::Cont
+            | WasmHeapTypeInner::ConcreteCont(_)
+            | WasmHeapTypeInner::NoCont => WasmHeapTypeInner::NoCont,
+        };
+
+        WasmHeapType::new(self.shared, inner)
+    }
+
+    /// Is this the bottom type within its type hierarchy?
+    #[inline]
+    pub fn is_bottom(&self) -> bool {
+        matches!(
+            self.inner,
+            WasmHeapTypeInner::None
+                | WasmHeapTypeInner::NoExtern
+                | WasmHeapTypeInner::NoFunc
+                | WasmHeapTypeInner::NoExn
+                | WasmHeapTypeInner::NoCont
+        )
+    }
+}
+
+impl fmt::Display for WasmHeapType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.shared {
+            write!(f, "shared ")?;
+        }
+        match &self.inner {
+            WasmHeapTypeInner::Extern => write!(f, "extern"),
+            WasmHeapTypeInner::NoExtern => write!(f, "noextern"),
+            WasmHeapTypeInner::Func => write!(f, "func"),
+            WasmHeapTypeInner::ConcreteFunc(i) => write!(f, "func {i:?}"),
+            WasmHeapTypeInner::NoFunc => write!(f, "nofunc"),
+            WasmHeapTypeInner::Any => write!(f, "any"),
+            WasmHeapTypeInner::Eq => write!(f, "eq"),
+            WasmHeapTypeInner::I31 => write!(f, "i31"),
+            WasmHeapTypeInner::Array => write!(f, "array"),
+            WasmHeapTypeInner::ConcreteArray(i) => write!(f, "array {i:?}"),
+            WasmHeapTypeInner::Struct => write!(f, "struct"),
+            WasmHeapTypeInner::ConcreteStruct(i) => write!(f, "struct {i:?}"),
+            WasmHeapTypeInner::None => write!(f, "none"),
+            WasmHeapTypeInner::Exn => write!(f, "exn"),
+            WasmHeapTypeInner::NoExn => write!(f, "noexn"),
+            WasmHeapTypeInner::Cont => write!(f, "cont"),
+            WasmHeapTypeInner::ConcreteCont(i) => write!(f, "cont {i:?}"),
+            WasmHeapTypeInner::NoCont => write!(f, "nocont"),
+        }
+    }
+}
+
+impl TypeTrace for WasmHeapType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        match self.inner {
+            WasmHeapTypeInner::ConcreteFunc(index)
+            | WasmHeapTypeInner::ConcreteArray(index)
+            | WasmHeapTypeInner::ConcreteStruct(index) => func(index),
+            _ => Ok(()),
+        }
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        match self.inner {
+            WasmHeapTypeInner::ConcreteFunc(ref mut index)
+            | WasmHeapTypeInner::ConcreteArray(ref mut index)
+            | WasmHeapTypeInner::ConcreteStruct(ref mut index) => func(index),
+            _ => Ok(()),
+        }
+    }
+}
+
+// === impl WasmSubType ===
+
+impl WasmSubType {
+    #[inline]
+    pub fn is_func(&self) -> bool {
+        self.composite_type.is_func()
+    }
+
+    #[inline]
+    pub fn as_func(&self) -> Option<&WasmFuncType> {
+        self.composite_type.as_func()
+    }
+
+    #[inline]
+    pub fn unwrap_func(&self) -> &WasmFuncType {
+        self.composite_type.unwrap_func()
+    }
+
+    #[inline]
+    pub fn is_array(&self) -> bool {
+        self.composite_type.is_array()
+    }
+
+    #[inline]
+    pub fn as_array(&self) -> Option<&WasmArrayType> {
+        self.composite_type.as_array()
+    }
+
+    #[inline]
+    pub fn unwrap_array(&self) -> &WasmArrayType {
+        self.composite_type.unwrap_array()
+    }
+
+    #[inline]
+    pub fn is_struct(&self) -> bool {
+        self.composite_type.is_struct()
+    }
+
+    #[inline]
+    pub fn as_struct(&self) -> Option<&WasmStructType> {
+        self.composite_type.as_struct()
+    }
+
+    #[inline]
+    pub fn unwrap_struct(&self) -> &WasmStructType {
+        self.composite_type.unwrap_struct()
+    }
+}
+
+impl fmt::Display for WasmSubType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_final && self.supertype.is_none() {
+            fmt::Display::fmt(&self.composite_type, f)
+        } else {
+            write!(f, "(sub")?;
+            if self.is_final {
+                write!(f, " final")?;
+            }
+            if let Some(sup) = self.supertype {
+                write!(f, " {sup:?}")?;
+            }
+            write!(f, " {})", self.composite_type)
+        }
+    }
+}
+
+impl TypeTrace for WasmSubType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        if let Some(sup) = self.supertype {
+            func(sup)?;
+        }
+        self.composite_type.trace(func)
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        if let Some(sup) = self.supertype.as_mut() {
+            func(sup)?;
+        }
+        self.composite_type.trace_mut(func)
+    }
+}
+
+// === impl WasmCompositeType ===
+
+impl WasmCompositeType {
+    pub(crate) fn new_func(shared: bool, ty: WasmFuncType) -> Self {
+        Self {
+            shared,
+            inner: WasmCompositeTypeInner::Func(ty),
+        }
+    }
+    pub(crate) fn new_array(shared: bool, ty: WasmArrayType) -> Self {
+        Self {
+            shared,
+            inner: WasmCompositeTypeInner::Array(ty),
+        }
+    }
+    pub(crate) fn new_struct(shared: bool, ty: WasmStructType) -> Self {
+        Self {
+            shared,
+            inner: WasmCompositeTypeInner::Struct(ty),
+        }
+    }
+    #[inline]
+    pub fn is_func(&self) -> bool {
+        self.inner.is_func()
+    }
+
+    #[inline]
+    pub fn as_func(&self) -> Option<&WasmFuncType> {
+        self.inner.as_func()
+    }
+
+    #[inline]
+    pub fn unwrap_func(&self) -> &WasmFuncType {
+        self.inner.unwrap_func()
+    }
+
+    #[inline]
+    pub fn is_array(&self) -> bool {
+        self.inner.is_array()
+    }
+
+    #[inline]
+    pub fn as_array(&self) -> Option<&WasmArrayType> {
+        self.inner.as_array()
+    }
+
+    #[inline]
+    pub fn unwrap_array(&self) -> &WasmArrayType {
+        self.inner.unwrap_array()
+    }
+
+    #[inline]
+    pub fn is_struct(&self) -> bool {
+        self.inner.is_struct()
+    }
+
+    #[inline]
+    pub fn as_struct(&self) -> Option<&WasmStructType> {
+        self.inner.as_struct()
+    }
+
+    #[inline]
+    pub fn unwrap_struct(&self) -> &WasmStructType {
+        self.inner.unwrap_struct()
+    }
+}
+
+impl fmt::Display for WasmCompositeType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.shared {
+            write!(f, "shared ")?;
+        }
+        match &self.inner {
+            WasmCompositeTypeInner::Func(ty) => fmt::Display::fmt(ty, f),
+            WasmCompositeTypeInner::Array(ty) => fmt::Display::fmt(ty, f),
+            WasmCompositeTypeInner::Struct(ty) => fmt::Display::fmt(ty, f),
+        }
+    }
+}
+
+impl TypeTrace for WasmCompositeType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        match self.inner {
+            WasmCompositeTypeInner::Func(ref inner) => inner.trace(func),
+            WasmCompositeTypeInner::Array(ref inner) => inner.trace(func),
+            WasmCompositeTypeInner::Struct(ref inner) => inner.trace(func),
+        }
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        match self.inner {
+            WasmCompositeTypeInner::Func(ref mut inner) => inner.trace_mut(func),
+            WasmCompositeTypeInner::Array(ref mut inner) => inner.trace_mut(func),
+            WasmCompositeTypeInner::Struct(ref mut inner) => inner.trace_mut(func),
+        }
+    }
+}
+
+impl WasmCompositeTypeInner {
+    enum_accessors! {
+        c
+        (Func(&WasmFuncType) is_func as_func unwrap_func c)
+        (Array(&WasmArrayType) is_array as_array unwrap_array c)
+        (Struct(&WasmStructType) is_struct as_struct unwrap_struct c)
+    }
+}
+
+// === impl WasmFuncType ===
+
+impl WasmFuncType {
+    /// Is this function type compatible with trampoline usage?
+    pub fn is_trampoline_type(&self) -> bool {
+        self.params.iter().all(|p| *p == p.trampoline_type())
+            && self.results.iter().all(|r| *r == r.trampoline_type())
+    }
+
+    /// Get the version of this function type that is suitable for usage as a
+    /// trampoline.
+    ///
+    /// If this function is suitable for trampoline usage as-is, then a borrowed
+    /// `Cow` is returned. If it must be tweaked for trampoline usage, then an
+    /// owned `Cow` is returned.
+    ///
+    /// ## What is a trampoline type?
+    ///
+    /// All reference types in parameters and results are mapped to their
+    /// nullable top type, e.g. `(ref $my_struct_type)` becomes `(ref null
+    /// any)`.
+    ///
+    /// This allows us to share trampolines between functions whose signatures
+    /// both map to the same trampoline type. It also allows the host to satisfy
+    /// a Wasm module's function import of type `S` with a function of type `T`
+    /// where `T <: S`, even when the Wasm module never defines the type `T`
+    /// (and might never even be able to!)
+    ///
+    /// The flip side is that this adds a constraint to our trampolines: they
+    /// can only pass references around (e.g. move a reference from one calling
+    /// convention's location to another's) and may not actually inspect the
+    /// references themselves (unless the trampolines start doing explicit,
+    /// fallible downcasts, but if we ever need that, then we might want to
+    /// redesign this stuff).
+    pub fn trampoline_type(&self) -> Cow<'_, Self> {
+        if self.is_trampoline_type() {
+            return Cow::Borrowed(self);
+        }
+
+        Cow::Owned(Self {
+            params: self.params.iter().map(|p| p.trampoline_type()).collect(),
+            results: self.results.iter().map(|r| r.trampoline_type()).collect(),
+        })
+    }
+}
+
+impl fmt::Display for WasmFuncType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(func")?;
+        if !self.params.is_empty() {
+            write!(f, " (param")?;
+            for p in &self.params {
+                write!(f, " {p}")?;
+            }
+            write!(f, ")")?;
+        }
+        if !self.results.is_empty() {
+            write!(f, " (result")?;
+            for r in &self.results {
+                write!(f, " {r}")?;
+            }
+            write!(f, ")")?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl TypeTrace for WasmFuncType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        for ty in &self.params {
+            ty.trace(func)?;
+        }
+        for ty in &self.results {
+            ty.trace(func)?;
+        }
+        Ok(())
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        for ty in &mut self.params {
+            ty.trace_mut(func)?;
+        }
+        for ty in &mut self.results {
+            ty.trace_mut(func)?;
+        }
+        Ok(())
+    }
+}
+
+// === impl WasmArrayType ===
+
+impl fmt::Display for WasmArrayType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(array {})", self.0)
+    }
+}
+
+impl TypeTrace for WasmArrayType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        self.0.trace(func)
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        self.0.trace_mut(func)
+    }
+}
+
+// === impl WasmStructType ===
+
+impl fmt::Display for WasmStructType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(struct")?;
+        for ty in &self.fields {
+            write!(f, " {ty}")?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl TypeTrace for WasmStructType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        for field in &self.fields {
+            field.trace(func)?;
+        }
+        Ok(())
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        for field in &mut self.fields {
+            field.trace_mut(func)?;
+        }
+        Ok(())
+    }
+}
+
+// === impl WasmFieldType ===
+
+impl fmt::Display for WasmFieldType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.mutable {
+            write!(f, "(mut {})", self.element_type)
+        } else {
+            fmt::Display::fmt(&self.element_type, f)
+        }
+    }
+}
+
+impl TypeTrace for WasmFieldType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        self.element_type.trace(func)
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        self.element_type.trace_mut(func)
+    }
+}
+
+// === impl WasmStorageType ===
+
+impl fmt::Display for WasmStorageType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WasmStorageType::I8 => write!(f, "i8"),
+            WasmStorageType::I16 => write!(f, "i16"),
+            WasmStorageType::Val(v) => fmt::Display::fmt(v, f),
+        }
+    }
+}
+
+impl TypeTrace for WasmStorageType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        if let Self::Val(val) = self {
+            val.trace(func)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        if let Self::Val(val) = self {
+            val.trace_mut(func)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// === impl WasmRecGroup ===
+
+impl TypeTrace for WasmRecGroup {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        for ty in &self.0 {
+            ty.trace(func)?;
+        }
+        Ok(())
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut CanonicalizedTypeIndex) -> Result<(), E>,
+    {
+        for ty in &mut self.0 {
+            ty.trace_mut(func)?;
+        }
+        Ok(())
+    }
+}
+
+// === impl WasmTableType ===
+
+impl WasmTableType {
+    /// Creates a new `TablePlan` for the given `wasmparser::TableType`.
+    pub fn from_wasmparser(
+        ty: wasmparser::TableType,
+        type_convert: &WasmparserTypeConverter,
+    ) -> Self {
+        Self {
+            element_type: type_convert.convert_ref_type(ty.element_type),
+            index_type: if ty.table64 {
+                WasmIndexType::I64
+            } else {
+                WasmIndexType::I32
+            },
+            limits: WasmLimits {
+                min: ty.initial,
+                max: ty.maximum,
+            },
+            shared: ty.shared,
+        }
+    }
+}
+
+// === impl WasmMemoryType ===
+
+impl WasmMemoryType {
+    /// WebAssembly page sizes are 64KiB by default.
+    pub const DEFAULT_PAGE_SIZE: u32 = 0x10000;
+
+    /// WebAssembly page sizes are 64KiB (or `2**16`) by default.
+    pub const DEFAULT_PAGE_SIZE_LOG2: u8 = {
+        let log2 = 16;
+        assert!(1 << log2 == Self::DEFAULT_PAGE_SIZE);
+        log2
+    };
+
+    /// Creates a new `MemoryPlan` for the given `wasmparser::MemoryType`.
+    pub fn from_wasmparser(ty: wasmparser::MemoryType) -> Self {
+        Self {
+            index_type: if ty.memory64 {
+                WasmIndexType::I64
+            } else {
+                WasmIndexType::I32
+            },
+            limits: WasmLimits {
+                min: ty.initial,
+                max: ty.maximum,
+            },
+            shared: ty.shared,
+            page_size_log2: ty
+                .page_size_log2
+                .map_or(Self::DEFAULT_PAGE_SIZE_LOG2, |log2| {
+                    u8::try_from(log2).unwrap()
+                }),
+            offset_guard_size: DEFAULT_OFFSET_GUARD_SIZE,
+        }
+    }
+
+    pub fn page_size(&self) -> u64 {
+        todo!()
+    }
+}


### PR DESCRIPTION
This PR moves the WebAssembly runtime out of the kernel crate into its own `kwasm` crate so testing, benchmarking, and verification becomes easier.