### PR TITLE
feat(kasync): arbitrary task metadata

### DIFF
--- a/kernel/src/state.rs
+++ b/kernel/src/state.rs
@@ -24,7 +24,7 @@ cpu_local! {
 
 #[derive(Debug)]
 pub struct Global {
-    pub executor: Executor,
+    pub executor: Executor<()>,
     pub timer: Timer,
     pub device_tree: DeviceTree,
     pub boot_info: &'static BootInfo,

--- a/libs/kasync/src/lib.rs
+++ b/libs/kasync/src/lib.rs
@@ -13,8 +13,8 @@
 #![feature(debug_closure_helpers)]
 #![feature(never_type)]
 #![feature(allocator_api)]
-extern crate alloc;
 
+extern crate alloc;
 mod error;
 pub mod executor;
 pub mod loom;


### PR DESCRIPTION
This PR adds the ability for a task to store arbitrary metadata, we will want to use this in the future to associate as tasks address space, fault handlers etc.

Unfortunately this turns into a bit of a generics nightmare :/