### PR TITLE
refactor(wavltree): add context parameter to `assert_valid` method.

### DIFF
--- a/kernel/src/mem/frame_alloc/frame.rs
+++ b/kernel/src/mem/frame_alloc/frame.rs
@@ -133,11 +133,13 @@ impl Frame {
     }
 
     /// Asserts the `Frame` is in a valid state.
-    pub fn assert_valid(&self) {
+    pub fn assert_valid(&self, ctx: &str) {
         let refcount = self.info().refcount.load(Ordering::Acquire);
-        assert!(refcount > 0);
-        assert!(refcount < MAX_REFCOUNT);
-        self.info().assert_valid();
+        assert!(
+            refcount < MAX_REFCOUNT,
+            "{ctx}refcount overflowed (must only be within 0..{MAX_REFCOUNT})"
+        );
+        self.info().assert_valid(ctx);
     }
 
     #[inline]
@@ -267,7 +269,7 @@ impl FrameInfo {
     }
 
     #[inline]
-    pub fn assert_valid(&self) {
+    pub fn assert_valid(&self, _ctx: &str) {
         // TODO add asserts here as we add more fields
     }
 }

--- a/kernel/src/mem/frame_alloc/frame_list.rs
+++ b/kernel/src/mem/frame_alloc/frame_list.rs
@@ -217,9 +217,9 @@ impl FrameList {
     }
 
     /// Asserts the frame list is in a valid state.
-    pub fn assert_valid(&self) {
-        self.nodes.assert_valid();
-        self.iter().for_each(|frame| frame.assert_valid());
+    pub fn assert_valid(&self, ctx: &str) {
+        self.nodes.assert_valid(ctx);
+        self.iter().for_each(|frame| frame.assert_valid(ctx));
     }
 }
 

--- a/kernel/src/mem/frame_alloc/mod.rs
+++ b/kernel/src/mem/frame_alloc/mod.rs
@@ -117,7 +117,8 @@ impl FrameAllocator {
         let frame = unsafe { Frame::from_free_info(frame) };
 
         #[cfg(debug_assertions)]
-        frame.assert_valid();
+        frame.assert_valid("FrameAllocator::alloc_one after allocation");
+
         Ok(frame)
     }
 
@@ -164,8 +165,10 @@ impl FrameAllocator {
             // Safety: we just allocated the frame
             unsafe { Frame::from_free_info(info) }
         }));
+
         #[cfg(debug_assertions)]
-        frames.assert_valid();
+        frames.assert_valid("FrameAllocator::allocate_contiguous after allocation");
+
         Ok(frames)
     }
 


### PR DESCRIPTION
The context parameter added in this change will be printed in front of all assert messages making it easier to associate wider runtime context with potential panics for better debuggability.