### PR TITLE
fix: kernel hang with `log=trace`

### DIFF
--- a/kernel/src/arch/riscv64/device/clock.rs
+++ b/kernel/src/arch/riscv64/device/clock.rs
@@ -17,39 +17,23 @@ static CLOCK_VTABLE: RawClockVTable =
     RawClockVTable::new(clone_raw, now_raw, schedule_wakeup_raw, drop_raw);
 
 unsafe fn clone_raw(ptr: *const ()) -> RawClock {
-    tracing::trace!(
-        clock.addr = ?ptr,
-        "RISCV CLOCK::clone_raw"
-    );
     debug_assert!(ptr.is_null());
     RawClock::new(ptr, &CLOCK_VTABLE)
 }
 
 unsafe fn now_raw(_ptr: *const ()) -> u64 {
-    tracing::trace!(
-        clock.addr = ?_ptr,
-        "RISCV CLOCK::now_raw"
-    );
     debug_assert!(_ptr.is_null());
 
     riscv::register::time::read64()
 }
 
 unsafe fn schedule_wakeup_raw(_ptr: *const (), at: u64) {
-    tracing::trace!(
-        clock.addr = ?_ptr,
-        "RISCV CLOCK::schedule_wakeup_raw"
-    );
     debug_assert!(_ptr.is_null());
 
     sbi::time::set_timer(at).unwrap();
 }
 
 unsafe fn drop_raw(_ptr: *const ()) {
-    tracing::trace!(
-        clock.addr = ?_ptr,
-        "RISCV CLOCK::drop_raw"
-    );
     debug_assert!(_ptr.is_null());
 }
 


### PR DESCRIPTION
This changes fixes a kernel hang (or rather infinite loop) introduced in 1656fcf50a1d2d35569ef5710ebccde45d48f654 when the new RISCV clock implementation started printing trace messages whie getting the current time. https://github.com/JonasKruckenberg/k23/commit/1656fcf50a1d2d35569ef5710ebccde45d48f654#diff-6011d78af5dae4cd359c21ca15b8566420c3f10a2406d9b4c461df2faaa414bdR27-R30 This leads to a recursive print-loop because getting the time is part of printing debug messages