### PR TITLE
ignore 'arange' typo false positive

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -16,12 +16,12 @@ rela = "rela" # the relocation format
 welp = "welp"
 alo = "alo" # for address-low
 canonicalizations = "canonicalizations"
+aranges = "aranges" # for address-ranges, used in kaddrline2
 
 [default]
 extend-ignore-identifiers-re = [
     "(?i:WAKE_ALLS)"
 ]
-#WAKE_ALLS = "WAKE_ALLS"
 
 [files]
 extend-exclude = ["**/emit_tests.rs", "tests/testsuite"]


### PR DESCRIPTION
This PR ignores the newly flagged, false-positive `arange`/`aranges` typos.