### PR TITLE
fix: don't pad-to-aligment before gap searching

### DIFF
--- a/libs/kmem/src/address_space.rs
+++ b/libs/kmem/src/address_space.rs
@@ -332,8 +332,6 @@ impl AddressSpace {
         // Note that in practice, we use a binary tree to keep track of regions, and we use binary search
         // to optimize the search for a suitable gap instead of linear iteration.
 
-        let layout = layout.pad_to_align();
-
         // First attempt: guess a random target index
         let max_candidate_spots = self.max_range.size();
 


### PR DESCRIPTION
This change removes the `pad_to_align` call from the gap searching method. It should not be necessary and will just waste virtual memory