### PR TITLE
fix(kasync): remove `*.try_spawn_in` methods.

### DIFF
--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -171,7 +171,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         // (e.g. setting the trap vector and enabling interrupts)
         let cpu = arch::device::cpu::Cpu::new(&device_tree, cpuid)?;
 
-        let executor = Executor::with_capacity(boot_info.cpu_mask.count_ones() as usize);
+        let executor = Executor::with_capacity(boot_info.cpu_mask.count_ones() as usize).unwrap();
         let timer = Timer::new(Duration::from_millis(1), cpu.clock);
 
         Ok(Global {
@@ -200,7 +200,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         Instant::from_ticks(&global.timer, Ticks(boot_ticks)).elapsed(&global.timer)
     );
 
-    let mut worker2 = Worker::new(&global.executor, FastRand::from_seed(rng.next_u64()));
+    let mut worker2 = Worker::new(&global.executor, FastRand::from_seed(rng.next_u64())).unwrap();
 
     cfg_if! {
         if #[cfg(test)] {

--- a/libs/kasync/src/lib.rs
+++ b/libs/kasync/src/lib.rs
@@ -9,11 +9,10 @@
 //!
 //! This crate was heavily inspired by tokio and the (much better) maitake crates, to a small extend smol also influenced the design.
 
-#![feature(allocator_api)]
 #![cfg_attr(not(any(test, feature = "__bench")), no_std)]
 #![feature(debug_closure_helpers)]
 #![feature(never_type)]
-
+#![feature(allocator_api)]
 extern crate alloc;
 
 mod error;

--- a/libs/kasync/src/task/builder.rs
+++ b/libs/kasync/src/task/builder.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::boxed::Box;
-use core::alloc::Allocator;
 use core::any::type_name;
 use core::panic::Location;
 
@@ -102,36 +101,6 @@ where
     {
         let task = self.build(future);
         let task = Box::try_new(task)?;
-        let (task, join) = TaskRef::new_allocated(task);
-
-        (self.schedule)(task)?;
-
-        Ok(join)
-    }
-
-    /// Attempt spawn this [`Future`] onto the executor using a custom [`Allocator`].
-    ///
-    /// This method returns a [`TaskRef`] which can be used to spawn it onto an [`crate::executor::Executor`]
-    /// and a [`JoinHandle`] which can be used to await the futures output as well as control some aspects
-    /// of its runtime behaviour (such as cancelling it).
-    ///
-    /// # Errors
-    ///
-    /// Returns [`AllocError`] when allocation of the task fails.
-    #[inline]
-    #[track_caller]
-    pub fn try_spawn_in<F, A>(
-        &self,
-        future: F,
-        alloc: A,
-    ) -> Result<JoinHandle<F::Output>, SpawnError>
-    where
-        F: Future + Send,
-        F::Output: Send,
-        A: Allocator,
-    {
-        let task = self.build(future);
-        let task = Box::try_new_in(task, alloc)?;
         let (task, join) = TaskRef::new_allocated(task);
 
         (self.schedule)(task)?;

--- a/libs/kasync/src/time/sleep.rs
+++ b/libs/kasync/src/time/sleep.rs
@@ -163,12 +163,12 @@ mod tests {
 
         loom::model(move || {
             loom::lazy_static! {
-                static ref EXEC: Executor = Executor::new();
+                static ref EXEC: Executor = Executor::new().unwrap();
                 static ref TIMER: Timer = Timer::new(Duration::from_millis(1), MockClock::new_1us());
                 static ref CALLED: AtomicBool = AtomicBool::new(false);
             }
 
-            let mut worker = Worker::new(&EXEC, FastRand::from_seed(0));
+            let mut worker = Worker::new(&EXEC, FastRand::from_seed(0)).unwrap();
 
             let th = EXEC
                 .try_spawn(async move {


### PR DESCRIPTION
We cannot actually allocate tasks with an allocator other than the default global one, since we currently do not have the ability to free using a custom allocator.