### PR TITLE
wip(kmem): AddressSpace API and AddressSpaceRegion tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kmem"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "lock_api",
+ "mycelium-bitfield",
+ "pin-project",
+ "wavltree",
+]
+
+[[package]]
 name = "ksharded-slab"
 version = "0.1.7"
 dependencies = [

--- a/libs/kmem/Cargo.toml
+++ b/libs/kmem/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kmem"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+lock_api.workspace = true
+anyhow.workspace = true
+mycelium-bitfield.workspace = true
+wavltree.workspace = true
+pin-project.workspace = true
+
+[lints]
+workspace = true

--- a/libs/kmem/src/access_rules.rs
+++ b/libs/kmem/src/access_rules.rs
@@ -1,0 +1,90 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+mycelium_bitfield::bitfield! {
+    /// Rules that dictate how a region of virtual memory may be accessed.
+    ///
+    /// # W^X
+    ///
+    /// In order to prevent malicious code execution as proactively as possible,
+    /// [`AccessRules`] can either allow *writes* OR *execution* but never both. This is enforced
+    /// through the [`WriteOrExecute`] enum field.
+    #[derive(PartialEq, Eq)]
+    pub struct AccessRules<u8> {
+        /// If set, reading from the memory region is allowed.
+        pub const READ: bool;
+        /// Whether executing, or writing this memory region is allowed (or neither).
+        pub const WRITE_OR_EXECUTE: WriteOrExecute;
+        /// If set, requires code in the memory region to use aarch64 Branch Target Identification.
+        /// Does nothing on non-aarch64 architectures.
+        pub const BTI: bool;
+    }
+}
+
+/// Whether executing, or writing this memory region is allowed (or neither).
+///
+/// This is an enum to enforce [`W^X`] at the type-level.
+///
+/// [`W^X`]: AccessRules
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum WriteOrExecute {
+    /// Neither writing nor execution of the memory region is allowed.
+    Neither = 0b00,
+    /// Writing to the memory region is allowed.
+    Write = 0b01,
+    /// Executing code from the memory region is allowed.
+    Execute = 0b10,
+}
+
+// ===== impl AccessRules =====
+
+impl AccessRules {
+    pub const fn is_read_only(&self) -> bool {
+        const READ_MASK: u8 = AccessRules::READ.max_value();
+        self.0 & READ_MASK == 1
+    }
+
+    pub fn allows_read(&self) -> bool {
+        self.get(Self::READ)
+    }
+
+    pub fn allows_write(&self) -> bool {
+        matches!(self.get(Self::WRITE_OR_EXECUTE), WriteOrExecute::Write)
+    }
+
+    pub fn allows_execution(&self) -> bool {
+        matches!(self.get(Self::WRITE_OR_EXECUTE), WriteOrExecute::Execute)
+    }
+}
+
+// ===== impl WriteOrExecute =====
+
+impl mycelium_bitfield::FromBits<u8> for WriteOrExecute {
+    type Error = core::convert::Infallible;
+
+    /// The number of bits required to represent a value of this type.
+    const BITS: u32 = 2;
+
+    #[inline]
+    fn try_from_bits(bits: u8) -> Result<Self, Self::Error> {
+        match bits {
+            b if b == Self::Neither as u8 => Ok(Self::Neither),
+            b if b == Self::Write as u8 => Ok(Self::Write),
+            b if b == Self::Execute as u8 => Ok(Self::Execute),
+            _ => {
+                // this should never happen unless the bitpacking code is broken
+                unreachable!("invalid memory region access rules {bits:#b}")
+            }
+        }
+    }
+
+    #[inline]
+    fn into_bits(self) -> u8 {
+        self as u8
+    }
+}

--- a/libs/kmem/src/address_space.rs
+++ b/libs/kmem/src/address_space.rs
@@ -1,0 +1,292 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+mod region;
+
+use core::alloc::Layout;
+use core::ptr::NonNull;
+
+use wavltree::WAVLTree;
+
+use crate::AccessRules;
+use crate::address_space::region::AddressSpaceRegion;
+
+pub struct AddressSpace {
+    regions: WAVLTree<AddressSpaceRegion>,
+}
+
+// ===== impl AddressSpace =====
+
+impl Default for AddressSpace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AddressSpace {
+    pub const fn new() -> Self {
+        todo!()
+    }
+
+    /// Attempts to reserve a region of virtual memory.
+    ///
+    /// On success, returns a [`NonNull<[u8]>`][NonNull] meeting the size and alignment guarantees
+    /// of `layout`. Access to this region must obey the provided `rules` or cause a hardware fault.
+    ///
+    /// The returned region may have a larger size than specified by `layout.size()`, and may or may
+    /// not have its contents initialized.
+    ///
+    /// The returned region of virtual memory remains mapped as long as it is [*currently mapped*]
+    /// and the address space type itself has not been dropped.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates the layout does not meet the address space's size or alignment
+    /// constraints, virtual memory is exhausted, or mapping otherwise fails.
+    #[expect(unused, reason = "used by later change")]
+    pub fn map<R: lock_api::RawRwLock>(
+        &mut self,
+        layout: Layout,
+        access_rules: AccessRules,
+    ) -> crate::Result<NonNull<[u8]>> {
+        // self.regions.insert(AddressSpaceRegion::new());
+
+        todo!()
+    }
+
+    /// Attempts to extend the virtual memory reservation.
+    ///
+    /// Returns a new [`NonNull<[u8]>`][NonNull] containing a pointer and the actual size of the
+    /// mapped region. The pointer is suitable for holding data described by `new_layout`. To accomplish
+    /// this, the address space may extend the mapping referenced by `ptr` to fit the new layout.
+    ///
+    /// TODO describe how extending a file-backed, of DMA-backed mapping works
+    ///
+    /// The [`AccessRules`] of the new virtual memory region are *the same* at the old ones.
+    ///
+    /// If this returns `Ok`, then ownership of the memory region referenced by `ptr` has been
+    /// transferred to this address space. Any access to the old `ptr` is [*Undefined Behavior*],
+    /// even if the mapping was grown in-place. The newly returned pointer is the only valid pointer
+    /// for accessing this region now.
+    ///
+    /// If this method returns `Err`, then ownership of the memory region has not been transferred to
+    /// this address space, and the contents of the region are unaltered.
+    ///
+    /// [*Undefined Behavior*]
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space.
+    /// * `old_layout` must [*fit*] that region (The `new_layout` argument need not fit it.).
+    /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
+    ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates the layout does not meet the address space's size or alignment
+    /// constraints, virtual memory is exhausted, or growing otherwise fails.
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn grow(
+        &mut self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> crate::Result<NonNull<[u8]>> {
+        todo!()
+    }
+
+    /// Behaves like [`grow`][AddressSpace::grow], only grows the region if it can be grown in-place.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space.
+    /// * `old_layout` must [*fit*] that region (The `new_layout` argument need not fit it.).
+    /// * `new_layout.size()` must be greater than or equal to `old_layout.size()`.
+    ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates the layout does not meet the address space's size or alignment
+    /// constraints, virtual memory is exhausted, or growing otherwise fails.
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn grow_in_place(
+        &mut self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> crate::Result<NonNull<[u8]>> {
+        todo!()
+    }
+
+    /// Attempts to shrink the virtual memory reservation.
+    ///
+    /// Returns a new [`NonNull<[u8]>`][NonNull] containing a pointer and the actual size of the
+    /// mapped region. The pointer is suitable for holding data described by `new_layout`. To accomplish
+    /// this, the address space may shrink the mapping referenced by `ptr` to fit the new layout.
+    ///
+    /// TODO describe how shrinking a file-backed, of DMA-backed mapping works
+    ///
+    /// The [`AccessRules`] of the new virtual memory region are *the same* at the old ones.
+    ///
+    /// If this returns `Ok`, then ownership of the memory region referenced by `ptr` has been
+    /// transferred to this address space. Any access to the old `ptr` is [*Undefined Behavior*],
+    /// even if the mapping was shrunk in-place. The newly returned pointer is the only valid pointer
+    /// for accessing this region now.
+    ///
+    /// If this method returns `Err`, then ownership of the memory region has not been transferred to
+    /// this address space, and the contents of the region are unaltered.
+    ///
+    /// [*Undefined Behavior*]
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space.
+    /// * `old_layout` must [*fit*] that region (The `new_layout` argument need not fit it.).
+    /// * `new_layout.size()` must be smaller than or equal to `old_layout.size()`.
+    ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates the layout does not meet the address space's size or alignment
+    /// constraints, virtual memory is exhausted, or shrinking otherwise fails.
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn shrink(
+        &mut self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> crate::Result<NonNull<[u8]>> {
+        todo!()
+    }
+
+    /// Behaves like [`shrink`][AddressSpace::shrink], but *guarantees* that the region will be
+    /// shrunk in-place. Both `old_layout` and `new_layout` need to be at least page aligned.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space.
+    /// * `old_layout` must [*fit*] that region (The `new_layout` argument need not fit it.).
+    /// * `new_layout.size()` must be smaller than or equal to `old_layout.size()`.
+    ///
+    /// Note that `new_layout.align()` need not be the same as `old_layout.align()`.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates the layout does not meet the address space's size or alignment
+    /// constraints, virtual memory is exhausted, or growing otherwise fails.
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn shrink_in_place(
+        &mut self,
+        ptr: NonNull<u8>,
+        old_layout: Layout,
+        new_layout: Layout,
+    ) -> crate::Result<NonNull<[u8]>> {
+        todo!()
+    }
+
+    /// Unmaps the virtual memory region referenced by `ptr`.
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space, and
+    /// * `layout` must [*fit*] that region of memory.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn unmap(&mut self, ptr: NonNull<u8>, layout: Layout) {
+        todo!()
+    }
+
+    /// Updates the access rules for the virtual memory region referenced by `ptr`.
+    ///
+    /// After this returns, access to this region must obey the new `rules` or cause a hardware fault.
+    // If this returns `Ok`, access to this region must obey the new `rules` or cause a hardware fault.
+    // If this method returns `Err`, the access rules of the memory region are unaltered.
+    ///
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space, and
+    /// * `layout` must [*fit*] that region of memory.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn update_access_rules(
+        &mut self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+        access_rules: AccessRules,
+    ) {
+        todo!()
+    }
+
+    /// Attempts to fill the virtual memory region referenced by `ptr` with zeroes.
+    ///
+    /// Returns a new [`NonNull<[u8]>`][NonNull] containing a pointer and the actual size of the
+    /// mapped region. The pointer is suitable for holding data described by `new_layout` and is
+    /// *guaranteed* to be zero-initialized. To accomplish this, the address space may remap the
+    /// virtual memory region.
+    ///
+    /// TODO describe how clearing a file-backed, of DMA-backed mapping works
+    ///
+    /// The [`AccessRules`] of the new virtual memory region are *the same* at the old ones.
+    ///
+    /// If this returns `Ok`, then ownership of the memory region referenced by `ptr` has been
+    /// transferred to this address space. Any access to the old `ptr` is [*Undefined Behavior*],
+    /// even if the mapping was cleared in-place. The newly returned pointer is the only valid pointer
+    /// for accessing this region now.
+    ///
+    /// If this method returns `Err`, then ownership of the memory region has not been transferred to
+    /// this address space, and the contents of the region are unaltered.
+    ///
+    /// [*Undefined Behavior*]
+    ///
+    /// # Safety
+    ///
+    /// * `ptr` must denote a region of memory [*currently mapped*] in this address space, and
+    /// * `layout` must [*fit*] that region of memory.
+    ///
+    /// [*currently mapped*]: #currently-mapped-memory
+    /// [*fit*]: #memory-fitting
+    ///
+    /// # Errors
+    ///
+    /// Returning `Err` indicates the layout does not meet the address space's size or alignment
+    /// constraints, clearing a virtual memory region is not supported by the backing storage, or
+    /// clearing otherwise fails.
+    #[expect(unused, reason = "used by later change")]
+    pub unsafe fn clear(
+        &mut self,
+        ptr: NonNull<u8>,
+        layout: Layout,
+    ) -> crate::Result<NonNull<[u8]>> {
+        todo!()
+    }
+
+    pub fn assert_valid(&self, ctx: &str) {
+        self.regions.assert_valid(ctx);
+    }
+}

--- a/libs/kmem/src/address_space/region.rs
+++ b/libs/kmem/src/address_space/region.rs
@@ -1,0 +1,72 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use alloc::boxed::Box;
+use core::alloc::Layout;
+use core::mem::offset_of;
+use core::ops::Range;
+use core::pin::Pin;
+use core::ptr::NonNull;
+
+use pin_project::pin_project;
+
+use crate::{AccessRules, VirtualAddress};
+
+#[pin_project(!Unpin)]
+#[derive(Debug)]
+pub struct AddressSpaceRegion {
+    range: Range<VirtualAddress>,
+    access_rules: AccessRules,
+    #[cfg(debug_assertions)]
+    layout: Layout,
+
+    /// The address range covered by this region and its WAVL tree subtree, used when allocating new regions
+    subtree_range: Range<VirtualAddress>,
+    /// The largest gap in this subtree, used when allocating new regions
+    max_gap: usize,
+
+    /// Links to other regions in the WAVL tree
+    #[pin]
+    links: wavltree::Links<AddressSpaceRegion>,
+}
+
+// Safety: the pinning and !Unpin requirements are enforced by the `#[pin_project(!Unpin)]` attribute
+// of the `AddressSpaceRegion`. see above.
+unsafe impl wavltree::Linked for AddressSpaceRegion {
+    /// Any heap-allocated type that owns an element may be used.
+    ///
+    /// An element *must not* move while part of an intrusive data
+    /// structure. In many cases, `Pin` may be used to enforce this.
+    type Handle = Pin<Box<Self>>; // TODO better handle type
+
+    type Key = VirtualAddress;
+
+    /// Convert an owned `Handle` into a raw pointer
+    fn into_ptr(handle: Self::Handle) -> NonNull<Self> {
+        // Safety: wavltree treats the ptr as pinned
+        unsafe { NonNull::from(Box::leak(Pin::into_inner_unchecked(handle))) }
+    }
+
+    /// Convert a raw pointer back into an owned `Handle`.
+    unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+        // Safety: `NonNull` *must* be constructed from a pinned reference
+        // which the tree implementation upholds.
+        unsafe { Pin::new_unchecked(Box::from_raw(ptr.as_ptr())) }
+    }
+
+    unsafe fn links(ptr: NonNull<Self>) -> NonNull<wavltree::Links<Self>> {
+        ptr.map_addr(|addr| {
+            let offset = offset_of!(Self, links);
+            addr.checked_add(offset).unwrap()
+        })
+        .cast()
+    }
+
+    fn get_key(&self) -> &Self::Key {
+        &self.range.start
+    }
+}

--- a/libs/kmem/src/addresses.rs
+++ b/libs/kmem/src/addresses.rs
@@ -1,0 +1,417 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use core::alloc::{Layout, LayoutError};
+use core::ops::Range;
+
+macro_rules! impl_address {
+    ($address_ty:ident) => {
+        impl $address_ty {
+            pub const MAX: Self = Self(usize::MAX);
+            pub const MIN: Self = Self(0);
+            pub const ZERO: Self = Self(0);
+            pub const BITS: u32 = usize::BITS;
+
+            #[inline]
+            pub const fn get(&self) -> usize {
+                self.0
+            }
+
+            #[must_use]
+            #[inline]
+            pub fn from_ptr<T: ?Sized>(ptr: *const T) -> Self {
+                Self(ptr.expose_provenance())
+            }
+
+            #[must_use]
+            #[inline]
+            pub fn from_mut_ptr<T: ?Sized>(ptr: *mut T) -> Self {
+                Self(ptr.expose_provenance())
+            }
+
+            #[must_use]
+            #[inline]
+            pub fn from_non_null<T: ?Sized>(ptr: ::core::ptr::NonNull<T>) -> Self {
+                Self(ptr.addr().get())
+            }
+
+            #[inline]
+            pub fn as_ptr(self) -> *const u8 {
+                ::core::ptr::with_exposed_provenance(self.0)
+            }
+
+            #[inline]
+            pub fn as_mut_ptr(self) -> *mut u8 {
+                ::core::ptr::with_exposed_provenance_mut(self.0)
+            }
+
+            #[inline]
+            pub fn as_non_null(self) -> Option<::core::ptr::NonNull<u8>> {
+                ::core::num::NonZeroUsize::new(self.0)
+                    .map(::core::ptr::NonNull::with_exposed_provenance)
+            }
+
+            #[must_use]
+            #[inline]
+            pub const fn checked_add(self, rhs: usize) -> Option<Self> {
+                if let Some(out) = self.0.checked_add(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+
+            #[must_use]
+            #[inline]
+            pub const fn checked_add_signed(self, rhs: isize) -> Option<Self> {
+                if let Some(out) = self.0.checked_add_signed(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+
+            #[must_use]
+            #[inline]
+            pub const fn checked_sub(self, rhs: usize) -> Option<Self> {
+                if let Some(out) = self.0.checked_sub(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+            #[must_use]
+            #[inline]
+            pub const fn checked_div(self, rhs: usize) -> Option<Self> {
+                if let Some(out) = self.0.checked_div(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+            #[must_use]
+            #[inline]
+            pub const fn checked_mul(self, rhs: usize) -> Option<Self> {
+                if let Some(out) = self.0.checked_mul(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+            #[must_use]
+            #[inline]
+            pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
+                if let Some(out) = self.0.checked_shl(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+            #[must_use]
+            #[inline]
+            pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
+                if let Some(out) = self.0.checked_shr(rhs) {
+                    Some(Self(out))
+                } else {
+                    None
+                }
+            }
+            // #[must_use]
+            // #[inline]
+            // pub const fn saturating_add(self, rhs: usize) -> Self {
+            //     Self(self.0.saturating_add(rhs))
+            // }
+            // #[must_use]
+            // #[inline]
+            // pub const fn saturating_add_signed(self, rhs: isize) -> Self {
+            //     Self(self.0.saturating_add_signed(rhs))
+            // }
+            // #[must_use]
+            // #[inline]
+            // pub const fn saturating_div(self, rhs: usize) -> Self {
+            //     Self(self.0.saturating_div(rhs))
+            // }
+            // #[must_use]
+            // #[inline]
+            // pub const fn saturating_sub(self, rhs: usize) -> Self {
+            //     Self(self.0.saturating_sub(rhs))
+            // }
+            // #[must_use]
+            // #[inline]
+            // pub const fn saturating_mul(self, rhs: usize) -> Self {
+            //     Self(self.0.saturating_mul(rhs))
+            // }
+            #[must_use]
+            #[inline]
+            pub const fn overflowing_shl(self, rhs: u32) -> (Self, bool) {
+                let (a, b) = self.0.overflowing_shl(rhs);
+                (Self(a), b)
+            }
+            #[must_use]
+            #[inline]
+            pub const fn overflowing_shr(self, rhs: u32) -> (Self, bool) {
+                let (a, b) = self.0.overflowing_shr(rhs);
+                (Self(a), b)
+            }
+
+            #[must_use]
+            #[inline]
+            pub const fn checked_sub_addr(self, rhs: Self) -> Option<usize> {
+                self.0.checked_sub(rhs.0)
+            }
+
+            // #[must_use]
+            // #[inline]
+            // pub const fn saturating_sub_addr(self, rhs: Self) -> usize {
+            //     self.0.saturating_sub(rhs.0)
+            // }
+
+            #[must_use]
+            #[inline]
+            pub const fn is_aligned_to(&self, align: usize) -> bool {
+                assert!(
+                    align.is_power_of_two(),
+                    "is_aligned_to: align is not a power-of-two"
+                );
+
+                self.0 & (align - 1) == 0
+            }
+
+            #[must_use]
+            #[inline]
+            pub const fn checked_align_up(self, align: usize) -> Option<Self> {
+                if !align.is_power_of_two() {
+                    panic!("checked_align_up: align is not a power-of-two");
+                }
+
+                // SAFETY: `align` has been checked to be a power of 2 above
+                let align_minus_one = unsafe { align.unchecked_sub(1) };
+
+                // addr.wrapping_add(align_minus_one) & 0usize.wrapping_sub(align)
+                if let Some(addr_plus_align) = self.0.checked_add(align_minus_one) {
+                    let aligned = Self(addr_plus_align & 0usize.wrapping_sub(align));
+                    debug_assert!(aligned.is_aligned_to(align));
+                    debug_assert!(aligned.0 >= self.0);
+                    Some(aligned)
+                } else {
+                    None
+                }
+            }
+
+            // #[must_use]
+            // #[inline]
+            // pub const fn wrapping_align_up(self, align: usize) -> Self {
+            //     if !align.is_power_of_two() {
+            //         panic!("checked_align_up: align is not a power-of-two");
+            //     }
+            //
+            //     // SAFETY: `align` has been checked to be a power of 2 above
+            //     let align_minus_one = unsafe { align.unchecked_sub(1) };
+            //
+            //     // addr.wrapping_add(align_minus_one) & 0usize.wrapping_sub(align)
+            //     let out = addr.wrapping_add(align_minus_one) & 0usize.wrapping_sub(align);
+            //     debug_assert!(out.is_aligned_to(align));
+            //     out
+            // }
+
+            #[inline]
+            pub const fn alignment(&self) -> usize {
+                self.0 & (!self.0 + 1)
+            }
+
+            #[must_use]
+            #[inline]
+            pub const fn align_down(self, align: usize) -> Self {
+                if !align.is_power_of_two() {
+                    panic!("checked_align_up: align is not a power-of-two");
+                }
+
+                let aligned = Self(self.0 & 0usize.wrapping_sub(align));
+                debug_assert!(aligned.is_aligned_to(align));
+                debug_assert!(aligned.0 <= self.0);
+                aligned
+            }
+        }
+
+        impl ::core::fmt::Display for $address_ty {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                f.write_fmt(format_args!("{:#018x}", self.0)) // 18 digits to account for the leading 0x
+            }
+        }
+
+        impl ::core::fmt::Debug for $address_ty {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                f.debug_tuple(stringify!($address_ty))
+                    .field(&format_args!("{:#018x}", self.0)) // 18 digits to account for the leading 0x
+                    .finish()
+            }
+        }
+    };
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VirtualAddress(usize);
+impl_address!(VirtualAddress);
+
+impl VirtualAddress {
+    #[must_use]
+    pub const fn new(n: usize) -> Self {
+        Self(n)
+    }
+
+    // pub const fn is_canonical<A: RawAddressSpace>(self) -> bool {
+    //     (self.0 & A::CANONICAL_ADDRESS_MASK).wrapping_sub(1) >= A::CANONICAL_ADDRESS_MASK - 1
+    // }
+    //
+    // #[inline]
+    // pub const fn is_user_accessible<A: RawAddressSpace>(self) -> bool {
+    //     // This address refers to userspace if it is in the lower half of the
+    //     // canonical addresses.  IOW - if all of the bits in the canonical address
+    //     // mask are zero.
+    //     (self.0 & A::CANONICAL_ADDRESS_MASK) == 0
+    // }
+}
+
+#[repr(transparent)]
+#[derive(Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct PhysicalAddress(usize);
+impl_address!(PhysicalAddress);
+
+impl PhysicalAddress {
+    pub const fn new(n: usize) -> Self {
+        Self(n)
+    }
+}
+
+macro_rules! address_range_impl {
+    () => {
+        fn size(&self) -> usize {
+            debug_assert!(self.start <= self.end);
+            let is = self.end.checked_sub_addr(self.start).unwrap_or_default();
+            let should = if self.is_empty() {
+                0
+            } else {
+                self.end.get() - self.start.get()
+            };
+            debug_assert_eq!(is, should);
+            is
+        }
+        fn checked_add(self, offset: usize) -> Option<Self> {
+            Some(Range::from(
+                self.start.checked_add(offset)?..self.end.checked_add(offset)?,
+            ))
+        }
+        fn as_ptr_range(&self) -> Range<*const u8> {
+            Range::from(self.start.as_ptr()..self.end.as_ptr())
+        }
+        fn as_mut_ptr_range(&self) -> Range<*mut u8> {
+            Range::from(self.start.as_mut_ptr()..self.end.as_mut_ptr())
+        }
+        fn checked_align_in(self, align: usize) -> Option<Self>
+        where
+            Self: Sized,
+        {
+            let res = Range::from(self.start.checked_align_up(align)?..self.end.align_down(align));
+            Some(res)
+        }
+        fn checked_align_out(self, align: usize) -> Option<Self>
+        where
+            Self: Sized,
+        {
+            let res = Range::from(self.start.align_down(align)..self.end.checked_align_up(align)?);
+            // aligning outwards can only increase the size
+            debug_assert!(res.start.0 <= res.end.0);
+            Some(res)
+        }
+        // fn saturating_align_in(self, align: usize) -> Self {
+        //     self.start.saturating_align_up(align)..self.end.saturating_align_down(align)
+        // }
+        // fn saturating_align_out(self, align: usize) -> Self {
+        //     self.start.saturating_align_down(align)..self.end.saturating_align_up(align)
+        // }
+
+        // TODO test
+        fn alignment(&self) -> usize {
+            self.start.alignment()
+        }
+        fn into_layout(self) -> core::result::Result<Layout, core::alloc::LayoutError> {
+            Layout::from_size_align(self.size(), self.alignment())
+        }
+        fn is_overlapping(&self, other: &Self) -> bool {
+            (self.start < other.end) & (other.start < self.end)
+        }
+        fn difference(&self, other: Self) -> (Option<Self>, Option<Self>) {
+            debug_assert!(self.is_overlapping(&other));
+            let a = Range::from(self.start..other.start);
+            let b = Range::from(other.end..self.end);
+            ((!a.is_empty()).then_some(a), (!b.is_empty()).then_some(b))
+        }
+        fn clamp(&self, range: Self) -> Self {
+            Range::from(self.start.max(range.start)..self.end.min(range.end))
+        }
+    };
+}
+
+pub trait AddressRangeExt {
+    fn size(&self) -> usize;
+    #[must_use]
+    fn checked_add(self, offset: usize) -> Option<Self>
+    where
+        Self: Sized;
+    #[must_use]
+    fn as_ptr_range(&self) -> Range<*const u8>;
+    #[must_use]
+    fn as_mut_ptr_range(&self) -> Range<*mut u8>;
+    #[must_use]
+    fn checked_align_in(self, align: usize) -> Option<Self>
+    where
+        Self: Sized;
+    #[must_use]
+    fn checked_align_out(self, align: usize) -> Option<Self>
+    where
+        Self: Sized;
+    // #[must_use]
+    // fn saturating_align_in(self, align: usize) -> Self;
+    // #[must_use]
+    // fn saturating_align_out(self, align: usize) -> Self;
+    fn alignment(&self) -> usize;
+    /// Return the largest [`Layout`] fitting this range.
+    ///
+    /// # Errors
+    ///
+    /// Return [`LayoutError`] if this range does not represent a valid layout.
+    fn into_layout(self) -> Result<Layout, LayoutError>;
+    fn is_overlapping(&self, other: &Self) -> bool;
+    fn difference(&self, other: Self) -> (Option<Self>, Option<Self>)
+    where
+        Self: Sized;
+    fn clamp(&self, range: Self) -> Self;
+    // fn is_user_accessible<A: RawAddressSpace>(&self) -> bool;
+}
+
+impl AddressRangeExt for Range<PhysicalAddress> {
+    address_range_impl!();
+    // fn is_user_accessible<A: RawAddressSpace>(&self) -> bool {
+    //     unimplemented!("PhysicalAddress is never user accessible")
+    // }
+}
+
+impl AddressRangeExt for Range<VirtualAddress> {
+    address_range_impl!();
+
+    // fn is_user_accessible<A: RawAddressSpace>(&self) -> bool {
+    //     if self.is_empty() {
+    //         return false;
+    //     }
+    //     let Some(end_minus_one) = self.end.checked_sub(1) else {
+    //         return false;
+    //     };
+    //
+    //     self.start.is_user_accessible::<A>() && end_minus_one.is_user_accessible::<A>()
+    // }
+}

--- a/libs/kmem/src/lib.rs
+++ b/libs/kmem/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![no_std]
+extern crate alloc;
+
+mod access_rules;
+mod address_space;
+mod addresses;
+
+pub type Result<T> = anyhow::Result<T>;
+
+pub use access_rules::{AccessRules, WriteOrExecute};
+pub use address_space::AddressSpace;
+pub use addresses::{AddressRangeExt, PhysicalAddress, VirtualAddress};

--- a/libs/wavltree/src/cursor.rs
+++ b/libs/wavltree/src/cursor.rs
@@ -88,6 +88,9 @@ where
     pub unsafe fn get_ptr(&self) -> Link<T> {
         self.current
     }
+    pub const fn has_current(&self) -> bool {
+        self.current.is_some()
+    }
     pub fn get(&self) -> Option<&'a T> {
         unsafe { self.current.map(|ptr| ptr.as_ref()) }
     }


### PR DESCRIPTION
This change implements the basic `AddressSpace` API surface and initial `AddressSpaceRegion` tree that sits at its core.