### PR TITLE
rustfmt `use` items

### DIFF
--- a/build/toml-patch/src/lib.rs
+++ b/build/toml-patch/src/lib.rs
@@ -19,9 +19,11 @@
 //! This crate exposes a single function [`merge_toml_documents`] which does
 //! this for you!
 
-use eyre::{Result, bail, eyre};
 use std::collections::BTreeMap;
-use toml_edit::{visit::Visit, visit_mut::VisitMut};
+
+use eyre::{Result, bail, eyre};
+use toml_edit::visit::Visit;
+use toml_edit::visit_mut::VisitMut;
 
 pub fn merge_toml_documents(
     original: &mut toml_edit::DocumentMut,
@@ -270,8 +272,9 @@ fn merge_toml_tables(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use indoc::indoc;
+
+    use super::*;
 
     fn patch_and_compare(a: &str, b: &str, out: &str) {
         let mut a: toml_edit::DocumentMut = a.parse().unwrap();

--- a/build/xtask/src/build.rs
+++ b/build/xtask/src/build.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use color_eyre::eyre::{Context, bail};
+use tracing_core::LevelFilter;
+
 use crate::Options;
 use crate::profile::{LogLevel, Profile, RustTarget};
 use crate::tracing::{ColorMode, OutputOptions};
 use crate::util::KillOnDrop;
-use color_eyre::eyre::{Context, bail};
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use tracing_core::LevelFilter;
 
 const DEFAULT_KERNEL_STACK_SIZE_PAGES: u32 = 256;
 

--- a/build/xtask/src/cmds/build.rs
+++ b/build/xtask/src/cmds/build.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
+
 use crate::Options;
 use crate::profile::Profile;
 use crate::tracing::OutputOptions;
-use clap::{Parser, ValueHint};
-use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {

--- a/build/xtask/src/cmds/dist.rs
+++ b/build/xtask/src/cmds/dist.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
+
 use crate::Options;
 use crate::profile::Profile;
 use crate::tracing::OutputOptions;
-use clap::{Parser, ValueHint};
-use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {

--- a/build/xtask/src/cmds/lldb.rs
+++ b/build/xtask/src/cmds/lldb.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::profile::Profile;
-use crate::tracing::OutputOptions;
-use crate::{Options, build, qemu};
-use clap::{Parser, ValueHint};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::{fs, thread};
+
+use clap::{Parser, ValueHint};
+
+use crate::profile::Profile;
+use crate::tracing::OutputOptions;
+use crate::{Options, build, qemu};
 
 #[derive(Debug, Parser)]
 pub struct Cmd {

--- a/build/xtask/src/cmds/qemu.rs
+++ b/build/xtask/src/cmds/qemu.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
+
 use crate::profile::Profile;
 use crate::tracing::OutputOptions;
 use crate::{Options, qemu};
-use clap::{Parser, ValueHint};
-use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {

--- a/build/xtask/src/cmds/run.rs
+++ b/build/xtask/src/cmds/run.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::path::PathBuf;
+
+use clap::{Parser, ValueHint};
+
 use crate::profile::Profile;
 use crate::tracing::OutputOptions;
 use crate::{Options, qemu};
-use clap::{Parser, ValueHint};
-use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {

--- a/build/xtask/src/cmds/test.rs
+++ b/build/xtask/src/cmds/test.rs
@@ -5,18 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::path::PathBuf;
+use std::process::ExitStatus;
+use std::time::Duration;
+
+use clap::{Parser, ValueHint};
+use color_eyre::Help;
+use color_eyre::eyre::{Context, format_err};
+use wait_timeout::ChildExt;
+
 use crate::build::{Cargo, CrateToBuild};
 use crate::profile::{Architecture, Profile};
 use crate::tracing::OutputOptions;
 use crate::util::KillOnDrop;
 use crate::{Options, qemu};
-use clap::{Parser, ValueHint};
-use color_eyre::Help;
-use color_eyre::eyre::{Context, format_err};
-use std::path::PathBuf;
-use std::process::ExitStatus;
-use std::time::Duration;
-use wait_timeout::ChildExt;
 
 #[derive(Debug, Parser)]
 pub struct Cmd {

--- a/build/xtask/src/main.rs
+++ b/build/xtask/src/main.rs
@@ -26,9 +26,10 @@ mod qemu;
 mod tracing;
 mod util;
 
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand, ValueHint};
 use color_eyre::eyre::Result;
-use std::path::PathBuf;
 #[derive(Debug, Parser)]
 struct Xtask {
     #[clap(subcommand)]

--- a/build/xtask/src/profile.rs
+++ b/build/xtask/src/profile.rs
@@ -7,12 +7,13 @@
 
 #![allow(unused)]
 
-use color_eyre::eyre::{Context, bail, eyre};
-use serde::Deserialize;
 use std::collections::BTreeSet;
 use std::fmt::{Display, Formatter};
 use std::hash::{DefaultHasher, Hasher};
 use std::path::{Path, PathBuf};
+
+use color_eyre::eyre::{Context, bail, eyre};
+use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]

--- a/build/xtask/src/qemu.rs
+++ b/build/xtask/src/qemu.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::profile::{Architecture, Profile};
-use crate::util::KillOnDrop;
-use clap::Parser;
 use std::path::Path;
 use std::process::{Command, Stdio};
+
+use clap::Parser;
+
+use crate::profile::{Architecture, Profile};
+use crate::util::KillOnDrop;
 
 #[derive(Debug, Parser)]
 pub struct QemuOptions {

--- a/build/xtask/src/tracing.rs
+++ b/build/xtask/src/tracing.rs
@@ -5,12 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::fmt;
+use std::io::IsTerminal;
+
 use clap::{ArgGroup, Args};
 use color_eyre::owo_colors;
 use color_eyre::owo_colors::{OwoColorize, Style, style};
 use heck::ToTitleCase;
-use std::fmt;
-use std::io::IsTerminal;
 use tracing_core::field::Visit;
 use tracing_core::{Collect, Event, Field, Level};
 use tracing_subscriber::fmt::format::Writer;

--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::mem::bootstrap_alloc::BootstrapAllocator;
-use crate::{INITIAL_HEAP_SIZE_PAGES, arch};
 use core::alloc::Layout;
 use core::range::Range;
+
 use loader_api::BootInfo;
 use talc::{ErrOnOom, Span, Talc, Talck};
+
+use crate::mem::bootstrap_alloc::BootstrapAllocator;
+use crate::{INITIAL_HEAP_SIZE_PAGES, arch};
 
 #[global_allocator]
 static KERNEL_ALLOCATOR: Talck<spin::Mutex<()>, ErrOnOom> = Talc::new(ErrOnOom).lock();

--- a/kernel/src/arch/riscv64/asid_allocator.rs
+++ b/kernel/src/arch/riscv64/asid_allocator.rs
@@ -8,6 +8,7 @@
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt;
+
 use riscv::satp;
 use spin::OnceLock;
 

--- a/kernel/src/arch/riscv64/block_on.rs
+++ b/kernel/src/arch/riscv64/block_on.rs
@@ -5,16 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::state;
 use alloc::sync::Arc;
 use core::arch::asm;
 use core::mem::ManuallyDrop;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
 use cpu_local::cpu_local;
 use futures::pin_mut;
 use futures::task::WakerRef;
 use riscv::sbi;
+
+use crate::state;
 
 struct HartNotify {
     hartid: usize,

--- a/kernel/src/arch/riscv64/device/clock.rs
+++ b/kernel/src/arch/riscv64/device/clock.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::device_tree::Device;
 use core::ptr;
 use core::time::Duration;
+
 use kasync::time::{Clock, NANOS_PER_SEC, RawClock, RawClockVTable};
 use riscv::sbi;
+
+use crate::device_tree::Device;
 
 static CLOCK_VTABLE: RawClockVTable =
     RawClockVTable::new(clone_raw, now_raw, schedule_wakeup_raw, drop_raw);

--- a/kernel/src/arch/riscv64/device/cpu.rs
+++ b/kernel/src/arch/riscv64/device/cpu.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch::device;
-use crate::device_tree::DeviceTree;
-use crate::irq::InterruptController;
-use bitflags::bitflags;
 use core::cell::RefCell;
 use core::fmt;
 use core::str::FromStr;
+
+use bitflags::bitflags;
+
+use crate::arch::device;
+use crate::device_tree::DeviceTree;
+use crate::irq::InterruptController;
 
 #[derive(Debug)]
 pub struct Cpu {

--- a/kernel/src/arch/riscv64/device/plic.rs
+++ b/kernel/src/arch/riscv64/device/plic.rs
@@ -5,13 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch::PAGE_SIZE;
-use crate::device_tree::{Device, DeviceTree, IrqSource};
-use crate::irq::{InterruptController, IrqClaim};
-use crate::mem::{
-    AddressRangeExt, AddressSpaceRegion, Permissions, PhysicalAddress, with_kernel_aspace,
-};
-use crate::util::either::Either;
 use alloc::string::ToString;
 use core::alloc::Layout;
 use core::mem::{MaybeUninit, offset_of};
@@ -19,8 +12,17 @@ use core::num::NonZero;
 use core::ops::{BitAnd, BitOr, Not};
 use core::ptr;
 use core::range::Range;
+
 use fallible_iterator::FallibleIterator;
 use static_assertions::const_assert_eq;
+
+use crate::arch::PAGE_SIZE;
+use crate::device_tree::{Device, DeviceTree, IrqSource};
+use crate::irq::{InterruptController, IrqClaim};
+use crate::mem::{
+    AddressRangeExt, AddressSpaceRegion, Permissions, PhysicalAddress, with_kernel_aspace,
+};
+use crate::util::either::Either;
 
 const MAX_CONTEXTS: usize = 64;
 

--- a/kernel/src/arch/riscv64/mem.rs
+++ b/kernel/src/arch/riscv64/mem.rs
@@ -5,20 +5,22 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch::{mb, wmb};
-use crate::mem::flush::Flush;
-use crate::mem::frame_alloc::{Frame, FrameAllocator};
-use crate::mem::{PhysicalAddress, VirtualAddress};
 use alloc::vec;
 use alloc::vec::Vec;
-use bitflags::bitflags;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::range::{Range, RangeInclusive};
 use core::{fmt, slice};
+
+use bitflags::bitflags;
 use riscv::satp;
 use riscv::sbi::rfence::sfence_vma_asid;
 use static_assertions::const_assert_eq;
+
+use crate::arch::{mb, wmb};
+use crate::mem::flush::Flush;
+use crate::mem::frame_alloc::{Frame, FrameAllocator};
+use crate::mem::{PhysicalAddress, VirtualAddress};
 
 pub const DEFAULT_ASID: u16 = 0;
 

--- a/kernel/src/arch/riscv64/mod.rs
+++ b/kernel/src/arch/riscv64/mod.rs
@@ -13,12 +13,7 @@ mod setjmp_longjmp;
 pub mod state;
 mod trap_handler;
 
-use crate::arch::device::cpu::Cpu;
-use crate::device_tree::DeviceTree;
-use crate::mem::VirtualAddress;
 use core::arch::asm;
-use riscv::sstatus::FS;
-use riscv::{interrupt, scounteren, sie, sstatus};
 
 pub use asid_allocator::AsidAllocator;
 pub use block_on::block_on;
@@ -26,7 +21,13 @@ pub use mem::{
     AddressSpace, CANONICAL_ADDRESS_MASK, DEFAULT_ASID, KERNEL_ASPACE_RANGE, PAGE_SHIFT, PAGE_SIZE,
     USER_ASPACE_RANGE, invalidate_range, is_kernel_address,
 };
+use riscv::sstatus::FS;
+use riscv::{interrupt, scounteren, sie, sstatus};
 pub use setjmp_longjmp::{JmpBuf, JmpBufStruct, call_with_setjmp, longjmp};
+
+use crate::arch::device::cpu::Cpu;
+use crate::device_tree::DeviceTree;
+use crate::mem::VirtualAddress;
 
 pub const STACK_ALIGNMENT: usize = 16;
 

--- a/kernel/src/arch/riscv64/setjmp_longjmp.rs
+++ b/kernel/src/arch/riscv64/setjmp_longjmp.rs
@@ -47,6 +47,7 @@ use core::arch::{asm, naked_asm};
 use core::marker::{PhantomData, PhantomPinned};
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr::addr_of_mut;
+
 use riscv::{load_fp, load_gp, save_fp, save_gp};
 
 /// A store for the register state used by `setjmp` and `longjmp`.

--- a/kernel/src/arch/riscv64/trap_handler.rs
+++ b/kernel/src/arch/riscv64/trap_handler.rs
@@ -5,19 +5,22 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use core::arch::{asm, naked_asm};
+use core::cell::Cell;
+
+use cpu_local::cpu_local;
+use riscv::scause::{Exception, Interrupt};
+use riscv::{
+    load_fp, load_gp, save_fp, save_gp, scause, sepc, sip, sscratch, sstatus, stval, stvec,
+};
+
 use crate::arch::PAGE_SIZE;
 use crate::arch::trap::Trap;
 use crate::backtrace::Backtrace;
 use crate::mem::VirtualAddress;
 use crate::state::{cpu_local, global};
 use crate::{TRAP_STACK_SIZE_PAGES, irq};
-use alloc::boxed::Box;
-use core::arch::{asm, naked_asm};
-use core::cell::Cell;
-use cpu_local::cpu_local;
-use riscv::scause::{Exception, Interrupt};
-use riscv::{load_fp, load_gp, save_fp, save_gp};
-use riscv::{scause, sepc, sip, sscratch, sstatus, stval, stvec};
 
 cpu_local! {
     static IN_TRAP: Cell<bool> = Cell::new(false);

--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -8,16 +8,18 @@
 mod print;
 mod symbolize;
 
-use crate::backtrace::print::BacktraceFmt;
-use crate::mem::VirtualAddress;
-use arrayvec::ArrayVec;
 use core::str::FromStr;
 use core::{fmt, slice};
+
+use arrayvec::ArrayVec;
 use fallible_iterator::FallibleIterator;
 use loader_api::BootInfo;
 use spin::OnceLock;
 use symbolize::SymbolizeContext;
 use unwind2::FrameIter;
+
+use crate::backtrace::print::BacktraceFmt;
+use crate::mem::VirtualAddress;
 
 static BACKTRACE_INFO: OnceLock<BacktraceInfo> = OnceLock::new();
 

--- a/kernel/src/backtrace/print.rs
+++ b/kernel/src/backtrace/print.rs
@@ -7,9 +7,10 @@
 
 //! Printing of backtraces. This is adapted from the standard library.
 
+use core::fmt;
+
 use crate::backtrace::BacktraceStyle;
 use crate::backtrace::symbolize::{Symbol, SymbolName};
-use core::fmt;
 
 const HEX_WIDTH: usize = 2 + 2 * size_of::<usize>();
 

--- a/kernel/src/backtrace/symbolize.rs
+++ b/kernel/src/backtrace/symbolize.rs
@@ -7,6 +7,7 @@
 
 use core::ffi::c_void;
 use core::{fmt, str};
+
 use fallible_iterator::FallibleIterator;
 use gimli::{EndianSlice, NativeEndian};
 use rustc_demangle::{Demangle, try_demangle};

--- a/kernel/src/bootargs.rs
+++ b/kernel/src/bootargs.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::str::FromStr;
+
 use crate::backtrace::BacktraceStyle;
 use crate::device_tree::DeviceTree;
 use crate::tracing::Filter;
-use core::str::FromStr;
 
 pub fn parse(devtree: &DeviceTree) -> crate::Result<Bootargs> {
     let chosen = devtree.find_by_path("/chosen").unwrap();

--- a/kernel/src/device_tree.rs
+++ b/kernel/src/device_tree.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use bumpalo::Bump;
 use core::ffi::CStr;
 use core::ptr::NonNull;
 use core::{fmt, iter, mem, slice};
+
+use bumpalo::Bump;
 use fallible_iterator::FallibleIterator;
 use fdt::{CellSizes, Error, Fdt, NodeName, StringList};
 use hashbrown::HashMap;

--- a/kernel/src/irq.rs
+++ b/kernel/src/irq.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::state::cpu_local;
 use alloc::sync::Arc;
 use core::num::NonZero;
+
 use hashbrown::HashMap;
 use kasync::sync::wait_queue::WaitQueue;
 use spin::{LazyLock, RwLock};
+
+use crate::state::cpu_local;
 
 pub trait InterruptController {
     fn irq_claim(&mut self) -> Option<IrqClaim>;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -42,24 +42,25 @@ mod tracing;
 mod util;
 mod wasm;
 
-use crate::backtrace::Backtrace;
-use crate::device_tree::DeviceTree;
-use crate::mem::bootstrap_alloc::BootstrapAllocator;
-use crate::state::{CpuLocal, Global};
-use abort::abort;
-use arrayvec::ArrayVec;
-use cfg_if::cfg_if;
 use core::range::Range;
 use core::slice;
 use core::time::Duration;
+
+use abort::abort;
+use arrayvec::ArrayVec;
+use cfg_if::cfg_if;
 use fastrand::FastRand;
 use kasync::executor::{Executor, Worker};
 use kasync::time::{Instant, Ticks, Timer};
 use loader_api::{BootInfo, LoaderConfig, MemoryRegionKind};
-use mem::PhysicalAddress;
-use mem::frame_alloc;
+use mem::{PhysicalAddress, frame_alloc};
 use rand::{RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
+
+use crate::backtrace::Backtrace;
+use crate::device_tree::DeviceTree;
+use crate::mem::bootstrap_alloc::BootstrapAllocator;
+use crate::state::{CpuLocal, Global};
 
 /// The size of the stack in pages
 pub const STACK_SIZE_PAGES: u32 = 256; // TODO find a lower more appropriate value

--- a/kernel/src/mem/address.rs
+++ b/kernel/src/mem/address.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
 use core::alloc::{Layout, LayoutError};
 use core::fmt;
 use core::range::Range;
+
+use crate::arch;
 
 macro_rules! address_impl {
     ($addr:ident) => {

--- a/kernel/src/mem/address_space.rs
+++ b/kernel/src/mem/address_space.rs
@@ -5,18 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::address_space_region::AddressSpaceRegion;
-use crate::mem::frame_alloc::FrameAllocator;
-use crate::mem::{
-    AddressRangeExt, ArchAddressSpace, Flush, PageFaultFlags, Permissions, PhysicalAddress,
-    VirtualAddress,
-};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use anyhow::{bail, ensure};
 use core::alloc::Layout;
 use core::fmt;
 use core::num::NonZeroUsize;
@@ -24,9 +16,19 @@ use core::ops::DerefMut;
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::range::{Bound, Range, RangeBounds, RangeInclusive};
+
+use anyhow::{bail, ensure};
 use rand::Rng;
 use rand::distr::Uniform;
 use rand_chacha::ChaCha20Rng;
+
+use crate::arch;
+use crate::mem::address_space_region::AddressSpaceRegion;
+use crate::mem::frame_alloc::FrameAllocator;
+use crate::mem::{
+    AddressRangeExt, ArchAddressSpace, Flush, PageFaultFlags, Permissions, PhysicalAddress,
+    VirtualAddress,
+};
 
 // const VIRT_ALLOC_ENTROPY: u8 = u8::try_from((arch::VIRT_ADDR_BITS - arch::PAGE_SHIFT as u32) + 1).unwrap();
 const VIRT_ALLOC_ENTROPY: u8 = 27;

--- a/kernel/src/mem/address_space_region.rs
+++ b/kernel/src/mem/address_space_region.rs
@@ -5,22 +5,24 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::address::VirtualAddress;
-use crate::mem::frame_alloc::FrameAllocator;
-use crate::mem::{AddressRangeExt, Batch, PageFaultFlags, Permissions, PhysicalAddress, Vmo};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::sync::Arc;
-use anyhow::bail;
 use core::cmp;
 use core::mem::offset_of;
 use core::num::NonZeroUsize;
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::range::Range;
+
+use anyhow::bail;
 use pin_project::pin_project;
 use spin::LazyLock;
+
+use crate::arch;
+use crate::mem::address::VirtualAddress;
+use crate::mem::frame_alloc::FrameAllocator;
+use crate::mem::{AddressRangeExt, Batch, PageFaultFlags, Permissions, PhysicalAddress, Vmo};
 
 /// A contiguous region of an address space
 #[pin_project]

--- a/kernel/src/mem/bootstrap_alloc.rs
+++ b/kernel/src/mem/bootstrap_alloc.rs
@@ -5,11 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::address::{AddressRangeExt, PhysicalAddress};
 use core::alloc::Layout;
 use core::range::Range;
 use core::{iter, ptr, slice};
+
+use crate::arch;
+use crate::mem::address::{AddressRangeExt, PhysicalAddress};
 
 pub struct BootstrapAllocator<'a> {
     regions: &'a [Range<PhysicalAddress>],

--- a/kernel/src/mem/flush.rs
+++ b/kernel/src/mem/flush.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::address::VirtualAddress;
-use anyhow::bail;
 use core::range::Range;
 use core::{cmp, mem};
+
+use anyhow::bail;
+
+use crate::arch;
+use crate::mem::address::VirtualAddress;
 
 #[must_use]
 pub struct Flush {

--- a/kernel/src/mem/frame_alloc/arena.rs
+++ b/kernel/src/mem/frame_alloc/arena.rs
@@ -5,17 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::frame::FrameInfo;
-use crate::arch;
-use crate::mem::address::{AddressRangeExt, PhysicalAddress, VirtualAddress};
-use cordyceps::List;
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use core::range::Range;
 use core::{cmp, fmt, mem, slice};
+
+use cordyceps::List;
 use fallible_iterator::FallibleIterator;
 use smallvec::SmallVec;
+
+use super::frame::FrameInfo;
+use crate::arch;
+use crate::mem::address::{AddressRangeExt, PhysicalAddress, VirtualAddress};
 
 const ARENA_PAGE_BOOKKEEPING_SIZE: usize = size_of::<FrameInfo>();
 const MAX_WASTED_ARENA_BYTES: usize = 0x8_4000; // 528 KiB

--- a/kernel/src/mem/frame_alloc/frame.rs
+++ b/kernel/src/mem/frame_alloc/frame.rs
@@ -5,12 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::address::{PhysicalAddress, VirtualAddress};
-use crate::mem::frame_alloc::FRAME_ALLOC;
 use alloc::slice;
-use cordyceps::Linked;
-use cordyceps::list;
 use core::marker::PhantomData;
 use core::mem::offset_of;
 use core::ops::Deref;
@@ -18,7 +13,13 @@ use core::ptr::NonNull;
 use core::sync::atomic;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{fmt, ptr};
+
+use cordyceps::{Linked, list};
 use static_assertions::assert_impl_all;
+
+use crate::arch;
+use crate::mem::address::{PhysicalAddress, VirtualAddress};
+use crate::mem::frame_alloc::FRAME_ALLOC;
 
 /// Soft limit on the amount of references that may be made to a `Frame`.
 const MAX_REFCOUNT: usize = isize::MAX as usize;

--- a/kernel/src/mem/frame_alloc/frame_list.rs
+++ b/kernel/src/mem/frame_alloc/frame_list.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::frame_alloc::Frame;
 use alloc::boxed::Box;
 use core::fmt::Formatter;
 use core::iter::{FlatMap, Flatten, FusedIterator};
@@ -14,8 +12,12 @@ use core::mem::offset_of;
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::{array, fmt};
+
 use pin_project::pin_project;
 use wavltree::WAVLTree;
+
+use crate::arch;
+use crate::mem::frame_alloc::Frame;
 
 const FRAME_LIST_NODE_FANOUT: usize = 16;
 

--- a/kernel/src/mem/frame_alloc/mod.rs
+++ b/kernel/src/mem/frame_alloc/mod.rs
@@ -9,25 +9,25 @@ mod arena;
 mod frame;
 pub mod frame_list;
 
-use crate::arch;
-use crate::mem::bootstrap_alloc::BootstrapAllocator;
-use crate::mem::{PhysicalAddress, VirtualAddress};
 use alloc::vec::Vec;
-use arena::Arena;
-use arena::select_arenas;
-use cordyceps::list::List;
 use core::alloc::Layout;
 use core::cell::RefCell;
 use core::ptr::NonNull;
 use core::range::Range;
 use core::sync::atomic::AtomicUsize;
 use core::{cmp, fmt, iter, slice};
+
+use arena::{Arena, select_arenas};
+use cordyceps::list::List;
 use cpu_local::collection::CpuLocal;
 use fallible_iterator::FallibleIterator;
+pub use frame::{Frame, FrameInfo};
 use spin::{Mutex, OnceLock};
 
+use crate::arch;
+use crate::mem::bootstrap_alloc::BootstrapAllocator;
 use crate::mem::frame_alloc::frame_list::FrameList;
-pub use frame::{Frame, FrameInfo};
+use crate::mem::{PhysicalAddress, VirtualAddress};
 
 pub static FRAME_ALLOC: OnceLock<FrameAllocator> = OnceLock::new();
 pub fn init(

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -5,19 +5,21 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::address::AddressRangeExt;
-use crate::mem::{
-    AddressSpace, AddressSpaceRegion, ArchAddressSpace, Batch, Permissions, PhysicalAddress,
-    VirtualAddress,
-};
 use alloc::string::String;
 use alloc::sync::Arc;
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
 use core::range::Range;
 use core::{ptr, slice};
+
 use spin::Mutex;
+
+use crate::arch;
+use crate::mem::address::AddressRangeExt;
+use crate::mem::{
+    AddressSpace, AddressSpaceRegion, ArchAddressSpace, Batch, Permissions, PhysicalAddress,
+    VirtualAddress,
+};
 
 /// A memory mapping.
 ///

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -16,27 +16,28 @@ mod provider;
 mod trap_handler;
 mod vmo;
 
-use crate::arch;
-use crate::mem::frame_alloc::FrameAllocator;
 use alloc::format;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use core::num::NonZeroUsize;
 use core::range::Range;
 use core::{fmt, slice};
-use loader_api::BootInfo;
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
-use spin::{Mutex, OnceLock};
-use xmas_elf::program::Type;
 
 pub use address::{AddressRangeExt, PhysicalAddress, VirtualAddress};
 pub use address_space::{AddressSpace, Batch};
 pub use address_space_region::AddressSpaceRegion;
 pub use flush::Flush;
+use loader_api::BootInfo;
 pub use mmap::Mmap;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use spin::{Mutex, OnceLock};
 pub use trap_handler::handle_page_fault;
 pub use vmo::Vmo;
+use xmas_elf::program::Type;
+
+use crate::arch;
+use crate::mem::frame_alloc::FrameAllocator;
 
 pub const KIB: usize = 1024;
 pub const MIB: usize = KIB * 1024;

--- a/kernel/src/mem/provider.rs
+++ b/kernel/src/mem/provider.rs
@@ -5,15 +5,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::frame_alloc::{FRAME_ALLOC, FrameAllocator};
-use crate::mem::frame_alloc::{Frame, frame_list::FrameList};
 use alloc::sync::Arc;
 use core::alloc::Layout;
 use core::fmt::Debug;
 use core::iter;
 use core::num::NonZeroUsize;
+
 use spin::{LazyLock, OnceLock};
+
+use crate::arch;
+use crate::mem::frame_alloc::frame_list::FrameList;
+use crate::mem::frame_alloc::{FRAME_ALLOC, Frame, FrameAllocator};
 
 pub trait Provider: Debug {
     // TODO make async

--- a/kernel/src/mem/trap_handler.rs
+++ b/kernel/src/mem/trap_handler.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ops::ControlFlow;
+
 use crate::arch::trap::Trap;
 use crate::mem::VirtualAddress;
 use crate::state::global;
-use core::ops::ControlFlow;
 
 pub fn handle_page_fault(_trap: Trap, _tval: VirtualAddress) -> ControlFlow<()> {
     let current_task = global()

--- a/kernel/src/mem/vmo.rs
+++ b/kernel/src/mem/vmo.rs
@@ -5,20 +5,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::frame_alloc::FrameAllocator;
-use crate::mem::provider::{Provider, THE_ZERO_FRAME};
-use crate::mem::{
-    AddressRangeExt, PhysicalAddress,
-    frame_alloc::{
-        Frame,
-        frame_list::{Entry, FrameList},
-    },
-};
 use alloc::sync::Arc;
-use anyhow::ensure;
 use core::range::Range;
+
+use anyhow::ensure;
 use spin::RwLock;
+
+use crate::arch;
+use crate::mem::frame_alloc::frame_list::{Entry, FrameList};
+use crate::mem::frame_alloc::{Frame, FrameAllocator};
+use crate::mem::provider::{Provider, THE_ZERO_FRAME};
+use crate::mem::{AddressRangeExt, PhysicalAddress};
 
 #[derive(Debug)]
 pub enum Vmo {

--- a/kernel/src/metrics.rs
+++ b/kernel/src/metrics.rs
@@ -26,6 +26,7 @@
 //! cpus.
 
 use core::sync::atomic::{AtomicU64, Ordering};
+
 use cpu_local::collection::CpuLocal;
 
 /// Declares a new counter.

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -15,19 +15,21 @@ const S: &str = r#"
 /_/\_\/____/____/
 "#;
 
-use crate::device_tree::DeviceTree;
-use crate::mem::{Mmap, PhysicalAddress, with_kernel_aspace};
-use crate::state::global;
-use crate::{arch, irq};
 use alloc::string::{String, ToString};
 use core::fmt;
 use core::fmt::Write;
 use core::ops::DerefMut;
 use core::range::Range;
 use core::str::FromStr;
+
 use fallible_iterator::FallibleIterator;
 use kasync::executor::Executor;
 use spin::{Barrier, OnceLock};
+
+use crate::device_tree::DeviceTree;
+use crate::mem::{Mmap, PhysicalAddress, with_kernel_aspace};
+use crate::state::global;
+use crate::{arch, irq};
 
 static COMMANDS: &[Command] = &[PANIC, FAULT, VERSION, SHUTDOWN];
 

--- a/kernel/src/state.rs
+++ b/kernel/src/state.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::device_tree::DeviceTree;
 use core::cell::OnceCell;
+
 use cpu_local::cpu_local;
 use kasync::executor::Executor;
 use kasync::time::{Instant, Timer};
 use loader_api::BootInfo;
 use spin::OnceLock;
+
+use crate::arch;
+use crate::device_tree::DeviceTree;
 
 static GLOBAL: OnceLock<Global> = OnceLock::new();
 

--- a/kernel/src/tests/mod.rs
+++ b/kernel/src/tests/mod.rs
@@ -11,18 +11,20 @@ mod smoke;
 mod spectest;
 mod wast;
 
-use crate::tests::args::Arguments;
-use crate::tests::printer::Printer;
-use crate::{arch, state};
 use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::any::Any;
 use core::ptr::addr_of;
 use core::sync::atomic::{AtomicU64, Ordering};
 use core::{hint, slice};
+
 use futures::FutureExt;
 use futures::future::try_join_all;
 use ktest::Test;
+
+use crate::tests::args::Arguments;
+use crate::tests::printer::Printer;
+use crate::{arch, state};
 
 /// The outcome of performing a single test.
 pub enum Outcome {

--- a/kernel/src/tests/printer.rs
+++ b/kernel/src/tests/printer.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::args::FormatSetting;
-use super::{Conclusion, Outcome};
 use alloc::boxed::Box;
 use core::sync::atomic::Ordering;
+
 use ktest::{Test, TestInfo};
+
+use super::args::FormatSetting;
+use super::{Conclusion, Outcome};
 
 pub struct Printer {
     format: FormatSetting,

--- a/kernel/src/tests/wast.rs
+++ b/kernel/src/tests/wast.rs
@@ -5,16 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::{
-    ConstExprEvaluator, Engine, Extern, Instance, Linker, Module, PlaceholderAllocatorDontUse,
-    Store, Val,
-};
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use alloc::{format, vec};
-use anyhow::{Context, anyhow, bail};
 use core::fmt::{Display, LowerHex};
+
+use anyhow::{Context, anyhow, bail};
 use spin::Mutex;
 use wasmparser::Validator;
 use wast::core::{EncodeOptions, NanPattern, V128Pattern, WastArgCore, WastRetCore};
@@ -22,6 +19,11 @@ use wast::parser::ParseBuffer;
 use wast::token::{F32, F64};
 use wast::{
     Error, QuoteWat, Wast, WastArg, WastDirective, WastExecute, WastInvoke, WastRet, Wat, parser,
+};
+
+use crate::wasm::{
+    ConstExprEvaluator, Engine, Extern, Instance, Linker, Module, PlaceholderAllocatorDontUse,
+    Store, Val,
 };
 
 macro_rules! wast_tests {

--- a/kernel/src/tracing/filter.rs
+++ b/kernel/src/tracing/filter.rs
@@ -12,6 +12,7 @@ use core::cmp::Ordering;
 use core::fmt;
 use core::fmt::Formatter;
 use core::str::FromStr;
+
 use fallible_iterator::{FallibleIterator, IteratorExt};
 use smallvec::SmallVec;
 use tracing::level_filters::STATIC_MAX_LEVEL;

--- a/kernel/src/tracing/mod.rs
+++ b/kernel/src/tracing/mod.rs
@@ -11,13 +11,12 @@ mod log;
 mod registry;
 mod writer;
 
-use crate::state::try_global;
-use crate::tracing::writer::{MakeWriter, Semihosting};
-pub use ::tracing::*;
-use color::{Color, SetColor};
 use core::cell::{Cell, OnceCell};
 use core::fmt;
 use core::fmt::Write;
+
+pub use ::tracing::*;
+use color::{Color, SetColor};
 use cpu_local::cpu_local;
 pub use filter::Filter;
 use registry::Registry;
@@ -25,6 +24,9 @@ use spin::OnceLock;
 use tracing::field;
 use tracing_core::span::{Attributes, Current, Id, Record};
 use tracing_core::{Collect, Dispatch, Event, Interest, Level, LevelFilter, Metadata};
+
+use crate::state::try_global;
+use crate::tracing::writer::{MakeWriter, Semihosting};
 
 static SUBSCRIBER: OnceLock<Subscriber> = OnceLock::new();
 

--- a/kernel/src/tracing/registry.rs
+++ b/kernel/src/tracing/registry.rs
@@ -9,6 +9,7 @@ use alloc::vec::Vec;
 use core::cell::RefCell;
 use core::sync::atomic;
 use core::sync::atomic::{AtomicUsize, Ordering};
+
 use cpu_local::collection::CpuLocal;
 use ksharded_slab::Pool;
 use ksharded_slab::pool::Ref;

--- a/kernel/src/tracing/writer.rs
+++ b/kernel/src/tracing/writer.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::tracing::color::{AnsiEscapes, Color, SetColor};
 use core::cell::UnsafeCell;
 use core::fmt::{Arguments, Write};
 use core::{cmp, fmt};
+
 use spin::{ReentrantMutex, ReentrantMutexGuard};
 use tracing_core::Metadata;
+
+use crate::tracing::color::{AnsiEscapes, Color, SetColor};
 
 pub trait MakeWriter<'a> {
     type Writer: fmt::Write;

--- a/kernel/src/wasm/code_registry.rs
+++ b/kernel/src/wasm/code_registry.rs
@@ -5,10 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::vm::CodeObject;
 use alloc::collections::BTreeMap;
 use alloc::sync::Arc;
+
 use spin::{OnceLock, RwLock};
+
+use crate::wasm::vm::CodeObject;
 
 fn global_code() -> &'static RwLock<GlobalRegistry> {
     static GLOBAL_CODE: OnceLock<RwLock<GlobalRegistry>> = OnceLock::new();

--- a/kernel/src/wasm/compile/compiled_function.rs
+++ b/kernel/src/wasm/compile/compiled_function.rs
@@ -5,16 +5,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::builtins::BuiltinFunctionIndex;
-use crate::wasm::compile::{FilePos, NS_BUILTIN, NS_WASM_FUNC};
-use crate::wasm::indices::FuncIndex;
-use crate::wasm::trap::TrapKind;
 use cranelift_codegen::ir::{ExternalName, StackSlots, UserExternalName, UserExternalNameRef};
 use cranelift_codegen::{
     Final, FinalizedMachReloc, FinalizedRelocTarget, MachBufferFinalized, ValueLabelsRanges,
     binemit,
 };
 use cranelift_entity::PrimaryMap;
+
+use crate::wasm::builtins::BuiltinFunctionIndex;
+use crate::wasm::compile::{FilePos, NS_BUILTIN, NS_WASM_FUNC};
+use crate::wasm::indices::FuncIndex;
+use crate::wasm::trap::TrapKind;
 
 #[derive(Debug)]
 pub struct CompiledFunction {

--- a/kernel/src/wasm/compile/mod.rs
+++ b/kernel/src/wasm/compile/mod.rs
@@ -8,6 +8,18 @@
 mod compile_key;
 mod compiled_function;
 
+use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use compile_key::CompileKey;
+pub use compiled_function::CompiledFunction;
+use cranelift_codegen::control::ControlPlane;
+use cranelift_entity::{EntitySet, PrimaryMap};
+use hashbrown::HashSet;
+
 use crate::wasm::Engine;
 use crate::wasm::builtins::BuiltinFunctionIndex;
 use crate::wasm::compile::compiled_function::{RelocationTarget, TrapInfo};
@@ -17,16 +29,6 @@ use crate::wasm::translate::{
 };
 use crate::wasm::trap::TrapKind;
 use crate::wasm::vm::{CodeObject, MmapVec};
-use alloc::boxed::Box;
-use alloc::collections::BTreeMap;
-use alloc::format;
-use alloc::string::String;
-use alloc::vec::Vec;
-use compile_key::CompileKey;
-pub use compiled_function::CompiledFunction;
-use cranelift_codegen::control::ControlPlane;
-use cranelift_entity::{EntitySet, PrimaryMap};
-use hashbrown::HashSet;
 
 /// Namespace corresponding to wasm functions, the index is the index of the
 /// defined function that's being referenced.

--- a/kernel/src/wasm/cranelift/builtins.rs
+++ b/kernel/src/wasm/cranelift/builtins.rs
@@ -7,12 +7,14 @@
 
 #![expect(unused, reason = "TODO")]
 
-use crate::wasm::builtins::{BuiltinFunctionIndex, foreach_builtin_function};
-use crate::wasm::compile::NS_BUILTIN;
 use alloc::vec;
+
 use cranelift_codegen::ir::{self, AbiParam, ArgumentPurpose, Function, Signature, Type, types};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
 use cranelift_entity::EntityRef;
+
+use crate::wasm::builtins::{BuiltinFunctionIndex, foreach_builtin_function};
+use crate::wasm::compile::NS_BUILTIN;
 
 pub struct BuiltinFunctions {
     types: BuiltinFunctionSignatures,

--- a/kernel/src/wasm/cranelift/compiler.rs
+++ b/kernel/src/wasm/cranelift/compiler.rs
@@ -5,6 +5,26 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::fmt::Formatter;
+use core::{cmp, fmt, mem};
+
+use anyhow::anyhow;
+use cranelift_codegen::control::ControlPlane;
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::immediates::Offset32;
+use cranelift_codegen::ir::{
+    Endianness, GlobalValueData, InstBuilder, MemFlags, Signature, Type, UserExternalName,
+    UserFuncName, Value,
+};
+use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
+use cranelift_codegen::{TextSectionBuilder, ir};
+use cranelift_frontend::FunctionBuilder;
+use spin::Mutex;
+use target_lexicon::Triple;
+use wasmparser::{FuncValidatorAllocations, FunctionBody};
+
 use crate::arch;
 use crate::wasm::builtins::BuiltinFunctionIndex;
 use crate::wasm::compile::{CompiledFunction, Compiler, FilePos, NS_WASM_FUNC};
@@ -20,22 +40,6 @@ use crate::wasm::utils::{array_call_signature, u32_offset_of, value_type, wasm_c
 use crate::wasm::vm::{
     StaticVMShape, VMArrayCallHostFuncContext, VMCONTEXT_MAGIC, VMFuncRef, VMStoreContext,
 };
-use alloc::boxed::Box;
-use alloc::vec::Vec;
-use anyhow::anyhow;
-use core::fmt::Formatter;
-use core::{cmp, fmt, mem};
-use cranelift_codegen::control::ControlPlane;
-use cranelift_codegen::ir::condcodes::IntCC;
-use cranelift_codegen::ir::immediates::Offset32;
-use cranelift_codegen::ir::{Endianness, InstBuilder, Type, Value};
-use cranelift_codegen::ir::{GlobalValueData, MemFlags, Signature, UserExternalName, UserFuncName};
-use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
-use cranelift_codegen::{TextSectionBuilder, ir};
-use cranelift_frontend::FunctionBuilder;
-use spin::Mutex;
-use target_lexicon::Triple;
-use wasmparser::{FuncValidatorAllocations, FunctionBody};
 
 pub struct CraneliftCompiler {
     isa: OwnedTargetIsa,

--- a/kernel/src/wasm/cranelift/env.rs
+++ b/kernel/src/wasm/cranelift/env.rs
@@ -7,6 +7,25 @@
 
 #![expect(unused, reason = "this module has a number of method stubs")]
 
+use alloc::vec;
+use alloc::vec::Vec;
+use core::cmp;
+use core::mem::offset_of;
+
+use cranelift_codegen::cursor::FuncCursor;
+use cranelift_codegen::ir;
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::immediates::Offset32;
+use cranelift_codegen::ir::types::{I32, I64};
+use cranelift_codegen::ir::{
+    ArgumentPurpose, ExtFuncData, ExternalName, FuncRef, Function, GlobalValue, GlobalValueData,
+    Inst, InstBuilder, MemFlags, MemoryType, SigRef, Signature, TrapCode, Type, UserExternalName,
+    Value,
+};
+use cranelift_codegen::isa::TargetIsa;
+use cranelift_frontend::FunctionBuilder;
+use smallvec::SmallVec;
+
 use crate::wasm::compile::NS_WASM_FUNC;
 use crate::wasm::cranelift::builtins::BuiltinFunctions;
 use crate::wasm::cranelift::code_translator::Reachability;
@@ -29,23 +48,6 @@ use crate::wasm::vm::{
     StaticVMShape, VMFuncRef, VMFunctionImport, VMGlobalImport, VMMemoryDefinition, VMMemoryImport,
     VMShape, VMTableDefinition, VMTableImport,
 };
-use alloc::vec;
-use alloc::vec::Vec;
-use core::cmp;
-use core::mem::offset_of;
-use cranelift_codegen::cursor::FuncCursor;
-use cranelift_codegen::ir;
-use cranelift_codegen::ir::condcodes::IntCC;
-use cranelift_codegen::ir::immediates::Offset32;
-use cranelift_codegen::ir::types::{I32, I64};
-use cranelift_codegen::ir::{
-    ArgumentPurpose, ExtFuncData, ExternalName, FuncRef, GlobalValue, GlobalValueData, Inst,
-    MemFlags, MemoryType, SigRef, Signature, TrapCode, Type, UserExternalName, Value,
-};
-use cranelift_codegen::ir::{Function, InstBuilder};
-use cranelift_codegen::isa::TargetIsa;
-use cranelift_frontend::FunctionBuilder;
-use smallvec::SmallVec;
 
 /// A smallvec that holds the IR values for a struct's fields.
 pub type StructFieldsVec = SmallVec<[Value; 4]>;

--- a/kernel/src/wasm/cranelift/func_translator.rs
+++ b/kernel/src/wasm/cranelift/func_translator.rs
@@ -5,15 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::cranelift::code_translator::{bitcast_wasm_returns, translate_operator};
-use crate::wasm::cranelift::env::TranslationEnvironment;
-use crate::wasm::cranelift::state::FuncTranslationState;
-use crate::wasm::cranelift::utils::get_vmctx_value_label;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{InstBuilder, ValueLabel};
 use cranelift_entity::EntityRef;
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
 use wasmparser::{BinaryReader, FuncValidator, FunctionBody, WasmModuleResources};
+
+use crate::wasm::cranelift::code_translator::{bitcast_wasm_returns, translate_operator};
+use crate::wasm::cranelift::env::TranslationEnvironment;
+use crate::wasm::cranelift::state::FuncTranslationState;
+use crate::wasm::cranelift::utils::get_vmctx_value_label;
 
 pub struct FuncTranslator {
     func_ctx: FunctionBuilderContext,

--- a/kernel/src/wasm/cranelift/memory.rs
+++ b/kernel/src/wasm/cranelift/memory.rs
@@ -5,18 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use cranelift_codegen::cursor::{Cursor, FuncCursor};
+use cranelift_codegen::ir;
+use cranelift_codegen::ir::condcodes::IntCC;
+use cranelift_codegen::ir::{
+    Expr, Fact, InstBuilder, MemFlags, RelSourceLoc, TrapCode, Type, Value,
+};
+use cranelift_frontend::FunctionBuilder;
+use wasmparser::MemArg;
+
 use crate::wasm::cranelift::code_translator::Reachability;
 use crate::wasm::cranelift::env::TranslationEnvironment;
 use crate::wasm::cranelift::utils::index_type_to_ir_type;
 use crate::wasm::translate::IndexType;
 use crate::wasm::trap::TRAP_HEAP_MISALIGNED;
-use cranelift_codegen::cursor::{Cursor, FuncCursor};
-use cranelift_codegen::ir;
-use cranelift_codegen::ir::InstBuilder;
-use cranelift_codegen::ir::condcodes::IntCC;
-use cranelift_codegen::ir::{Expr, Fact, MemFlags, RelSourceLoc, TrapCode, Type, Value};
-use cranelift_frontend::FunctionBuilder;
-use wasmparser::MemArg;
 
 #[derive(Debug, Clone)]
 pub struct CraneliftMemory {

--- a/kernel/src/wasm/cranelift/mod.rs
+++ b/kernel/src/wasm/cranelift/mod.rs
@@ -14,13 +14,14 @@ mod memory;
 mod state;
 mod utils;
 
-use crate::wasm::trap::TRAP_TABLE_OUT_OF_BOUNDS;
 pub use compiler::CraneliftCompiler;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::immediates::Imm64;
 use cranelift_codegen::ir::{InstBuilder, MemFlags};
 use cranelift_frontend::FunctionBuilder;
+
+use crate::wasm::trap::TRAP_TABLE_OUT_OF_BOUNDS;
 
 /// The value of a WebAssembly global variable.
 #[derive(Clone, Copy)]

--- a/kernel/src/wasm/cranelift/state.rs
+++ b/kernel/src/wasm/cranelift/state.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::vec::Vec;
+
+use cranelift_codegen::ir;
+use cranelift_codegen::ir::{Block, FuncRef, Function, Inst, SigRef, Value};
+use hashbrown::HashMap;
+
 use crate::wasm::cranelift::env::TranslationEnvironment;
 use crate::wasm::cranelift::memory::CraneliftMemory;
 use crate::wasm::cranelift::{CraneliftGlobal, CraneliftTable};
 use crate::wasm::indices::{FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex};
-use alloc::vec::Vec;
-use cranelift_codegen::ir;
-use cranelift_codegen::ir::{Block, FuncRef, Function, Inst, SigRef, Value};
-use hashbrown::HashMap;
 
 pub struct FuncTranslationState {
     /// A stack of values corresponding to the active values in the input wasm function at this

--- a/kernel/src/wasm/cranelift/utils.rs
+++ b/kernel/src/wasm/cranelift/utils.rs
@@ -5,12 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::cranelift::env::TranslationEnvironment;
-use crate::wasm::translate::IndexType;
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::types;
 use cranelift_frontend::FunctionBuilder;
 use wasmparser::{FuncValidator, WasmModuleResources};
+
+use crate::wasm::cranelift::env::TranslationEnvironment;
+use crate::wasm::translate::IndexType;
 
 /// Get the parameter and result types for the given Wasm blocktype.
 pub fn blocktype_params_results<T>(

--- a/kernel/src/wasm/engine.rs
+++ b/kernel/src/wasm/engine.rs
@@ -5,16 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::wasm::compile::Compiler;
-use crate::wasm::cranelift::CraneliftCompiler;
-use crate::wasm::type_registry::TypeRegistry;
 use alloc::sync::Arc;
 use core::sync::atomic::AtomicU64;
+
 use cranelift_codegen::settings::{Configurable, Flags};
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use spin::{Mutex, MutexGuard};
+
+use crate::arch;
+use crate::wasm::compile::Compiler;
+use crate::wasm::cranelift::CraneliftCompiler;
+use crate::wasm::type_registry::TypeRegistry;
 
 /// Global context for the runtime.
 ///

--- a/kernel/src/wasm/func/host.rs
+++ b/kernel/src/wasm/func/host.rs
@@ -5,6 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::mem::MaybeUninit;
+use core::ptr::NonNull;
+use core::{iter, ptr};
+
+use anyhow::bail;
+
 use crate::wasm::func::typed::WasmTy;
 use crate::wasm::func::{FuncData, FuncKind};
 use crate::wasm::store::{StoreInner, StoreOpaque};
@@ -13,12 +21,6 @@ use crate::wasm::vm::{
     InstanceAndStore, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMOpaqueContext, VMVal,
 };
 use crate::wasm::{Engine, Func};
-use alloc::boxed::Box;
-use alloc::sync::Arc;
-use anyhow::bail;
-use core::mem::MaybeUninit;
-use core::ptr::NonNull;
-use core::{iter, ptr};
 
 #[derive(Debug)]
 pub struct HostFunc {

--- a/kernel/src/wasm/func/mod.rs
+++ b/kernel/src/wasm/func/mod.rs
@@ -8,6 +8,16 @@
 mod host;
 mod typed;
 
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::ffi::c_void;
+use core::mem;
+use core::ptr::NonNull;
+
+use anyhow::ensure;
+pub use host::{HostFunc, IntoFunc};
+pub use typed::{TypedFunc, WasmParams, WasmResults, WasmTy};
+
 use crate::arch;
 use crate::mem::VirtualAddress;
 use crate::util::zip_eq::IteratorExt;
@@ -21,14 +31,6 @@ use crate::wasm::vm::{
     VMVal, VmPtr,
 };
 use crate::wasm::{MAX_WASM_STACK, Module, Store};
-use alloc::boxed::Box;
-use alloc::sync::Arc;
-use anyhow::ensure;
-use core::ffi::c_void;
-use core::mem;
-use core::ptr::NonNull;
-pub use host::{HostFunc, IntoFunc};
-pub use typed::{TypedFunc, WasmParams, WasmResults, WasmTy};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Func(pub(super) Stored<FuncData>);

--- a/kernel/src/wasm/func/typed.rs
+++ b/kernel/src/wasm/func/typed.rs
@@ -5,17 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::func::do_call;
-use crate::wasm::store::StoreOpaque;
-use crate::wasm::types::{FuncType, HeapType, RefType, ValType};
-use crate::wasm::vm::VMVal;
-use crate::wasm::{Engine, Func};
 use core::ffi::c_void;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use core::ptr;
 use core::ptr::NonNull;
+
 use static_assertions::assert_impl_all;
+
+use crate::wasm::func::do_call;
+use crate::wasm::store::StoreOpaque;
+use crate::wasm::types::{FuncType, HeapType, RefType, ValType};
+use crate::wasm::vm::VMVal;
+use crate::wasm::{Engine, Func};
 
 pub struct TypedFunc<Params, Results> {
     ty: FuncType,

--- a/kernel/src/wasm/global.rs
+++ b/kernel/src/wasm/global.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ptr;
+use core::ptr::NonNull;
+
+use anyhow::{Context, bail};
+
 use crate::wasm::Func;
 use crate::wasm::store::{StoreOpaque, Stored};
 use crate::wasm::types::{GlobalType, HeapTypeInner, Mutability, ValType};
 use crate::wasm::values::{Ref, Val};
 use crate::wasm::vm::{ExportedGlobal, VMGlobalDefinition, VMGlobalImport, VmPtr};
-use anyhow::{Context, bail};
-use core::ptr;
-use core::ptr::NonNull;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Global(Stored<ExportedGlobal>);

--- a/kernel/src/wasm/indices.rs
+++ b/kernel/src/wasm/indices.rs
@@ -5,8 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::utils::enum_accessors;
 use cranelift_entity::entity_impl;
+
+use crate::wasm::utils::enum_accessors;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TypeIndex(u32);

--- a/kernel/src/wasm/instance.rs
+++ b/kernel/src/wasm/instance.rs
@@ -5,14 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::util::zip_eq::IteratorExt;
 use crate::wasm::indices::EntityIndex;
 use crate::wasm::module::Module;
 use crate::wasm::store::{StoreOpaque, Stored};
 use crate::wasm::vm::{ConstExprEvaluator, Imports, InstanceHandle};
 use crate::wasm::{Extern, Func, Global, Memory, Table};
-use alloc::vec;
-use alloc::vec::Vec;
 
 /// An instantiated WebAssembly module.
 ///

--- a/kernel/src/wasm/linker.rs
+++ b/kernel/src/wasm/linker.rs
@@ -5,6 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+use anyhow::{Context, bail, format_err};
+use hashbrown::HashMap;
+use hashbrown::hash_map::Entry;
+
 use crate::wasm::func::{HostFunc, IntoFunc, WasmParams, WasmResults};
 use crate::wasm::indices::VMSharedTypeIndex;
 use crate::wasm::store::StoreOpaque;
@@ -12,12 +20,6 @@ use crate::wasm::translate::EntityType;
 use crate::wasm::types::{GlobalType, MemoryType, TableType, TagType};
 use crate::wasm::vm::{ConstExprEvaluator, Imports};
 use crate::wasm::{Engine, Extern, Func, Global, Instance, Memory, Module, Store, Table, Tag};
-use alloc::sync::Arc;
-use alloc::vec::Vec;
-use anyhow::{Context, bail, format_err};
-use core::marker::PhantomData;
-use hashbrown::HashMap;
-use hashbrown::hash_map::Entry;
 
 /// A dynamic linker for WebAssembly modules.
 #[derive(Debug)]

--- a/kernel/src/wasm/mod.rs
+++ b/kernel/src/wasm/mod.rs
@@ -31,9 +31,6 @@ mod utils;
 mod values;
 mod vm;
 
-use crate::wasm::store::StoreOpaque;
-use crate::wasm::utils::{enum_accessors, owned_enum_accessors};
-
 pub use engine::Engine;
 pub use func::Func;
 pub use global::Global;
@@ -50,6 +47,9 @@ pub use trap::TrapKind;
 pub use values::Val;
 #[cfg(test)]
 pub use vm::{ConstExprEvaluator, PlaceholderAllocatorDontUse};
+
+use crate::wasm::store::StoreOpaque;
+use crate::wasm::utils::{enum_accessors, owned_enum_accessors};
 
 /// The number of pages (for 32-bit modules) we can have before we run out of
 /// byte index space.

--- a/kernel/src/wasm/module.rs
+++ b/kernel/src/wasm/module.rs
@@ -5,6 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use core::mem;
+use core::ops::DerefMut;
+use core::ptr::NonNull;
+
+use wasmparser::{Validator, WasmFeatures};
+
 use crate::wasm::Engine;
 use crate::wasm::code_registry::{register_code, unregister_code};
 use crate::wasm::compile::{CompileInputs, CompiledFunctionInfo};
@@ -13,12 +21,6 @@ use crate::wasm::translate::{Import, ModuleTranslator, TranslatedModule};
 use crate::wasm::type_registry::RuntimeTypeCollection;
 use crate::wasm::utils::u8_size_of;
 use crate::wasm::vm::{CodeObject, MmapVec, VMArrayCallFunction, VMShape, VMWasmCallFunction};
-use alloc::string::{String, ToString};
-use alloc::sync::Arc;
-use core::mem;
-use core::ops::DerefMut;
-use core::ptr::NonNull;
-use wasmparser::{Validator, WasmFeatures};
 
 /// A compiled WebAssembly module, ready to be instantiated.
 ///

--- a/kernel/src/wasm/store/mod.rs
+++ b/kernel/src/wasm/store/mod.rs
@@ -7,14 +7,6 @@
 
 mod stored;
 
-use crate::mem::VirtualAddress;
-use crate::wasm::trap_handler::WasmFault;
-use crate::wasm::vm::{
-    InstanceAllocator, InstanceHandle, VMContext, VMFuncRef, VMGlobalDefinition, VMStoreContext,
-    VMTableDefinition, VMVal,
-};
-use crate::wasm::{Engine, Module, vm};
-use abort::abort;
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -23,9 +15,19 @@ use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::{fmt, mem};
+
+use abort::abort;
 use pin_project::pin_project;
 use static_assertions::{assert_impl_all, const_assert};
 pub use stored::{Stored, StoredData};
+
+use crate::mem::VirtualAddress;
+use crate::wasm::trap_handler::WasmFault;
+use crate::wasm::vm::{
+    InstanceAllocator, InstanceHandle, VMContext, VMFuncRef, VMGlobalDefinition, VMStoreContext,
+    VMTableDefinition, VMVal,
+};
+use crate::wasm::{Engine, Module, vm};
 
 pub struct Store<T>(Pin<Box<StoreInner<T>>>);
 

--- a/kernel/src/wasm/table.rs
+++ b/kernel/src/wasm/table.rs
@@ -5,16 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ptr::NonNull;
+use core::sync::atomic::Ordering;
+
+use anyhow::Context;
+use cranelift_entity::packed_option::ReservedValue;
+
 use crate::wasm::indices::DefinedTableIndex;
 use crate::wasm::store::{StoreOpaque, Stored};
 use crate::wasm::types::TableType;
 use crate::wasm::values::Ref;
 use crate::wasm::vm::{ExportedTable, InstanceAndStore, TableElement, VMTableImport, VmPtr};
 use crate::wasm::{Func, vm};
-use anyhow::Context;
-use core::ptr::NonNull;
-use core::sync::atomic::Ordering;
-use cranelift_entity::packed_option::ReservedValue;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Table(Stored<ExportedTable>);

--- a/kernel/src/wasm/translate/const_expr.rs
+++ b/kernel/src/wasm/translate/const_expr.rs
@@ -5,9 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::indices::{FuncIndex, GlobalIndex, TypeIndex};
 use anyhow::bail;
 use smallvec::SmallVec;
+
+use crate::wasm::indices::{FuncIndex, GlobalIndex, TypeIndex};
 
 /// A constant expression.
 ///

--- a/kernel/src/wasm/translate/mod.rs
+++ b/kernel/src/wasm/translate/mod.rs
@@ -11,24 +11,15 @@ mod module_types;
 mod type_convert;
 mod types;
 
-use crate::wasm::indices::{
-    CanonicalizedTypeIndex, DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex,
-    DefinedTableIndex, DefinedTagIndex, ElemIndex, EntityIndex, FieldIndex, FuncIndex,
-    FuncRefIndex, GlobalIndex, LabelIndex, LocalIndex, MemoryIndex, ModuleInternedTypeIndex,
-    OwnedMemoryIndex, TableIndex, TagIndex, TypeIndex,
-};
-use crate::wasm::{DEFAULT_OFFSET_GUARD_SIZE, WASM32_MAX_SIZE};
 use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
+
 use anyhow::Context;
+pub use const_expr::{ConstExpr, ConstOp};
 use cranelift_entity::packed_option::ReservedValue;
 use cranelift_entity::{EntityRef, EntitySet, PrimaryMap};
 use hashbrown::HashMap;
-use wasmparser::WasmFeatures;
-use wasmparser::collections::IndexMap;
-
-pub use const_expr::{ConstExpr, ConstOp};
 pub use module_translator::ModuleTranslator;
 pub use module_types::ModuleTypes;
 pub use type_convert::WasmparserTypeConverter;
@@ -37,6 +28,16 @@ pub use types::{
     WasmHeapTopType, WasmHeapType, WasmHeapTypeInner, WasmRecGroup, WasmRefType, WasmStorageType,
     WasmSubType, WasmValType,
 };
+use wasmparser::WasmFeatures;
+use wasmparser::collections::IndexMap;
+
+use crate::wasm::indices::{
+    CanonicalizedTypeIndex, DataIndex, DefinedFuncIndex, DefinedGlobalIndex, DefinedMemoryIndex,
+    DefinedTableIndex, DefinedTagIndex, ElemIndex, EntityIndex, FieldIndex, FuncIndex,
+    FuncRefIndex, GlobalIndex, LabelIndex, LocalIndex, MemoryIndex, ModuleInternedTypeIndex,
+    OwnedMemoryIndex, TableIndex, TagIndex, TypeIndex,
+};
+use crate::wasm::{DEFAULT_OFFSET_GUARD_SIZE, WASM32_MAX_SIZE};
 
 #[derive(Debug)]
 pub struct ModuleTranslation<'data> {

--- a/kernel/src/wasm/translate/module_translator.rs
+++ b/kernel/src/wasm/translate/module_translator.rs
@@ -5,6 +5,21 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::string::ToString;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use cranelift_entity::packed_option::ReservedValue;
+use hashbrown::HashMap;
+use wasmparser::{
+    BinaryReader, CustomSectionReader, DataKind, DataSectionReader, ElementItems, ElementKind,
+    ElementSectionReader, ExportSectionReader, ExternalKind, FunctionSectionReader,
+    GlobalSectionReader, ImportSectionReader, IndirectNameMap, MemorySectionReader, Name, NameMap,
+    NameSectionReader, Parser, Payload, ProducersFieldValue, ProducersSectionReader, TableInit,
+    TableSectionReader, TagKind, TagSectionReader, TypeRef, TypeSectionReader, Validator,
+    WasmFeatures,
+};
+
 use crate::wasm::indices::{
     CanonicalizedTypeIndex, DataIndex, ElemIndex, EntityIndex, FieldIndex, FuncIndex, FuncRefIndex,
     GlobalIndex, LabelIndex, LocalIndex, MemoryIndex, TableIndex, TagIndex, TypeIndex,
@@ -17,19 +32,6 @@ use crate::wasm::translate::{
     ModuleTranslation, ProducersLanguage, ProducersLanguageField, ProducersSdk, ProducersSdkField,
     ProducersTool, ProducersToolField, Table, TableInitialValue, TableSegment,
     TableSegmentElements, Tag,
-};
-use alloc::string::ToString;
-use alloc::sync::Arc;
-use alloc::vec::Vec;
-use cranelift_entity::packed_option::ReservedValue;
-use hashbrown::HashMap;
-use wasmparser::{
-    BinaryReader, CustomSectionReader, DataKind, DataSectionReader, ElementItems, ElementKind,
-    ElementSectionReader, ExportSectionReader, ExternalKind, FunctionSectionReader,
-    GlobalSectionReader, ImportSectionReader, IndirectNameMap, MemorySectionReader, Name, NameMap,
-    NameSectionReader, Parser, Payload, ProducersFieldValue, ProducersSectionReader, TableInit,
-    TableSectionReader, TagKind, TagSectionReader, TypeRef, TypeSectionReader, Validator,
-    WasmFeatures,
 };
 
 /// A translator for converting the output of `wasmparser` into types used by this crate.

--- a/kernel/src/wasm/translate/module_types.rs
+++ b/kernel/src/wasm/translate/module_types.rs
@@ -5,20 +5,22 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::borrow::Cow;
+use alloc::vec::Vec;
+use core::fmt;
+use core::range::Range;
+
+use cranelift_entity::packed_option::PackedOption;
+use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
+use hashbrown::HashMap;
+use wasmparser::{Validator, ValidatorId};
+
 use crate::wasm::indices::{ModuleInternedRecGroupIndex, ModuleInternedTypeIndex};
 use crate::wasm::translate::type_convert::WasmparserTypeConverter;
 use crate::wasm::translate::types::WasmSubType;
 use crate::wasm::translate::{
     TranslatedModule, WasmCompositeType, WasmCompositeTypeInner, WasmFuncType,
 };
-use alloc::borrow::Cow;
-use alloc::vec::Vec;
-use core::fmt;
-use core::range::Range;
-use cranelift_entity::packed_option::PackedOption;
-use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
-use hashbrown::HashMap;
-use wasmparser::{Validator, ValidatorId};
 
 /// Types defined within a single WebAssembly module.
 #[derive(Debug, Default)]

--- a/kernel/src/wasm/translate/type_convert.rs
+++ b/kernel/src/wasm/translate/type_convert.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::vec::Vec;
+
+use wasmparser::UnpackedIndex;
+
 use crate::wasm::indices::{CanonicalizedTypeIndex, ModuleInternedTypeIndex, TypeIndex};
 use crate::wasm::translate::types::{
     WasmArrayType, WasmCompositeType, WasmCompositeTypeInner, WasmFieldType, WasmHeapType,
     WasmHeapTypeInner, WasmRefType, WasmStorageType, WasmStructType, WasmValType,
 };
 use crate::wasm::translate::{ModuleTypes, TranslatedModule, WasmFuncType, WasmSubType};
-use alloc::vec::Vec;
-use wasmparser::UnpackedIndex;
 
 /// A type that knows how to convert from `wasmparser` types to types in this crate.
 pub struct WasmparserTypeConverter<'a> {
@@ -48,9 +50,9 @@ impl<'a> WasmparserTypeConverter<'a> {
         match ty {
             wasmparser::HeapType::Concrete(index) => self.lookup_heap_type(index),
             wasmparser::HeapType::Abstract { shared, ty } => {
-                use crate::wasm::translate::types::WasmHeapTypeInner::*;
-
                 use wasmparser::AbstractHeapType;
+
+                use crate::wasm::translate::types::WasmHeapTypeInner::*;
                 let ty = match ty {
                     AbstractHeapType::Func => Func,
                     AbstractHeapType::Extern => Extern,

--- a/kernel/src/wasm/translate/types.rs
+++ b/kernel/src/wasm/translate/types.rs
@@ -5,13 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use core::fmt;
+
 use crate::wasm::indices::CanonicalizedTypeIndex;
 use crate::wasm::translate::{Global, Memory, Table};
 use crate::wasm::type_registry::TypeTrace;
 use crate::wasm::utils::enum_accessors;
-use alloc::borrow::Cow;
-use alloc::boxed::Box;
-use core::fmt;
 
 /// Represents the types of values in a WebAssembly module.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/kernel/src/wasm/trap.rs
+++ b/kernel/src/wasm/trap.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::fmt;
+
 use cranelift_codegen::ir::TrapCode;
 
 const TRAP_OFFSET: u8 = 1;

--- a/kernel/src/wasm/trap_handler.rs
+++ b/kernel/src/wasm/trap_handler.rs
@@ -5,12 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::VirtualAddress;
-use crate::wasm::TrapKind;
-use crate::wasm::code_registry::lookup_code;
-use crate::wasm::store::StoreOpaque;
-use crate::wasm::vm::{VMContext, VMStoreContext};
 use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -20,7 +14,15 @@ use core::ops::ControlFlow;
 use core::panic::AssertUnwindSafe;
 use core::ptr::NonNull;
 use core::{fmt, ptr};
+
 use cpu_local::cpu_local;
+
+use crate::arch;
+use crate::mem::VirtualAddress;
+use crate::wasm::TrapKind;
+use crate::wasm::code_registry::lookup_code;
+use crate::wasm::store::StoreOpaque;
+use crate::wasm::vm::{VMContext, VMStoreContext};
 
 /// Description about a fault that occurred in WebAssembly.
 #[derive(Debug)]

--- a/kernel/src/wasm/type_registry.rs
+++ b/kernel/src/wasm/type_registry.rs
@@ -5,13 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::Engine;
-use crate::wasm::indices::{
-    CanonicalizedTypeIndex, ModuleInternedTypeIndex, RecGroupRelativeTypeIndex, VMSharedTypeIndex,
-};
-use crate::wasm::translate::{
-    ModuleTypes, WasmCompositeType, WasmCompositeTypeInner, WasmRecGroup, WasmSubType,
-};
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::sync::Arc;
@@ -23,11 +16,20 @@ use core::hash::{Hash, Hasher};
 use core::range::Range;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use core::{fmt, iter};
+
 use cranelift_entity::packed_option::{PackedOption, ReservedValue};
 use cranelift_entity::{PrimaryMap, SecondaryMap, iter_entity_range};
 use hashbrown::HashSet;
 use spin::RwLock;
 use wasmtime_slab::Slab;
+
+use crate::wasm::Engine;
+use crate::wasm::indices::{
+    CanonicalizedTypeIndex, ModuleInternedTypeIndex, RecGroupRelativeTypeIndex, VMSharedTypeIndex,
+};
+use crate::wasm::translate::{
+    ModuleTypes, WasmCompositeType, WasmCompositeTypeInner, WasmRecGroup, WasmSubType,
+};
 
 pub trait TypeTrace {
     /// Visit each edge.

--- a/kernel/src/wasm/types.rs
+++ b/kernel/src/wasm/types.rs
@@ -5,6 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::fmt;
+use core::fmt::{Display, Write};
+
+use anyhow::{bail, ensure};
+
 use crate::wasm::Engine;
 use crate::wasm::indices::{CanonicalizedTypeIndex, VMSharedTypeIndex};
 use crate::wasm::translate::{
@@ -13,12 +20,6 @@ use crate::wasm::translate::{
     WasmSubType, WasmValType,
 };
 use crate::wasm::type_registry::RegisteredType;
-use alloc::string::{String, ToString};
-use alloc::vec::Vec;
-use anyhow::{bail, ensure};
-use core::fmt;
-use core::fmt::Display;
-use core::fmt::Write;
 
 /// Indicator of whether a global value, struct's field, or array type's
 /// elements are mutable or not.

--- a/kernel/src/wasm/utils.rs
+++ b/kernel/src/wasm/utils.rs
@@ -5,11 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch::PAGE_SIZE;
-use crate::wasm::translate::{WasmFuncType, WasmHeapTopType, WasmHeapType, WasmValType};
 use cranelift_codegen::ir;
 use cranelift_codegen::ir::{AbiParam, ArgumentPurpose, Signature};
 use cranelift_codegen::isa::{CallConv, TargetIsa};
+
+use crate::arch::PAGE_SIZE;
+use crate::wasm::translate::{WasmFuncType, WasmHeapTopType, WasmHeapType, WasmValType};
 
 /// Helper macro to generate accessors for an enum.
 macro_rules! enum_accessors {

--- a/kernel/src/wasm/values.rs
+++ b/kernel/src/wasm/values.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ptr;
+
+use anyhow::bail;
+
 use crate::wasm::Func;
 use crate::wasm::store::StoreOpaque;
 use crate::wasm::types::{HeapType, HeapTypeInner, RefType, ValType};
 use crate::wasm::utils::enum_accessors;
 use crate::wasm::vm::{TableElement, VMVal};
-use anyhow::bail;
-use core::ptr;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Val {

--- a/kernel/src/wasm/vm/builtins.rs
+++ b/kernel/src/wasm/vm/builtins.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ptr::NonNull;
+
 use crate::wasm::TrapKind;
 use crate::wasm::indices::{DataIndex, ElemIndex, MemoryIndex, TableIndex};
 use crate::wasm::store::StoreOpaque;
@@ -12,7 +14,6 @@ use crate::wasm::trap_handler::HostResultHasUnwindSentinel;
 use crate::wasm::vm::instance::Instance;
 use crate::wasm::vm::table::{TableElement, TableElementType};
 use crate::wasm::vm::{Table, VMFuncRef};
-use core::ptr::NonNull;
 
 /// A helper structure to represent the return value of a memory or table growth
 /// call.

--- a/kernel/src/wasm/vm/code_object.rs
+++ b/kernel/src/wasm/vm/code_object.rs
@@ -5,18 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::vec;
+use alloc::vec::Vec;
+use core::ptr::NonNull;
+use core::range::Range;
+use core::slice;
+
+use anyhow::Context;
+use cranelift_entity::PrimaryMap;
+
 use crate::mem::{AddressSpace, Mmap, VirtualAddress};
 use crate::wasm::TrapKind;
 use crate::wasm::compile::{CompiledFunctionInfo, FunctionLoc};
 use crate::wasm::indices::{DefinedFuncIndex, ModuleInternedTypeIndex};
 use crate::wasm::vm::{MmapVec, VMWasmCallFunction};
-use alloc::vec;
-use alloc::vec::Vec;
-use anyhow::Context;
-use core::ptr::NonNull;
-use core::range::Range;
-use core::slice;
-use cranelift_entity::PrimaryMap;
 
 #[derive(Debug)]
 pub struct CodeObject {

--- a/kernel/src/wasm/vm/const_eval.rs
+++ b/kernel/src/wasm/vm/const_eval.rs
@@ -5,6 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use anyhow::bail;
+use smallvec::SmallVec;
+
 use crate::wasm::indices::{FuncIndex, GlobalIndex, VMSharedTypeIndex};
 use crate::wasm::store::StoreOpaque;
 use crate::wasm::translate::{
@@ -13,8 +16,6 @@ use crate::wasm::translate::{
 };
 use crate::wasm::vm::instance::Instance;
 use crate::wasm::vm::vmcontext::VMVal;
-use anyhow::bail;
-use smallvec::SmallVec;
 
 /// Simple interpreter for constant expressions.
 #[derive(Debug, Default)]

--- a/kernel/src/wasm/vm/instance.rs
+++ b/kernel/src/wasm/vm/instance.rs
@@ -5,6 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::string::String;
+use core::alloc::Layout;
+use core::marker::PhantomPinned;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicU64, Ordering};
+use core::{fmt, ptr, slice};
+
+use anyhow::{bail, ensure};
+use cranelift_entity::packed_option::ReservedValue;
+use cranelift_entity::{EntityRef, EntitySet, PrimaryMap};
+use static_assertions::const_assert_eq;
+
 use crate::mem::VirtualAddress;
 use crate::wasm::TrapKind;
 use crate::wasm::indices::{
@@ -30,16 +42,6 @@ use crate::wasm::vm::{
     VMOpaqueContext, VMShape, VMStoreContext, VMTableDefinition, VMTableImport, VMTagDefinition,
     VMTagImport,
 };
-use alloc::string::String;
-use anyhow::{bail, ensure};
-use core::alloc::Layout;
-use core::marker::PhantomPinned;
-use core::ptr::NonNull;
-use core::sync::atomic::{AtomicU64, Ordering};
-use core::{fmt, ptr, slice};
-use cranelift_entity::packed_option::ReservedValue;
-use cranelift_entity::{EntityRef, EntitySet, PrimaryMap};
-use static_assertions::const_assert_eq;
 
 #[derive(Debug)]
 pub struct InstanceHandle {

--- a/kernel/src/wasm/vm/instance_alloc.rs
+++ b/kernel/src/wasm/vm/instance_alloc.rs
@@ -5,6 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::alloc::Allocator;
+use core::ops::DerefMut;
+use core::ptr::NonNull;
+use core::{cmp, mem};
+
+use anyhow::Context;
+use cranelift_entity::PrimaryMap;
+
 use crate::mem::Mmap;
 use crate::wasm::indices::{DefinedMemoryIndex, DefinedTableIndex};
 use crate::wasm::module::Module;
@@ -14,12 +22,6 @@ use crate::wasm::vm::instance::Instance;
 use crate::wasm::vm::mmap_vec::MmapVec;
 use crate::wasm::vm::{InstanceHandle, TableElement, VMShape};
 use crate::wasm::{MEMORY_MAX, TABLE_MAX, translate, vm};
-use anyhow::Context;
-use core::alloc::Allocator;
-use core::ops::DerefMut;
-use core::ptr::NonNull;
-use core::{cmp, mem};
-use cranelift_entity::PrimaryMap;
 
 /// A type that knows how to allocate backing memory for instance resources.
 pub trait InstanceAllocator {

--- a/kernel/src/wasm/vm/memory.rs
+++ b/kernel/src/wasm/vm/memory.rs
@@ -5,11 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ptr::NonNull;
+use core::range::Range;
+
 use crate::mem::{Mmap, VirtualAddress};
 use crate::wasm::vm::VMMemoryDefinition;
 use crate::wasm::vm::provenance::VmPtr;
-use core::ptr::NonNull;
-use core::range::Range;
 
 #[derive(Debug)]
 pub struct Memory {

--- a/kernel/src/wasm/vm/mmap_vec.rs
+++ b/kernel/src/wasm/vm/mmap_vec.rs
@@ -5,16 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::mem::{AddressSpace, Mmap};
 use alloc::sync::Arc;
-use anyhow::Context;
 use core::cmp::max;
 use core::marker::PhantomData;
 use core::ops::Deref;
 use core::range::Range;
 use core::slice;
+
+use anyhow::Context;
 use spin::Mutex;
+
+use crate::arch;
+use crate::mem::{AddressSpace, Mmap};
 
 #[derive(Debug)]
 pub struct MmapVec<T> {

--- a/kernel/src/wasm/vm/mod.rs
+++ b/kernel/src/wasm/vm/mod.rs
@@ -20,9 +20,6 @@ mod vmshape;
 use alloc::vec::Vec;
 use core::ptr::NonNull;
 
-use crate::wasm::indices::DefinedMemoryIndex;
-use crate::wasm::translate;
-use crate::wasm::translate::TranslatedModule;
 pub use code_object::CodeObject;
 pub use const_eval::ConstExprEvaluator;
 pub use instance::{Instance, InstanceAndStore, InstanceHandle};
@@ -35,6 +32,10 @@ pub use provenance::VmPtr;
 pub use table::{Table, TableElement};
 pub use vmcontext::*;
 pub use vmshape::{StaticVMShape, VMShape};
+
+use crate::wasm::indices::DefinedMemoryIndex;
+use crate::wasm::translate;
+use crate::wasm::translate::TranslatedModule;
 
 /// The value of an export passed from one instance to another.
 #[derive(Debug, Clone)]

--- a/kernel/src/wasm/vm/provenance.rs
+++ b/kernel/src/wasm/vm/provenance.rs
@@ -5,12 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::wasm::indices::VMSharedTypeIndex;
 use core::fmt;
 use core::marker::PhantomData;
 use core::num::NonZeroUsize;
 use core::ptr::NonNull;
 use core::sync::atomic::AtomicUsize;
+
+use crate::wasm::indices::VMSharedTypeIndex;
 
 /// A pointer that is used by compiled code, or in other words is accessed
 /// outside of Rust.

--- a/kernel/src/wasm/vm/table.rs
+++ b/kernel/src/wasm/vm/table.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ptr;
+use core::ptr::NonNull;
+use core::range::Range;
+
+use anyhow::anyhow;
+
 use crate::wasm::TrapKind;
 use crate::wasm::vm::mmap_vec::MmapVec;
 use crate::wasm::vm::provenance::VmPtr;
 use crate::wasm::vm::{VMFuncRef, VMTableDefinition};
-use anyhow::anyhow;
-use core::ptr;
-use core::ptr::NonNull;
-use core::range::Range;
 
 #[derive(Debug, Clone, Copy)]
 pub enum TableElement {

--- a/kernel/src/wasm/vm/vmcontext.rs
+++ b/kernel/src/wasm/vm/vmcontext.rs
@@ -5,14 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::mem::VirtualAddress;
-use crate::wasm::builtins::{BuiltinFunctionIndex, foreach_builtin_function};
-use crate::wasm::indices::{DefinedMemoryIndex, VMSharedTypeIndex};
-use crate::wasm::store::StoreOpaque;
-use crate::wasm::translate::{WasmHeapTopType, WasmValType};
-use crate::wasm::type_registry::RegisteredType;
-use crate::wasm::types::FuncType;
-use crate::wasm::vm::provenance::{VmPtr, VmSafe};
 use alloc::boxed::Box;
 use core::any::Any;
 use core::cell::UnsafeCell;
@@ -22,8 +14,18 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::{fmt, ptr};
+
 use cranelift_entity::Unsigned;
 use static_assertions::const_assert_eq;
+
+use crate::mem::VirtualAddress;
+use crate::wasm::builtins::{BuiltinFunctionIndex, foreach_builtin_function};
+use crate::wasm::indices::{DefinedMemoryIndex, VMSharedTypeIndex};
+use crate::wasm::store::StoreOpaque;
+use crate::wasm::translate::{WasmHeapTopType, WasmValType};
+use crate::wasm::type_registry::RegisteredType;
+use crate::wasm::types::FuncType;
+use crate::wasm::vm::provenance::{VmPtr, VmSafe};
 
 /// Magic value for core Wasm VM contexts.
 ///

--- a/libs/cpu-local/src/collection.rs
+++ b/libs/cpu-local/src/collection.rs
@@ -5,14 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::cpu_local;
 use alloc::boxed::Box;
 use core::cell::UnsafeCell;
 use core::iter::FusedIterator;
 use core::panic::UnwindSafe;
 use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 use core::{fmt, mem, ptr, slice};
+
 use util::CheckedMaybeUninit;
+
+use crate::cpu_local;
 
 /// The total number of buckets stored in each cpu-local storage.
 /// All buckets combined can hold up to `usize::MAX - 1` entries.
@@ -568,14 +570,14 @@ fn cpuid() -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloc::string::String;
-
     use alloc::sync::Arc;
     use core::cell::RefCell;
     use core::sync::atomic::AtomicUsize;
     use core::sync::atomic::Ordering::Relaxed;
     use std::thread;
+
+    use super::*;
 
     fn make_create() -> Arc<dyn Fn() -> usize + Send + Sync> {
         let count = AtomicUsize::new(0);

--- a/libs/fdt/src/lib.rs
+++ b/libs/fdt/src/lib.rs
@@ -10,11 +10,13 @@
 mod error;
 mod parser;
 
-pub use crate::error::Error;
-use crate::parser::{BigEndianToken, Parser, StringsBlock, StructsBlock};
 use core::ffi::CStr;
 use core::{fmt, slice};
+
 use fallible_iterator::FallibleIterator;
+
+pub use crate::error::Error;
+use crate::parser::{BigEndianToken, Parser, StringsBlock, StructsBlock};
 
 const DTB_MAGIC: u32 = 0xD00D_FEED;
 

--- a/libs/kaddr2line/src/frame.rs
+++ b/libs/kaddr2line/src/frame.rs
@@ -5,9 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::{Error, Function, InlinedFunction, ResUnit, maybe_small};
 use core::iter;
+
 use fallible_iterator::FallibleIterator;
+
+use crate::{Error, Function, InlinedFunction, ResUnit, maybe_small};
 
 /// A source location.
 pub struct Location<'a> {

--- a/libs/kaddr2line/src/unit.rs
+++ b/libs/kaddr2line/src/unit.rs
@@ -5,16 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cmp;
+
+use fallible_iterator::FallibleIterator;
+
 use crate::{
     Context, DebugFile, Error, Function, LazyFunctions, LazyLines, LazyResult,
     LineLocationRangeIter, Lines, Location, LookupContinuation, LookupResult, RangeAttributes,
     SimpleLookup, SplitDwarfLoad,
 };
-use alloc::boxed::Box;
-use alloc::sync::Arc;
-use alloc::vec::Vec;
-use core::cmp;
-use fallible_iterator::FallibleIterator;
 
 pub(crate) struct UnitRange {
     unit_id: usize,

--- a/libs/kasync/benches/spawn.rs
+++ b/libs/kasync/benches/spawn.rs
@@ -1,7 +1,8 @@
+use std::hint::black_box;
+
 use criterion::{Criterion, criterion_group, criterion_main};
 use fastrand::FastRand;
 use kasync2::executor::{Executor, Worker};
-use std::hint::black_box;
 
 async fn work() -> usize {
     let val = 1 + 1;

--- a/libs/kasync/src/executor.rs
+++ b/libs/kasync/src/executor.rs
@@ -7,24 +7,25 @@
 
 mod steal;
 
-use crate::error::Closed;
-use crate::error::SpawnError;
-use crate::executor::steal::{Injector, Stealer, TryStealError};
-use crate::future::Either;
-use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
-use crate::sync::wait_queue::WaitQueue;
-use crate::task::{Header, JoinHandle, PollResult, Task, TaskBuilder, TaskRef};
 use alloc::boxed::Box;
-use cordyceps::mpsc_queue::{MpscQueue, TryDequeueError};
 use core::alloc::Allocator;
 use core::num::NonZeroUsize;
 use core::ptr;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
+
+use cordyceps::mpsc_queue::{MpscQueue, TryDequeueError};
 use cpu_local::collection::CpuLocal;
 use fastrand::FastRand;
 use futures::pin_mut;
 use spin::Backoff;
+
+use crate::error::{Closed, SpawnError};
+use crate::executor::steal::{Injector, Stealer, TryStealError};
+use crate::future::Either;
+use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
+use crate::sync::wait_queue::WaitQueue;
+use crate::task::{Header, JoinHandle, PollResult, Task, TaskBuilder, TaskRef};
 
 #[derive(Debug)]
 pub struct Executor {
@@ -491,12 +492,14 @@ impl Scheduler {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{loom, test_util};
     use core::hint::black_box;
     use core::sync::atomic::AtomicBool;
+
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::util::SubscriberInitExt;
+
+    use super::*;
+    use crate::{loom, test_util};
 
     async fn work() -> usize {
         let val = 1 + 1;

--- a/libs/kasync/src/executor/steal.rs
+++ b/libs/kasync/src/executor/steal.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use alloc::boxed::Box;
+use core::fmt::Debug;
+use core::num::NonZeroUsize;
+
+use cordyceps::{MpscQueue, mpsc_queue};
+
 use crate::executor::Scheduler;
 use crate::loom::sync::atomic::{AtomicUsize, Ordering};
 use crate::task::{Header, Task, TaskRef};
-use alloc::boxed::Box;
-use cordyceps::{MpscQueue, mpsc_queue};
-use core::fmt::Debug;
-use core::num::NonZeroUsize;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]

--- a/libs/kasync/src/sync/oneshot.rs
+++ b/libs/kasync/src/sync/oneshot.rs
@@ -5,12 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::cell::UnsafeCell;
-use crate::sync::WaitCell;
 use alloc::sync::Arc;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{Context, Poll, ready};
+
+use crate::loom::cell::UnsafeCell;
+use crate::sync::WaitCell;
 
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let inner = Arc::new(Inner {

--- a/libs/kasync/src/sync/wait_cell.rs
+++ b/libs/kasync/src/sync/wait_cell.rs
@@ -5,16 +5,18 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::error::Closed;
-use crate::loom::cell::UnsafeCell;
-use crate::loom::sync::atomic::{AtomicUsize, Ordering};
-use bitflags::bitflags;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
 use core::{fmt, task};
+
+use bitflags::bitflags;
 use static_assertions::const_assert_eq;
 use util::{CachePadded, loom_const_fn};
+
+use crate::error::Closed;
+use crate::loom::cell::UnsafeCell;
+use crate::loom::sync::atomic::{AtomicUsize, Ordering};
 
 /// An atomically registered [`Waker`].
 ///

--- a/libs/kasync/src/sync/wait_queue.rs
+++ b/libs/kasync/src/sync/wait_queue.rs
@@ -5,10 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::error::Closed;
-use crate::sync::wake_batch::WakeBatch;
 use alloc::sync::Arc;
-use cordyceps::{Linked, List, list};
 use core::cell::UnsafeCell;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
@@ -16,10 +13,15 @@ use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use core::task::{Context, Poll, Waker};
 use core::{fmt, mem, ptr};
+
+use cordyceps::{Linked, List, list};
 use mycelium_bitfield::{FromBits, bitfield, enum_from_bits};
 use pin_project::{pin_project, pinned_drop};
 use spin::{Mutex, MutexGuard};
 use util::{CachePadded, loom_const_fn};
+
+use crate::error::Closed;
+use crate::sync::wake_batch::WakeBatch;
 
 /// A queue of waiting tasks which can be [woken in first-in, first-out
 /// order][wake], or [all at once][wake_all].

--- a/libs/kasync/src/sync/wake_batch.rs
+++ b/libs/kasync/src/sync/wake_batch.rs
@@ -5,8 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use arrayvec::ArrayVec;
 use core::task::Waker;
+
+use arrayvec::ArrayVec;
 
 const NUM_WAKERS: usize = 32;
 

--- a/libs/kasync/src/task.rs
+++ b/libs/kasync/src/task.rs
@@ -11,10 +11,7 @@ mod join_handle;
 mod state;
 mod yield_now;
 
-use crate::loom::cell::UnsafeCell;
-use crate::task::state::{JoinAction, StartPollAction, State, WakeByRefAction, WakeByValAction};
 use alloc::boxed::Box;
-use cordyceps::mpsc_queue;
 use core::alloc::Allocator;
 use core::any::type_name;
 use core::mem::offset_of;
@@ -24,13 +21,17 @@ use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use core::{fmt, mem};
-use util::{CachePadded, CheckedMaybeUninit, loom_const_fn};
 
-use crate::executor::Scheduler;
 pub use builder::TaskBuilder;
+use cordyceps::mpsc_queue;
 pub use id::Id;
 pub use join_handle::{JoinError, JoinHandle};
+use util::{CachePadded, CheckedMaybeUninit, loom_const_fn};
 pub use yield_now::yield_now;
+
+use crate::executor::Scheduler;
+use crate::loom::cell::UnsafeCell;
+use crate::task::state::{JoinAction, StartPollAction, State, WakeByRefAction, WakeByValAction};
 
 /// Outcome of calling [`Task::poll`].
 ///

--- a/libs/kasync/src/task/builder.rs
+++ b/libs/kasync/src/task/builder.rs
@@ -5,15 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::error::Closed;
-use crate::error::SpawnError;
-use crate::task::id::Id;
-use crate::task::join_handle::JoinHandle;
-use crate::task::{Task, TaskRef};
 use alloc::boxed::Box;
 use core::alloc::Allocator;
 use core::any::type_name;
 use core::panic::Location;
+
+use crate::error::{Closed, SpawnError};
+use crate::task::id::Id;
+use crate::task::join_handle::JoinHandle;
+use crate::task::{Task, TaskRef};
 
 pub struct TaskBuilder<'a, S> {
     location: Option<Location<'a>>,

--- a/libs/kasync/src/task/id.rs
+++ b/libs/kasync/src/task/id.rs
@@ -5,8 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::sync::atomic::{AtomicU64, Ordering};
 use core::fmt;
+
+use crate::loom::sync::atomic::{AtomicU64, Ordering};
 
 /// An opaque ID that uniquely identifies a task relative to all other currently
 /// running tasks.

--- a/libs/kasync/src/task/join_handle.rs
+++ b/libs/kasync/src/task/join_handle.rs
@@ -5,8 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::task::Id;
-use crate::task::TaskRef;
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::any::Any;
@@ -17,6 +15,8 @@ use core::ops::Deref;
 use core::panic::{RefUnwindSafe, UnwindSafe};
 use core::pin::Pin;
 use core::task::{Context, Poll};
+
+use crate::task::{Id, TaskRef};
 
 pub struct JoinHandle<T> {
     state: JoinHandleState,

--- a/libs/kasync/src/task/state.rs
+++ b/libs/kasync/src/task/state.rs
@@ -5,11 +5,13 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::sync::atomic::{self, AtomicUsize, Ordering};
-use crate::task::PollResult;
 use core::fmt;
+
 use spin::Backoff;
 use util::loom_const_fn;
+
+use crate::loom::sync::atomic::{self, AtomicUsize, Ordering};
+use crate::task::PollResult;
 
 /// Task state. The task stores its state in an atomic `usize` with various bitfields for the
 /// necessary information. The state has the following layout:

--- a/libs/kasync/src/test_util.rs
+++ b/libs/kasync/src/test_util.rs
@@ -5,13 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::sync::Arc;
-use crate::loom::sync::{Condvar, Mutex as StdMutex};
 use core::mem::ManuallyDrop;
 use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
 use futures::pin_mut;
 use futures::task::WakerRef;
 use util::loom_const_fn;
+
+use crate::loom::sync::{Arc, Condvar, Mutex as StdMutex};
 
 #[derive(Debug)]
 pub struct ThreadNotify {

--- a/libs/kasync/src/time.rs
+++ b/libs/kasync/src/time.rs
@@ -13,7 +13,8 @@ mod test_util;
 mod timeout;
 mod timer;
 
-use core::{fmt, time::Duration};
+use core::fmt;
+use core::time::Duration;
 
 pub use clock::{Clock, RawClock, RawClockVTable};
 pub use instant::Instant;

--- a/libs/kasync/src/time/clock.rs
+++ b/libs/kasync/src/time/clock.rs
@@ -5,9 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::time::max_duration;
 use core::fmt;
 use core::time::Duration;
+
+use crate::time::max_duration;
 
 pub struct Clock {
     name: &'static str,

--- a/libs/kasync/src/time/instant.rs
+++ b/libs/kasync/src/time/instant.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::time::{NANOS_PER_SEC, Ticks, TimeError, Timer};
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 use core::time::Duration;
+
+use crate::time::{NANOS_PER_SEC, Ticks, TimeError, Timer};
 
 /// A measurement of a monotonically nondecreasing clock.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/libs/kasync/src/time/sleep.rs
+++ b/libs/kasync/src/time/sleep.rs
@@ -5,16 +5,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::sync::atomic::Ordering;
-use crate::time::Ticks;
-use crate::time::{TimeError, Timer, instant::Instant, timer::Entry};
-use core::{
-    fmt,
-    pin::Pin,
-    task::{Context, Poll, ready},
-    time::Duration,
-};
+use core::fmt;
+use core::pin::Pin;
+use core::task::{Context, Poll, ready};
+use core::time::Duration;
+
 use pin_project::{pin_project, pinned_drop};
+
+use crate::loom::sync::atomic::Ordering;
+use crate::time::instant::Instant;
+use crate::time::timer::Entry;
+use crate::time::{Ticks, TimeError, Timer};
 
 /// Wait until duration has elapsed.
 ///
@@ -139,16 +140,15 @@ impl PinnedDrop for Sleep<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::loom::sync::atomic::{AtomicBool, Ordering};
-    use crate::time::test_util::MockClock;
-    use crate::{
-        executor::{Executor, Worker},
-        loom,
-    };
     use fastrand::FastRand;
     use tracing_subscriber::EnvFilter;
     use tracing_subscriber::fmt::format::FmtSpan;
+
+    use super::*;
+    use crate::executor::{Executor, Worker};
+    use crate::loom;
+    use crate::loom::sync::atomic::{AtomicBool, Ordering};
+    use crate::time::test_util::MockClock;
 
     // loom is not happy about this test. For whatever reason it triggers the "too many branches"
     // error. But both the regular test AND miri are fine with it

--- a/libs/kasync/src/time/test_util.rs
+++ b/libs/kasync/src/time/test_util.rs
@@ -5,12 +5,12 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::sync::Arc;
-use crate::loom::sync::Mutex as StdMutex;
-use crate::time::{Clock, RawClock, RawClockVTable};
 use core::ptr::NonNull;
 use core::time::Duration;
 use std::time::Instant as StdInstant;
+
+use crate::loom::sync::{Arc, Mutex as StdMutex};
+use crate::time::{Clock, RawClock, RawClockVTable};
 
 pub struct MockClock {
     time_anchor: StdInstant,

--- a/libs/kasync/src/time/timeout.rs
+++ b/libs/kasync/src/time/timeout.rs
@@ -5,18 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use core::time::Duration;
+
 use pin_project::pin_project;
 
-use crate::time::{
-    TimeError, Timer,
-    instant::Instant,
-    sleep::{Sleep, sleep, sleep_until},
-};
-use core::{
-    pin::Pin,
-    task::{Context, Poll},
-    time::Duration,
-};
+use crate::time::instant::Instant;
+use crate::time::sleep::{Sleep, sleep, sleep_until};
+use crate::time::{TimeError, Timer};
 
 /// Requires a `Future` to complete before the specified duration has elapsed.
 ///

--- a/libs/kasync/src/time/timer.rs
+++ b/libs/kasync/src/time/timer.rs
@@ -8,15 +8,19 @@
 mod entry;
 mod wheel;
 
-use crate::time::{Clock, NANOS_PER_SEC, TimeError, max_duration};
-use crate::{loom::sync::atomic::Ordering, time::Instant};
+use core::pin::Pin;
+use core::ptr::NonNull;
+use core::task::Poll;
+use core::time::Duration;
+
 use cordyceps::List;
-use core::{pin::Pin, ptr::NonNull, task::Poll, time::Duration};
+pub(in crate::time) use entry::Entry;
 use spin::Mutex;
 use util::loom_const_fn;
 use wheel::Wheel;
 
-pub(in crate::time) use entry::Entry;
+use crate::loom::sync::atomic::Ordering;
+use crate::time::{Clock, Instant, NANOS_PER_SEC, TimeError, max_duration};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Ticks(pub u64);

--- a/libs/kasync/src/time/timer/entry.rs
+++ b/libs/kasync/src/time/timer/entry.rs
@@ -5,15 +5,17 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::sync::wait_cell::WaitCell;
-use crate::time::Ticks;
-use cordyceps::{Linked, list};
 use core::marker::PhantomPinned;
 use core::mem::offset_of;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, Ordering};
+
+use cordyceps::{Linked, list};
 use pin_project::pin_project;
 use util::loom_const_fn;
+
+use crate::sync::wait_cell::WaitCell;
+use crate::time::Ticks;
 
 /// An entry in a timing [`Wheel`][crate::time::timer::Wheel].
 #[pin_project]

--- a/libs/kasync/src/time/timer/wheel.rs
+++ b/libs/kasync/src/time/timer/wheel.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::time::Ticks;
-use crate::time::timer::entry::Entry;
-use crate::time::timer::{Core, Deadline};
-use cordyceps::List;
 use core::pin::Pin;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
+
+use cordyceps::List;
+
+use crate::time::Ticks;
+use crate::time::timer::entry::Entry;
+use crate::time::timer::{Core, Deadline};
 
 #[derive(Debug)]
 pub(crate) struct Wheel {

--- a/libs/kbacktrace/src/lib.rs
+++ b/libs/kbacktrace/src/lib.rs
@@ -10,9 +10,10 @@
 
 mod symbolize;
 
-use arrayvec::ArrayVec;
 use core::fmt;
 use core::fmt::Formatter;
+
+use arrayvec::ArrayVec;
 use fallible_iterator::FallibleIterator;
 use unwind2::FrameIter;
 

--- a/libs/kbacktrace/src/symbolize.rs
+++ b/libs/kbacktrace/src/symbolize.rs
@@ -7,6 +7,7 @@
 
 use core::ffi::c_void;
 use core::{fmt, str};
+
 use fallible_iterator::FallibleIterator;
 use gimli::{EndianSlice, NativeEndian};
 use rustc_demangle::{Demangle, try_demangle};

--- a/libs/ksharded-slab/src/cfg.rs
+++ b/libs/ksharded-slab/src/cfg.rs
@@ -1,9 +1,9 @@
+use core::fmt;
+use core::marker::PhantomData;
+
 use crate::Pack;
-use crate::page::{
-    Addr,
-    slot::{Generation, RefCount},
-};
-use core::{fmt, marker::PhantomData};
+use crate::page::Addr;
+use crate::page::slot::{Generation, RefCount};
 
 /// Configuration parameters which can be overridden to tune the behavior of a slab.
 pub trait Config: Sized {

--- a/libs/ksharded-slab/src/iter.rs
+++ b/libs/ksharded-slab/src/iter.rs
@@ -1,4 +1,5 @@
-use core::{iter::FusedIterator, slice};
+use core::iter::FusedIterator;
+use core::slice;
 
 use crate::{cfg, page, shard};
 

--- a/libs/ksharded-slab/src/lib.rs
+++ b/libs/ksharded-slab/src/lib.rs
@@ -220,20 +220,19 @@ mod page;
 mod shard;
 mod tid;
 
-pub use self::{
-    cfg::{Config, DefaultConfig},
-    clear::Clear,
-    iter::UniqueIter,
-};
+use alloc::sync::Arc;
+use core::marker::PhantomData;
+use core::{fmt, ptr};
+
+use cfg::CfgPrivate;
 #[doc(inline)]
 pub use pool::Pool;
-
+use shard::Shard;
 pub(crate) use tid::Tid;
 
-use alloc::sync::Arc;
-use cfg::CfgPrivate;
-use core::{fmt, marker::PhantomData, ptr};
-use shard::Shard;
+pub use self::cfg::{Config, DefaultConfig};
+pub use self::clear::Clear;
+pub use self::iter::UniqueIter;
 
 /// A sharded slab.
 ///

--- a/libs/ksharded-slab/src/page/mod.rs
+++ b/libs/ksharded-slab/src/page/mod.rs
@@ -1,15 +1,18 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use crate::Pack;
 use crate::cfg::{self, CfgPrivate};
 use crate::clear::Clear;
-use alloc::boxed::Box;
-use alloc::vec::Vec;
 
 pub(crate) mod slot;
 mod stack;
 
-pub(crate) use self::slot::Slot;
 use core::cell::UnsafeCell;
-use core::{fmt, marker::PhantomData};
+use core::fmt;
+use core::marker::PhantomData;
+
+pub(crate) use self::slot::Slot;
 
 /// A page address encodes the location of a slot within a shard (the page
 /// number and offset within that page) as a single linear value.

--- a/libs/ksharded-slab/src/page/slot.rs
+++ b/libs/ksharded-slab/src/page/slot.rs
@@ -1,9 +1,13 @@
-use super::FreeList;
-use crate::{Pack, Tid, cfg, clear::Clear};
 use core::cell::UnsafeCell;
+use core::marker::PhantomData;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use core::{fmt, marker::PhantomData, mem, ptr};
+use core::{fmt, mem, ptr};
+
 use spin::Backoff;
+
+use super::FreeList;
+use crate::clear::Clear;
+use crate::{Pack, Tid, cfg};
 
 pub(crate) struct Slot<T, C> {
     lifecycle: AtomicUsize,

--- a/libs/ksharded-slab/src/page/stack.rs
+++ b/libs/ksharded-slab/src/page/stack.rs
@@ -1,6 +1,8 @@
-use crate::cfg;
+use core::fmt;
+use core::marker::PhantomData;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use core::{fmt, marker::PhantomData};
+
+use crate::cfg;
 
 pub(super) struct TransferStack<C = cfg::DefaultConfig> {
     head: AtomicUsize,

--- a/libs/ksharded-slab/src/pool.rs
+++ b/libs/ksharded-slab/src/pool.rs
@@ -5,16 +5,14 @@
 //!
 //! [pool]: ../struct.Pool.html
 //! [`Slab`]: ../struct.Slab.html
-use crate::{
-    Pack, Shard,
-    cfg::{self, CfgPrivate, DefaultConfig},
-    clear::Clear,
-    page, shard,
-    tid::Tid,
-};
-
 use alloc::sync::Arc;
-use core::{fmt, marker::PhantomData};
+use core::fmt;
+use core::marker::PhantomData;
+
+use crate::cfg::{self, CfgPrivate, DefaultConfig};
+use crate::clear::Clear;
+use crate::tid::Tid;
+use crate::{Pack, Shard, page, shard};
 
 /// A lock-free concurrent object pool.
 ///

--- a/libs/ksharded-slab/src/shard.rs
+++ b/libs/ksharded-slab/src/shard.rs
@@ -1,15 +1,13 @@
-use crate::{
-    Pack,
-    cfg::{self, CfgPrivate},
-    clear::Clear,
-    page,
-    tid::Tid,
-};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::sync::atomic;
 use core::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use core::{fmt, ptr, slice};
+
+use crate::cfg::{self, CfgPrivate};
+use crate::clear::Clear;
+use crate::tid::Tid;
+use crate::{Pack, page};
 
 // ┌─────────────┐      ┌────────┐
 // │ page 1      │      │        │

--- a/libs/ksharded-slab/src/tid.rs
+++ b/libs/ksharded-slab/src/tid.rs
@@ -1,17 +1,14 @@
-use crate::{
-    Pack,
-    cfg::{self, CfgPrivate},
-    page,
-};
 use alloc::collections::VecDeque;
+use core::cell::{Cell, UnsafeCell};
+use core::fmt;
+use core::marker::PhantomData;
 use core::sync::atomic::{AtomicUsize, Ordering};
-use core::{
-    cell::{Cell, UnsafeCell},
-    fmt,
-    marker::PhantomData,
-};
+
 use cpu_local::cpu_local;
 use spin::{LazyLock, Mutex};
+
+use crate::cfg::{self, CfgPrivate};
+use crate::{Pack, page};
 
 /// Uniquely identifies a thread.
 pub(crate) struct Tid<C> {

--- a/libs/ktest/src/lib.rs
+++ b/libs/ktest/src/lib.rs
@@ -11,6 +11,7 @@ extern crate alloc;
 
 use alloc::boxed::Box;
 use core::pin::Pin;
+
 pub use ktest_macros::*;
 
 /// A single test case

--- a/libs/panic-unwind2/src/hook.rs
+++ b/libs/panic-unwind2/src/hook.rs
@@ -9,6 +9,7 @@ use alloc::string::String;
 use core::any::Any;
 use core::panic::Location;
 use core::{fmt, mem};
+
 use spin::RwLock;
 
 #[derive(Debug)]

--- a/libs/panic-unwind2/src/lib.rs
+++ b/libs/panic-unwind2/src/lib.rs
@@ -19,15 +19,17 @@ extern crate alloc;
 mod hook;
 mod panic_count;
 
-use crate::hook::{HOOK, Hook, PanicHookInfo, default_hook};
-use crate::panic_count::MustAbort;
-use abort::abort;
 use alloc::boxed::Box;
 use alloc::string::String;
 use core::any::Any;
 use core::panic::{PanicPayload, UnwindSafe};
 use core::{fmt, mem};
+
+use abort::abort;
 pub use hook::{set_hook, take_hook};
+
+use crate::hook::{HOOK, Hook, PanicHookInfo, default_hook};
+use crate::panic_count::MustAbort;
 
 /// Determines whether the current thread is unwinding because of panic.
 #[inline]

--- a/libs/panic-unwind2/src/panic_count.rs
+++ b/libs/panic-unwind2/src/panic_count.rs
@@ -5,10 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::{
-    cell::Cell,
-    sync::atomic::{AtomicUsize, Ordering},
-};
+use core::cell::Cell;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
 use cpu_local::cpu_local;
 
 /// A reason for forcing an immediate abort on panic.

--- a/libs/riscv/src/hio.rs
+++ b/libs/riscv/src/hio.rs
@@ -7,10 +7,12 @@
 
 //! Host I/O
 
-use super::semihosting::syscall;
 use core::fmt::{Error, Write};
 use core::{fmt, slice};
+
 use spin::Mutex;
+
+use super::semihosting::syscall;
 
 const OPEN: usize = 0x01;
 const WRITE: usize = 0x05;

--- a/libs/riscv/src/lib.rs
+++ b/libs/riscv/src/lib.rs
@@ -20,6 +20,7 @@ pub mod semihosting;
 pub mod trap;
 
 use core::arch::asm;
+
 pub use error::Error;
 pub use register::*;
 pub type Result<T> = core::result::Result<T, Error>;

--- a/libs/riscv/src/register/satp.rs
+++ b/libs/riscv/src/register/satp.rs
@@ -7,9 +7,10 @@
 
 //! Supervisor Address Translation and Protection Register
 
+use core::fmt;
+
 use super::{read_csr_as, write_csr};
 use crate::Error;
-use core::fmt;
 
 /// satp register
 #[derive(Clone, Copy)]

--- a/libs/riscv/src/register/scause.rs
+++ b/libs/riscv/src/register/scause.rs
@@ -7,10 +7,11 @@
 
 //! Supervisor Cause Register
 
-use super::{read_csr_as, write_csr};
-use crate::trap::Trap;
 use core::fmt;
 use core::fmt::Formatter;
+
+use super::{read_csr_as, write_csr};
+use crate::trap::Trap;
 
 /// scause register
 #[derive(Clone, Copy)]

--- a/libs/riscv/src/register/sie.rs
+++ b/libs/riscv/src/register/sie.rs
@@ -7,9 +7,10 @@
 
 //! Supervisor Interrupt Enable Register
 
-use super::{clear_csr, read_csr_as, set_csr};
 use core::fmt;
 use core::fmt::Formatter;
+
+use super::{clear_csr, read_csr_as, set_csr};
 
 /// sie register
 #[derive(Clone, Copy)]

--- a/libs/riscv/src/register/sstatus.rs
+++ b/libs/riscv/src/register/sstatus.rs
@@ -7,10 +7,11 @@
 
 //! Supervisor Status Register
 
-use super::{clear_csr, read_csr_as, set_clear_csr_field, set_csr};
-use crate::set_csr_field;
 use core::fmt;
 use core::fmt::Formatter;
+
+use super::{clear_csr, read_csr_as, set_clear_csr_field, set_csr};
+use crate::set_csr_field;
 
 /// Supervisor Status Register
 #[derive(Clone, Copy)]

--- a/libs/riscv/src/register/stvec.rs
+++ b/libs/riscv/src/register/stvec.rs
@@ -7,9 +7,10 @@
 
 //! Supervisor Trap Vector Base Address Register
 
-use super::{read_csr_as, set_csr};
 use core::fmt;
 use core::fmt::Formatter;
+
+use super::{read_csr_as, set_csr};
 
 #[derive(Clone, Copy)]
 pub struct Stvec {

--- a/libs/spin/src/barrier.rs
+++ b/libs/spin/src/barrier.rs
@@ -5,9 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::Mutex;
 use core::hint;
+
 use util::loom_const_fn;
+
+use crate::Mutex;
 
 pub struct Barrier {
     lock: Mutex<BarrierState>,
@@ -69,10 +71,10 @@ impl BarrierWaitResult {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::loom::Arc;
-    use crate::loom::thread;
     use std::sync::mpsc::{TryRecvError, channel};
+
+    use super::*;
+    use crate::loom::{Arc, thread};
 
     #[test]
     fn test_barrier() {

--- a/libs/spin/src/lazy_lock.rs
+++ b/libs/spin/src/lazy_lock.rs
@@ -5,16 +5,16 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::{Once, once::ExclusiveState};
-use crate::loom::UnsafeCell;
-use core::{
-    fmt,
-    mem::ManuallyDrop,
-    ops::Deref,
-    panic::{RefUnwindSafe, UnwindSafe},
-    ptr,
-};
+use core::mem::ManuallyDrop;
+use core::ops::Deref;
+use core::panic::{RefUnwindSafe, UnwindSafe};
+use core::{fmt, ptr};
+
 use util::loom_const_fn;
+
+use super::Once;
+use super::once::ExclusiveState;
+use crate::loom::UnsafeCell;
 
 union Data<T, F> {
     value: ManuallyDrop<T>,
@@ -167,11 +167,11 @@ impl<T: UnwindSafe, F: UnwindSafe> UnwindSafe for LazyLock<T, F> {}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::loom::thread;
-    use crate::loom::{AtomicUsize, Ordering};
-    use crate::{Mutex, OnceLock};
     use std::cell::LazyCell;
+
+    use super::*;
+    use crate::loom::{AtomicUsize, Ordering, thread};
+    use crate::{Mutex, OnceLock};
 
     fn spawn_and_wait<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> R {
         thread::spawn(f).join().unwrap()

--- a/libs/spin/src/mutex.rs
+++ b/libs/spin/src/mutex.rs
@@ -14,13 +14,14 @@
 // ArcMutexGuardarc_lock
 // An RAII mutex guard returned by the Arc locking operations on Mutex.
 
-use crate::backoff::Backoff;
-use crate::loom::Ordering;
-use crate::loom::{AtomicBool, UnsafeCell};
 use core::marker::PhantomData;
 use core::ops::{Deref, DerefMut};
 use core::{fmt, mem};
+
 use util::loom_const_fn;
+
+use crate::backoff::Backoff;
+use crate::loom::{AtomicBool, Ordering, UnsafeCell};
 
 /// A mutual exclusion primitive useful for protecting shared data
 ///
@@ -335,11 +336,11 @@ unsafe impl lock_api::RawMutex for Mutex<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::loom::Arc;
-    use crate::loom::AtomicUsize;
     use core::fmt::Debug;
     use std::{hint, mem};
+
+    use super::*;
+    use crate::loom::{Arc, AtomicUsize};
 
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);

--- a/libs/spin/src/once.rs
+++ b/libs/spin/src/once.rs
@@ -5,9 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::{AtomicU8, Ordering};
 use core::mem;
+
 use util::loom_const_fn;
+
+use crate::loom::{AtomicU8, Ordering};
 
 /// No initialization has run yet, and no thread is currently using the Once.
 const STATUS_INCOMPLETE: u8 = 0;
@@ -148,9 +150,10 @@ impl Drop for PanicGuard<'_> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc::channel;
+
     use super::*;
     use crate::loom::thread;
-    use std::sync::mpsc::channel;
 
     #[test]
     fn smoke_once() {

--- a/libs/spin/src/once_lock.rs
+++ b/libs/spin/src/once_lock.rs
@@ -5,14 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::fmt;
+use core::mem::MaybeUninit;
+use core::panic::{RefUnwindSafe, UnwindSafe};
+
+use util::loom_const_fn;
+
 use super::Once;
 use crate::loom::UnsafeCell;
-use core::{
-    fmt,
-    mem::MaybeUninit,
-    panic::{RefUnwindSafe, UnwindSafe},
-};
-use util::loom_const_fn;
 
 /// A synchronization primitive which can be written to only once.
 ///
@@ -316,10 +316,10 @@ unsafe impl<#[may_dangle] T> Drop for OnceLock<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::loom::thread;
-    use crate::loom::{AtomicUsize, Ordering};
     use std::sync::mpsc::channel;
+
+    use super::*;
+    use crate::loom::{AtomicUsize, Ordering, thread};
 
     fn spawn_and_wait<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> R {
         thread::spawn(f).join().unwrap()

--- a/libs/spin/src/remutex.rs
+++ b/libs/spin/src/remutex.rs
@@ -5,9 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::loom::AtomicUsize;
-use crate::loom::{Ordering, UnsafeCell};
-use crate::{Backoff, GuardNoSend};
 use core::cell::Cell;
 use core::fmt;
 use core::marker::PhantomData;
@@ -15,7 +12,11 @@ use core::num::NonZeroUsize;
 use core::ops::Deref;
 use core::ptr::addr_of;
 use core::sync::atomic::AtomicBool;
+
 use util::loom_const_fn;
+
+use crate::loom::{AtomicUsize, Ordering, UnsafeCell};
+use crate::{Backoff, GuardNoSend};
 
 /// A mutex which can be recursively locked by a single thread.
 ///

--- a/libs/spin/src/rw_lock.rs
+++ b/libs/spin/src/rw_lock.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::Backoff;
-use crate::loom::{AtomicUsize, Ordering, UnsafeCell};
 use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use core::{fmt, mem};
+
 use util::loom_const_fn;
+
+use crate::Backoff;
+use crate::loom::{AtomicUsize, Ordering, UnsafeCell};
 
 const READER: usize = 1 << 2;
 const UPGRADED: usize = 1 << 1;
@@ -621,13 +623,13 @@ fn compare_exchange(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::loom::Arc;
-    use crate::loom::thread;
     use core::fmt::Debug;
     use core::mem;
     use std::hint;
     use std::sync::mpsc::channel;
+
+    use super::*;
+    use crate::loom::{Arc, thread};
 
     #[derive(Eq, PartialEq, Debug)]
     struct NonCopy(i32);

--- a/libs/uart-16550/src/lib.rs
+++ b/libs/uart-16550/src/lib.rs
@@ -7,9 +7,10 @@
 
 #![cfg_attr(not(test), no_std)]
 
-use bitflags::bitflags;
 use core::fmt;
 use core::sync::atomic::{AtomicPtr, Ordering};
+
+use bitflags::bitflags;
 use spin::Backoff;
 
 macro_rules! wait_for {

--- a/libs/unwind2/src/arch/riscv64.rs
+++ b/libs/unwind2/src/arch/riscv64.rs
@@ -6,10 +6,10 @@
 // copied, modified, or distributed except according to those terms.
 
 //! RISC-V specific unwinding code, mostly saving and restoring registers.
-use cfg_if::cfg_if;
 use core::arch::{asm, naked_asm};
-use core::fmt;
-use core::ops;
+use core::{fmt, ops};
+
+use cfg_if::cfg_if;
 use gimli::{Register, RiscV};
 
 // Match DWARF_FRAME_REGISTERS in libgcc

--- a/libs/unwind2/src/eh_action.rs
+++ b/libs/unwind2/src/eh_action.rs
@@ -5,9 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use gimli::{EndianSlice, NativeEndian, Pointer, Reader, constants};
+
 use crate::frame::Frame;
 use crate::utils::deref_pointer;
-use gimli::{EndianSlice, NativeEndian, Pointer, Reader, constants};
 
 #[derive(Debug)]
 pub enum EHAction {

--- a/libs/unwind2/src/eh_info.rs
+++ b/libs/unwind2/src/eh_info.rs
@@ -5,9 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use super::utils::{deref_pointer, get_unlimited_slice};
 use gimli::{BaseAddresses, EhFrame, EhFrameHdr, EndianSlice, NativeEndian, ParsedEhFrameHdr};
 use spin::LazyLock;
+
+use super::utils::{deref_pointer, get_unlimited_slice};
 
 // Below is a fun hack: We need a reference to the `.eh_frame` and `.eh_frame_hdr` sections and
 // must therefore force the linker to retain those even in release builds. By abusing mutable statics

--- a/libs/unwind2/src/exception.rs
+++ b/libs/unwind2/src/exception.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::Error;
-use abort::abort;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::ffi::c_int;
 use core::ptr;
+
+use abort::abort;
+
+use crate::Error;
 
 /// The C ABI UnwindReasonCode passed to the exception cleanup function when a foreign
 /// (i.e. not originating from this crate) exception is caught. Since that exception might have

--- a/libs/unwind2/src/frame.rs
+++ b/libs/unwind2/src/frame.rs
@@ -5,14 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::eh_info::obtain_eh_info;
-use crate::utils::{StoreOnStack, deref_pointer, get_unlimited_slice, with_context};
 use fallible_iterator::FallibleIterator;
 use gimli::{
     CfaRule, EhFrame, EndianSlice, EvaluationResult, FrameDescriptionEntry, NativeEndian, Register,
     RegisterRule, UnwindExpression, UnwindSection, UnwindTableRow, Value,
 };
+
+use crate::arch;
+use crate::eh_info::obtain_eh_info;
+use crate::utils::{StoreOnStack, deref_pointer, get_unlimited_slice, with_context};
 
 /// A frame in a stack.
 ///

--- a/libs/unwind2/src/lang_items.rs
+++ b/libs/unwind2/src/lang_items.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use abort::abort;
+
 use crate::exception::Exception;
 use crate::utils::with_context;
 use crate::{Error, FrameIter, arch, raise_exception_phase2};
-use abort::abort;
 
 /// In traditional unwinders the personality routine is responsible for determining the unwinders
 /// behaviour for each frame (stop unwinding because a handler has been found, continue etc.)

--- a/libs/unwind2/src/lib.rs
+++ b/libs/unwind2/src/lib.rs
@@ -21,13 +21,15 @@ mod frame;
 mod lang_items;
 mod utils;
 
-use abort::abort;
 use alloc::boxed::Box;
 use core::any::Any;
 use core::intrinsics;
 use core::mem::ManuallyDrop;
 use core::panic::UnwindSafe;
 use core::ptr::addr_of_mut;
+
+use abort::abort;
+pub use arch::Registers;
 use eh_action::{EHAction, find_eh_action};
 pub use eh_info::EhInfo;
 pub use error::Error;
@@ -36,8 +38,6 @@ use fallible_iterator::FallibleIterator;
 pub use frame::{Frame, FrameIter};
 use lang_items::ensure_personality_stub;
 pub use utils::with_context;
-
-pub use arch::Registers;
 
 pub(crate) type Result<T> = core::result::Result<T, Error>;
 
@@ -228,8 +228,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloc::boxed::Box;
+
+    use super::*;
 
     #[test]
     fn begin_and_catch_roundtrip() {

--- a/libs/unwind2/src/utils.rs
+++ b/libs/unwind2/src/utils.rs
@@ -5,9 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
 use core::ptr;
+
 use gimli::{Pointer, Register, RegisterRule, UnwindTableRow};
+
+use crate::arch;
 
 pub struct StoreOnStack;
 

--- a/libs/util/src/checked_maybe_uninit.rs
+++ b/libs/util/src/checked_maybe_uninit.rs
@@ -5,7 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::{fmt, mem::MaybeUninit};
+use core::fmt;
+use core::mem::MaybeUninit;
 
 /// A checked version of [`MaybeUninit`]. This type is taken from mycelium.
 ///

--- a/libs/wast/src/error.rs
+++ b/libs/wast/src/error.rs
@@ -1,10 +1,11 @@
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use core::fmt;
+
+use unicode_width::UnicodeWidthStr;
+
 use crate::lexer::LexError;
 use crate::token::Span;
-use alloc::boxed::Box;
-use alloc::string::String;
-use alloc::string::ToString;
-use core::fmt;
-use unicode_width::UnicodeWidthStr;
 
 /// A convenience error type to tie together all the detailed errors produced by
 /// this crate.

--- a/libs/wast/src/gensym.rs
+++ b/libs/wast/src/gensym.rs
@@ -1,6 +1,8 @@
-use crate::token::{Id, Span};
 use core::cell::Cell;
+
 use cpu_local::cpu_local;
+
+use crate::token::{Id, Span};
 
 cpu_local!(static NEXT: Cell<u32> = Cell::new(0));
 

--- a/libs/wast/src/lexer.rs
+++ b/libs/wast/src/lexer.rs
@@ -24,17 +24,14 @@
 //!
 //! [`Lexer`]: crate::lexer::Lexer
 
+use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::str::Utf8Error;
+use core::{char, fmt, slice, str};
+
 use crate::Error;
 use crate::token::Span;
-use alloc::borrow::Cow;
-use alloc::string::String;
-use alloc::string::ToString;
-use alloc::vec::Vec;
-use core::char;
-use core::fmt;
-use core::slice;
-use core::str;
-use core::str::Utf8Error;
 
 /// A structure used to lex the s-expression syntax of WAT files.
 ///

--- a/libs/wast/src/names.rs
+++ b/libs/wast/src/names.rs
@@ -1,7 +1,9 @@
+use alloc::format;
+
+use hashbrown::HashMap;
+
 use crate::Error;
 use crate::token::{Id, Index};
-use alloc::format;
-use hashbrown::HashMap;
 
 #[derive(Default)]
 pub struct Namespace<'a> {

--- a/libs/wast/src/parser.rs
+++ b/libs/wast/src/parser.rs
@@ -62,19 +62,20 @@
 //! This module is heavily inspired by [`syn`](https://docs.rs/syn) so you can
 //! likely also draw inspiration from the excellent examples in the `syn` crate.
 
-use crate::Error;
-use crate::lexer::{Float, Integer, Lexer, Token, TokenKind};
-use crate::token::Span;
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
 use alloc::format;
-use alloc::string::String;
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
-use bumpalo::Bump;
 use core::cell::{Cell, RefCell};
 use core::fmt;
+
+use bumpalo::Bump;
 use hashbrown::HashMap;
+
+use crate::Error;
+use crate::lexer::{Float, Integer, Lexer, Token, TokenKind};
+use crate::token::Span;
 
 /// The maximum recursive depth of parens to parse.
 ///

--- a/libs/wast/src/token.rs
+++ b/libs/wast/src/token.rs
@@ -2,14 +2,13 @@
 //! associated specifically with the wasm text format per se (useful in other
 //! contexts too perhaps).
 
+use alloc::string::{String, ToString};
+use core::hash::{Hash, Hasher};
+use core::{fmt, str};
+
 use crate::annotation;
 use crate::lexer::Float;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
-use alloc::string::String;
-use alloc::string::ToString;
-use core::fmt;
-use core::hash::{Hash, Hasher};
-use core::str;
 
 /// A position in the original source stream, used to render errors.
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]

--- a/libs/wast/tests/parse-fail.rs
+++ b/libs/wast/tests/parse-fail.rs
@@ -4,9 +4,10 @@
 //! Use `BLESS=1` in the environment to auto-update `*.err` files. Be sure to
 //! look at the diff!
 
-use libtest_mimic::{Arguments, Trial};
 use std::env;
 use std::path::{Path, PathBuf};
+
+use libtest_mimic::{Arguments, Trial};
 
 fn main() {
     let mut tests = Vec::new();

--- a/libs/wavltree/benches/insertions_deletions.rs
+++ b/libs/wavltree/benches/insertions_deletions.rs
@@ -1,10 +1,11 @@
-use criterion::{Criterion, criterion_group, criterion_main};
-use rand::prelude::SliceRandom;
-use rand::thread_rng;
 use std::fmt;
 use std::mem::offset_of;
 use std::pin::Pin;
 use std::ptr::NonNull;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use rand::prelude::SliceRandom;
+use rand::thread_rng;
 use wavltree::{Linked, Links, WAVLTree};
 
 #[derive(Default)]

--- a/libs/wavltree/src/cursor.rs
+++ b/libs/wavltree/src/cursor.rs
@@ -5,8 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::{Link, Linked, WAVLTree, utils};
 use core::pin::Pin;
+
+use crate::{Link, Linked, WAVLTree, utils};
 
 /// A cursor which provides read-only access to a [`WAVLTree`].
 pub struct Cursor<'a, T>

--- a/libs/wavltree/src/dot.rs
+++ b/libs/wavltree/src/dot.rs
@@ -5,11 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::Linked;
-use crate::WAVLTree;
-use crate::utils::Side;
 use core::fmt;
 use core::ptr::NonNull;
+
+use crate::utils::Side;
+use crate::{Linked, WAVLTree};
 
 pub struct Dot<'a, T>
 where

--- a/libs/wavltree/src/entry.rs
+++ b/libs/wavltree/src/entry.rs
@@ -5,10 +5,11 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::utils::Side;
-use crate::{Link, Linked, WAVLTree, utils};
 use core::pin::Pin;
 use core::ptr::NonNull;
+
+use crate::utils::Side;
+use crate::{Link, Linked, WAVLTree, utils};
 
 pub enum Entry<'a, T>
 where

--- a/libs/wavltree/src/iter.rs
+++ b/libs/wavltree/src/iter.rs
@@ -5,10 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::{Link, Linked};
-use crate::{WAVLTree, utils};
 use core::iter::FusedIterator;
 use core::pin::Pin;
+
+use crate::{Link, Linked, WAVLTree, utils};
 
 /// An iterator over references to the entries of a [`WAVLTree`].
 pub struct Iter<'a, T: Linked + ?Sized> {

--- a/libs/wavltree/src/lib.rs
+++ b/libs/wavltree/src/lib.rs
@@ -148,14 +148,14 @@ use core::pin::Pin;
 use core::ptr::NonNull;
 use core::{fmt, mem, ptr};
 
+#[cfg(feature = "dot")]
+pub use dot::Dot;
+pub use iter::{IntoIter, Iter, IterMut};
+pub use utils::Side;
+
 pub use crate::cursor::{Cursor, CursorMut};
 pub use crate::entry::{Entry, OccupiedEntry, VacantEntry};
 use crate::utils::get_sibling;
-#[cfg(feature = "dot")]
-pub use dot::Dot;
-pub use iter::IntoIter;
-pub use iter::{Iter, IterMut};
-pub use utils::Side;
 
 /// Trait implemented by types which can be members of an [intrusive WAVL tree][WAVLTree].
 ///
@@ -1683,13 +1683,15 @@ impl<T: ?Sized> Links<T> {
 mod tests {
     extern crate alloc;
 
-    use super::*;
     use alloc::boxed::Box;
     use alloc::vec::Vec;
     use core::mem::offset_of;
     use core::pin::Pin;
+
     use rand::prelude::SliceRandom;
     use rand::rng;
+
+    use super::*;
 
     #[derive(Default)]
     struct TestEntry {

--- a/libs/wavltree/src/utils.rs
+++ b/libs/wavltree/src/utils.rs
@@ -5,9 +5,10 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::{Link, Linked};
 use core::ptr::NonNull;
 use core::{fmt, ptr};
+
+use crate::{Link, Linked};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Side {

--- a/loader/build.rs
+++ b/loader/build.rs
@@ -22,7 +22,8 @@ fn main() {
 }
 
 fn copy_linker_script() {
-    use std::{fs::File, io::Write};
+    use std::fs::File;
+    use std::io::Write;
 
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir);

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -5,17 +5,19 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::arch::{asm, naked_asm};
+use core::fmt;
+use core::num::NonZero;
+use core::ptr::NonNull;
+
+use bitflags::bitflags;
+use riscv::satp;
+
 use crate::GlobalInitResult;
 use crate::error::Error;
 use crate::frame_alloc::FrameAllocator;
 use crate::machine_info::MachineInfo;
 use crate::mapping::Flags;
-use bitflags::bitflags;
-use core::arch::{asm, naked_asm};
-use core::fmt;
-use core::num::NonZero;
-use core::ptr::NonNull;
-use riscv::satp;
 
 pub const DEFAULT_ASID: u16 = 0;
 pub const KERNEL_ASPACE_BASE: usize = 0xffffffc000000000;

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::frame_alloc::FrameAllocator;
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
 use core::range::Range;
 use core::slice;
+
 use loader_api::{BootInfo, MemoryRegion, MemoryRegionKind, MemoryRegions, TlsTemplate};
+
+use crate::arch;
+use crate::frame_alloc::FrameAllocator;
 
 #[expect(clippy::too_many_arguments, reason = "")]
 pub fn prepare_boot_info(

--- a/loader/src/frame_alloc.rs
+++ b/loader/src/frame_alloc.rs
@@ -5,13 +5,15 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
-use crate::error::Error;
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
 use core::range::Range;
 use core::{cmp, iter, ptr, slice};
+
 use fallible_iterator::FallibleIterator;
+
+use crate::arch;
+use crate::error::Error;
 
 pub struct FrameAllocator<'a> {
     regions: &'a [Range<usize>],

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::error::Error;
 use core::fmt::Formatter;
 use core::range::Range;
 use core::{fmt, slice};
+
 use loader_api::LoaderConfig;
 use xmas_elf::program::{ProgramHeader, Type};
+
+use crate::error::Error;
 
 /// The inlined kernel
 static INLINED_KERNEL_BYTES: KernelBytes = KernelBytes(*include_bytes!(env!("KERNEL")));

--- a/loader/src/machine_info.rs
+++ b/loader/src/machine_info.rs
@@ -5,18 +5,20 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch::PAGE_SIZE;
-use crate::error::Error;
-use crate::mapping::{align_down, checked_align_up};
-use arrayvec::ArrayVec;
 use core::cmp::Ordering;
 use core::ffi::{CStr, c_void};
 use core::fmt;
 use core::fmt::Formatter;
 use core::range::Range;
 use core::str::FromStr;
+
+use arrayvec::ArrayVec;
 use fallible_iterator::FallibleIterator;
 use fdt::{CellSizes, Fdt, PropertiesIter};
+
+use crate::arch::PAGE_SIZE;
+use crate::error::Error;
+use crate::mapping::{align_down, checked_align_up};
 
 /// Information about the machine we're running on.
 /// This is collected from the FDT (flatting device tree) passed to us by the previous stage loader.

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -11,6 +11,14 @@
 #![feature(maybe_uninit_slice)]
 #![feature(alloc_layout_extra)]
 
+use core::ffi::c_void;
+use core::range::Range;
+
+use arrayvec::ArrayVec;
+use rand::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use spin::{Barrier, OnceLock};
+
 use crate::boot_info::prepare_boot_info;
 use crate::error::Error;
 use crate::frame_alloc::FrameAllocator;
@@ -20,12 +28,6 @@ use crate::mapping::{
     StacksAllocation, TlsAllocation, identity_map_self, map_kernel, map_kernel_stacks,
     map_physical_memory,
 };
-use arrayvec::ArrayVec;
-use core::ffi::c_void;
-use core::range::Range;
-use rand::SeedableRng;
-use rand_chacha::ChaCha20Rng;
-use spin::{Barrier, OnceLock};
 
 mod arch;
 mod boot_info;

--- a/loader/src/mapping.rs
+++ b/loader/src/mapping.rs
@@ -5,22 +5,24 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::alloc::Layout;
+use core::num::NonZeroUsize;
+use core::range::Range;
+use core::{cmp, ptr, slice};
+
+use bitflags::bitflags;
+use fallible_iterator::FallibleIterator;
+use loader_api::TlsTemplate;
+use xmas_elf::P64;
+use xmas_elf::dynamic::Tag;
+use xmas_elf::program::{SegmentData, Type};
+
 use crate::error::Error;
 use crate::frame_alloc::FrameAllocator;
 use crate::kernel::Kernel;
 use crate::machine_info::MachineInfo;
 use crate::page_alloc::PageAllocator;
 use crate::{SelfRegions, arch};
-use bitflags::bitflags;
-use core::alloc::Layout;
-use core::num::NonZeroUsize;
-use core::range::Range;
-use core::{cmp, ptr, slice};
-use fallible_iterator::FallibleIterator;
-use loader_api::TlsTemplate;
-use xmas_elf::P64;
-use xmas_elf::dynamic::Tag;
-use xmas_elf::program::{SegmentData, Type};
 
 bitflags! {
     #[derive(Debug, Copy, Clone, PartialEq)]

--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -5,12 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
 use core::alloc::Layout;
 use core::range::Range;
+
 use rand::distr::{Distribution, Uniform};
 use rand::prelude::IteratorRandom;
 use rand_chacha::ChaCha20Rng;
+
+use crate::arch;
 
 pub fn init(prng: Option<ChaCha20Rng>) -> PageAllocator {
     PageAllocator {

--- a/loader/src/panic.rs
+++ b/loader/src/panic.rs
@@ -5,8 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use crate::arch;
 use abort::abort;
+
+use crate::arch;
 
 #[panic_handler]
 fn panic(info: &core::panic::PanicInfo) -> ! {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"


### PR DESCRIPTION
Adds a `rustfmt.toml` file with the following configuration:

```toml
group_imports = "StdExternalCrate"
imports_granularity = "Module"
```

Defining a stable ordering of `use` items which are traditionally quite messy