### PR TITLE
refactor(kasync): simplify stub

### DIFF
--- a/libs/kasync/src/executor.rs
+++ b/libs/kasync/src/executor.rs
@@ -7,7 +7,6 @@
 
 mod steal;
 
-use alloc::boxed::Box;
 use core::alloc::AllocError;
 use core::num::NonZeroUsize;
 use core::ptr;
@@ -25,7 +24,7 @@ use crate::executor::steal::{Injector, Stealer, TryStealError};
 use crate::future::Either;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
 use crate::sync::wait_queue::WaitQueue;
-use crate::task::{Header, JoinHandle, PollResult, Task, TaskBuilder, TaskRef};
+use crate::task::{Header, JoinHandle, PollResult, TaskBuilder, TaskRef};
 
 #[derive(Debug)]
 pub struct Executor {
@@ -332,8 +331,7 @@ impl Worker {
 
 impl Scheduler {
     fn new() -> Result<Self, AllocError> {
-        let stub_task = Box::try_new(Task::new_stub())?;
-        let (stub_task, _) = TaskRef::new_allocated(stub_task);
+        let stub_task = TaskRef::new_stub()?;
 
         Ok(Self {
             run_queue: MpscQueue::new_with_stub(stub_task),

--- a/libs/kasync/src/executor/steal.rs
+++ b/libs/kasync/src/executor/steal.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use alloc::boxed::Box;
 use core::alloc::AllocError;
 use core::fmt::Debug;
 use core::num::NonZeroUsize;
@@ -14,7 +13,7 @@ use cordyceps::{MpscQueue, mpsc_queue};
 
 use crate::executor::Scheduler;
 use crate::loom::sync::atomic::{AtomicUsize, Ordering};
-use crate::task::{Header, Task, TaskRef};
+use crate::task::{Header, TaskRef};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]
@@ -34,8 +33,7 @@ pub struct Injector {
 
 impl Injector {
     pub fn new() -> Result<Self, AllocError> {
-        let stub_task = Box::try_new(Task::new_stub())?;
-        let (stub_task, _) = TaskRef::new_allocated(stub_task);
+        let stub_task = TaskRef::new_stub()?;
 
         Ok(Self {
             run_queue: MpscQueue::new_with_stub(stub_task),


### PR DESCRIPTION
This change build off of #525 and further simplifies the task code. The major simplification comes from the stub task, which used to be a full task but now is just a `Header` allocation.