### PR TITLE
refactor: remove new range API uses from `kernel` and `loader`

### DIFF
--- a/kernel/src/allocator.rs
+++ b/kernel/src/allocator.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::alloc::Layout;
-use core::range::Range;
 
 use loader_api::BootInfo;
 use talc::{ErrOnOom, Span, Talc, Talck};
@@ -30,7 +29,7 @@ pub fn init(boot_alloc: &mut BootstrapAllocator, boot_info: &BootInfo) {
             .checked_add(phys.get())
             .unwrap();
 
-        Range::from(start..start.checked_add(layout.size()).unwrap())
+        start..start.checked_add(layout.size()).unwrap()
     };
     tracing::debug!("Kernel Heap: {virt:#x?}");
 

--- a/kernel/src/arch/riscv64/device/plic.rs
+++ b/kernel/src/arch/riscv64/device/plic.rs
@@ -11,7 +11,6 @@ use core::mem::{MaybeUninit, offset_of};
 use core::num::NonZero;
 use core::ops::{BitAnd, BitOr, Not};
 use core::ptr;
-use core::range::Range;
 
 use fallible_iterator::FallibleIterator;
 use static_assertions::const_assert_eq;
@@ -110,7 +109,7 @@ impl Plic {
             let reg = dev.regs().unwrap().next()?.unwrap();
 
             let start = PhysicalAddress::new(reg.starting_address);
-            Range::from(start..start.checked_add(reg.size.unwrap()).unwrap())
+            start..start.checked_add(reg.size.unwrap()).unwrap()
         };
 
         let mmio_region = with_kernel_aspace(|aspace| {
@@ -122,7 +121,7 @@ impl Plic {
                     Permissions::READ | Permissions::WRITE,
                     |range, perms, batch| {
                         let region = AddressSpaceRegion::new_phys(
-                            range,
+                            range.clone(),
                             perms,
                             mmio_range,
                             Some("PLIC".to_string()),
@@ -133,6 +132,7 @@ impl Plic {
                 )
                 .unwrap()
                 .range
+                .clone()
         });
 
         // Specifies how many external interrupts are supported by this controller.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -9,7 +9,6 @@
 #![no_main]
 #![feature(used_with_arg)]
 #![feature(thread_local, never_type)]
-#![feature(new_range_api)]
 #![feature(debug_closure_helpers)]
 #![expect(internal_features, reason = "panic internals")]
 #![feature(std_internals, panic_can_unwind, formatting_options)]
@@ -42,7 +41,7 @@ mod tracing;
 mod util;
 mod wasm;
 
-use core::range::Range;
+use core::ops::Range;
 use core::slice;
 use core::time::Duration;
 
@@ -230,9 +229,8 @@ fn allocatable_memory_regions(boot_info: &BootInfo) -> ArrayVec<Range<PhysicalAd
         .memory_regions
         .iter()
         .filter_map(|region| {
-            let range = Range::from(
-                PhysicalAddress::new(region.range.start)..PhysicalAddress::new(region.range.end),
-            );
+            let range =
+                PhysicalAddress::new(region.range.start)..PhysicalAddress::new(region.range.end);
 
             region.kind.is_usable().then_some(range)
         })
@@ -275,6 +273,6 @@ fn locate_device_tree(boot_info: &BootInfo) -> (&'static [u8], Range<PhysicalAdd
         unsafe { slice::from_raw_parts(base, fdt.range.end.checked_sub(fdt.range.start).unwrap()) };
     (
         slice,
-        Range::from(PhysicalAddress::new(fdt.range.start)..PhysicalAddress::new(fdt.range.end)),
+        PhysicalAddress::new(fdt.range.start)..PhysicalAddress::new(fdt.range.end),
     )
 }

--- a/kernel/src/mem/bootstrap_alloc.rs
+++ b/kernel/src/mem/bootstrap_alloc.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::alloc::Layout;
-use core::range::Range;
+use core::ops::Range;
 use core::{iter, ptr, slice};
 
 use crate::arch;
@@ -29,7 +29,7 @@ impl<'a> BootstrapAllocator<'a> {
     pub fn free_regions(&self) -> FreeRegions<'_> {
         FreeRegions {
             offset: self.offset,
-            inner: self.regions.iter().rev().copied(),
+            inner: self.regions.iter().rev().cloned(),
         }
     }
 
@@ -97,7 +97,7 @@ impl<'a> BootstrapAllocator<'a> {
         unsafe {
             ptr::write_bytes::<u8>(
                 arch::KERNEL_ASPACE_RANGE
-                    .start
+                    .start()
                     .checked_add(addr.get())
                     .unwrap()
                     .as_mut_ptr(),
@@ -111,7 +111,7 @@ impl<'a> BootstrapAllocator<'a> {
 
 pub struct FreeRegions<'a> {
     offset: usize,
-    inner: iter::Copied<iter::Rev<slice::Iter<'a, Range<PhysicalAddress>>>>,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<PhysicalAddress>>>>,
 }
 
 impl Iterator for FreeRegions<'_> {

--- a/kernel/src/mem/flush.rs
+++ b/kernel/src/mem/flush.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::range::Range;
+use core::ops::Range;
 use core::{cmp, mem};
 
 use anyhow::bail;

--- a/kernel/src/mem/frame_alloc/arena.rs
+++ b/kernel/src/mem/frame_alloc/arena.rs
@@ -7,8 +7,8 @@
 
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
+use core::ops::Range;
 use core::ptr::NonNull;
-use core::range::Range;
 use core::{cmp, fmt, mem, slice};
 
 use cordyceps::List;
@@ -300,7 +300,7 @@ impl FallibleIterator for ArenaSelections {
             return Err(SelectionError { range: aligned });
         }
 
-        let bookkeeping = Range::from(bookkeeping_start..aligned.end);
+        let bookkeeping = bookkeeping_start..aligned.end;
         aligned.end = bookkeeping.start;
 
         Ok(Some(ArenaSelection {

--- a/kernel/src/mem/frame_alloc/mod.rs
+++ b/kernel/src/mem/frame_alloc/mod.rs
@@ -12,8 +12,8 @@ pub mod frame_list;
 use alloc::vec::Vec;
 use core::alloc::Layout;
 use core::cell::RefCell;
+use core::ops::Range;
 use core::ptr::NonNull;
-use core::range::Range;
 use core::sync::atomic::AtomicUsize;
 use core::{cmp, fmt, iter, slice};
 

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -20,7 +20,7 @@ use alloc::format;
 use alloc::string::ToString;
 use alloc::sync::Arc;
 use core::num::NonZeroUsize;
-use core::range::Range;
+use core::ops::Range;
 use core::{fmt, slice};
 
 pub use address::{AddressRangeExt, PhysicalAddress, VirtualAddress};
@@ -87,10 +87,8 @@ fn reserve_wired_regions(aspace: &mut AddressSpace, boot_info: &BootInfo, flush:
     // reserve the physical memory map
     aspace
         .reserve(
-            Range::from(
-                VirtualAddress::new(boot_info.physical_memory_map.start).unwrap()
-                    ..VirtualAddress::new(boot_info.physical_memory_map.end).unwrap(),
-            ),
+            VirtualAddress::new(boot_info.physical_memory_map.start).unwrap()
+                ..VirtualAddress::new(boot_info.physical_memory_map.end).unwrap(),
             Permissions::READ | Permissions::WRITE,
             Some("Physical Memory Map".to_string()),
             flush,

--- a/kernel/src/mem/vmo.rs
+++ b/kernel/src/mem/vmo.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::sync::Arc;
-use core::range::Range;
+use core::ops::Range;
 
 use anyhow::ensure;
 use spin::RwLock;
@@ -74,7 +74,7 @@ impl PhysVmo {
             self.range
         );
 
-        Ok(Range::from(start..end))
+        Ok(start..end)
     }
 }
 

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -19,7 +19,6 @@ use alloc::string::{String, ToString};
 use core::fmt;
 use core::fmt::Write;
 use core::ops::DerefMut;
-use core::range::Range;
 use core::str::FromStr;
 
 use fallible_iterator::FallibleIterator;
@@ -96,7 +95,7 @@ fn init_uart(devtree: &DeviceTree) -> (uart_16550::SerialPort, Mmap, u32) {
 
         let range_phys = {
             let start = PhysicalAddress::new(reg.starting_address);
-            Range::from(start..start.checked_add(size).unwrap())
+            start..start.checked_add(size).unwrap()
         };
 
         let mmap = Mmap::new_phys(
@@ -108,7 +107,7 @@ fn init_uart(devtree: &DeviceTree) -> (uart_16550::SerialPort, Mmap, u32) {
         )
         .unwrap();
 
-        mmap.commit(aspace.lock().deref_mut(), Range::from(0..size), true)
+        mmap.commit(aspace.lock().deref_mut(), 0..size, true)
             .unwrap();
 
         mmap

--- a/kernel/src/wasm/translate/module_types.rs
+++ b/kernel/src/wasm/translate/module_types.rs
@@ -8,7 +8,7 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
 use core::fmt;
-use core::range::Range;
+use core::ops::Range;
 
 use cranelift_entity::packed_option::PackedOption;
 use cranelift_entity::{EntityRef, PrimaryMap, SecondaryMap};
@@ -227,7 +227,7 @@ impl ModuleTypesBuilder {
             "should have defined the number of types declared in `start_rec_group`"
         );
 
-        let idx = self.push_rec_group(Range::from(start..end));
+        let idx = self.push_rec_group(start..end);
         debug_assert_eq!(idx, rec_group_index);
 
         self.seen_rec_groups.insert(rec_group_id, rec_group_index);
@@ -305,7 +305,7 @@ impl ModuleTypesBuilder {
                     self.set_trampoline_type(idx, idx);
 
                     let next = self.next_ty();
-                    self.push_rec_group(Range::from(idx..next));
+                    self.push_rec_group(idx..next);
                     self.trampoline_types.insert(f, idx);
                     idx
                 }

--- a/kernel/src/wasm/vm/code_object.rs
+++ b/kernel/src/wasm/vm/code_object.rs
@@ -7,8 +7,8 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
+use core::ops::Range;
 use core::ptr::NonNull;
-use core::range::Range;
 use core::slice;
 
 use anyhow::Context;
@@ -95,7 +95,7 @@ impl CodeObject {
     pub fn text_range(&self) -> Range<VirtualAddress> {
         let start = self.mmap.range().start;
 
-        Range::from(start..start.checked_add(self.len).unwrap())
+        start..start.checked_add(self.len).unwrap()
     }
 
     pub fn resolve_function_loc(&self, func_loc: FunctionLoc) -> usize {

--- a/kernel/src/wasm/vm/memory.rs
+++ b/kernel/src/wasm/vm/memory.rs
@@ -5,8 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ops::Range;
 use core::ptr::NonNull;
-use core::range::Range;
 
 use crate::mem::{Mmap, VirtualAddress};
 use crate::wasm::vm::VMMemoryDefinition;

--- a/kernel/src/wasm/vm/mmap_vec.rs
+++ b/kernel/src/wasm/vm/mmap_vec.rs
@@ -9,7 +9,6 @@ use alloc::sync::Arc;
 use core::cmp::max;
 use core::marker::PhantomData;
 use core::ops::Deref;
-use core::range::Range;
 use core::slice;
 
 use anyhow::Context;
@@ -115,7 +114,7 @@ impl<T> MmapVec<T> {
             .copy_to_userspace(
                 aspace,
                 src,
-                Range::from(self.len * size_of::<T>()..(self.len + other.len()) * size_of::<T>()),
+                self.len * size_of::<T>()..(self.len + other.len()) * size_of::<T>(),
             )
             .unwrap();
         self.len += other.len();
@@ -128,7 +127,7 @@ impl<T> MmapVec<T> {
         assert!(self.len() + count <= self.capacity());
 
         self.mmap
-            .with_user_slice_mut(aspace, Range::from(self.len..self.len + count), |dst| {
+            .with_user_slice_mut(aspace, self.len..self.len + count, |dst| {
                 // "Transmute" the slice to a byte slice
                 // Safety: we're just converting the slice to a byte slice of the same length
                 let dst =

--- a/kernel/src/wasm/vm/table.rs
+++ b/kernel/src/wasm/vm/table.rs
@@ -5,9 +5,9 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use core::ops::Range;
 use core::ptr;
 use core::ptr::NonNull;
-use core::range::Range;
 
 use anyhow::anyhow;
 
@@ -166,8 +166,8 @@ impl Table {
                 return Err(TrapKind::TableOutOfBounds);
             }
 
-            let src_range = Range::from(src_index..src_index + len);
-            let dst_range = Range::from(dst_index..dst_index + len);
+            let src_range = src_index..src_index + len;
+            let dst_range = dst_index..dst_index + len;
 
             if ptr::eq(dst_table, src_table) {
                 (*dst_table).copy_elements_within(dst_range, src_range);

--- a/loader/api/src/info.rs
+++ b/loader/api/src/info.rs
@@ -5,8 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::ops::{Deref, DerefMut};
-use core::range::Range;
+use core::ops::{Deref, DerefMut, Range};
 use core::{fmt, slice};
 
 #[derive(Debug)]
@@ -105,7 +104,7 @@ impl From<MemoryRegions> for &'static mut [MemoryRegion] {
 }
 
 /// Represent a physical memory region.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[repr(C)]
 pub struct MemoryRegion {
     /// The physical start address region.

--- a/loader/api/src/lib.rs
+++ b/loader/api/src/lib.rs
@@ -5,7 +5,6 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-#![feature(new_range_api)]
 #![no_std]
 #![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
 

--- a/loader/src/boot_info.rs
+++ b/loader/src/boot_info.rs
@@ -7,7 +7,7 @@
 
 use core::alloc::Layout;
 use core::mem::MaybeUninit;
-use core::range::Range;
+use core::ops::Range;
 use core::slice;
 
 use loader_api::{BootInfo, MemoryRegion, MemoryRegionKind, MemoryRegions, TlsTemplate};
@@ -34,8 +34,13 @@ pub fn prepare_boot_info(
     )?;
     let page = physical_address_offset.checked_add(frame).unwrap();
 
-    let memory_regions =
-        init_boot_info_memory_regions(page, frame_alloc, fdt_phys, loader_phys, kernel_phys);
+    let memory_regions = init_boot_info_memory_regions(
+        page,
+        frame_alloc,
+        fdt_phys,
+        loader_phys,
+        kernel_phys.clone(),
+    );
 
     let mut boot_info = BootInfo::new(memory_regions);
     boot_info.physical_address_offset = physical_address_offset;
@@ -96,11 +101,11 @@ fn init_boot_info_memory_regions(
     //
     // We can still mark the range before and after the kernel as usable.
     push_region(MemoryRegion {
-        range: Range::from(loader_phys.start..kernel_phys.start),
+        range: loader_phys.start..kernel_phys.start,
         kind: MemoryRegionKind::Usable,
     });
     push_region(MemoryRegion {
-        range: Range::from(kernel_phys.end..loader_phys.end),
+        range: kernel_phys.end..loader_phys.end,
         kind: MemoryRegionKind::Usable,
     });
 

--- a/loader/src/frame_alloc.rs
+++ b/loader/src/frame_alloc.rs
@@ -7,7 +7,7 @@
 
 use core::alloc::Layout;
 use core::num::NonZeroUsize;
-use core::range::Range;
+use core::ops::Range;
 use core::{cmp, iter, ptr, slice};
 
 use fallible_iterator::FallibleIterator;
@@ -32,7 +32,7 @@ impl<'a> FrameAllocator<'a> {
     pub fn free_regions(&self) -> FreeRegions<'_> {
         FreeRegions {
             offset: self.offset,
-            inner: self.regions.iter().rev().copied(),
+            inner: self.regions.iter().rev().cloned(),
         }
     }
 
@@ -40,7 +40,7 @@ impl<'a> FrameAllocator<'a> {
     pub fn used_regions(&self) -> UsedRegions<'_> {
         UsedRegions {
             offset: self.offset,
-            inner: self.regions.iter().rev().copied(),
+            inner: self.regions.iter().rev().cloned(),
         }
     }
 
@@ -223,7 +223,7 @@ impl FallibleIterator for FrameIterZeroed<'_, '_> {
 
 pub struct FreeRegions<'a> {
     offset: usize,
-    inner: iter::Copied<iter::Rev<slice::Iter<'a, Range<usize>>>>,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<usize>>>>,
 }
 
 impl Iterator for FreeRegions<'_> {
@@ -249,7 +249,7 @@ impl Iterator for FreeRegions<'_> {
 
 pub struct UsedRegions<'a> {
     offset: usize,
-    inner: iter::Copied<iter::Rev<slice::Iter<'a, Range<usize>>>>,
+    inner: iter::Cloned<iter::Rev<slice::Iter<'a, Range<usize>>>>,
 }
 
 impl Iterator for UsedRegions<'_> {

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::fmt::Formatter;
-use core::range::Range;
+use core::ops::Range;
 use core::{fmt, slice};
 
 use loader_api::LoaderConfig;
@@ -63,7 +63,7 @@ impl Kernel<'static> {
 impl Kernel<'_> {
     pub fn phys_range(&self) -> Range<usize> {
         let fdt = INLINED_KERNEL_BYTES.0.as_ptr_range();
-        Range::from(fdt.start as usize..fdt.end as usize)
+        fdt.start as usize..fdt.end as usize
     }
 
     /// Returns the size of the kernel in memory.

--- a/loader/src/machine_info.rs
+++ b/loader/src/machine_info.rs
@@ -9,7 +9,7 @@ use core::cmp::Ordering;
 use core::ffi::{CStr, c_void};
 use core::fmt;
 use core::fmt::Formatter;
-use core::range::Range;
+use core::ops::Range;
 use core::str::FromStr;
 
 use arrayvec::ArrayVec;
@@ -83,9 +83,8 @@ impl MachineInfo<'_> {
                     .as_regs(stack[depth - 1].unwrap().1);
 
                 while let Some(reg) = iter.next()? {
-                    memories.push(Range::from(
-                        reg.starting_address..reg.starting_address + reg.size.unwrap_or(0),
-                    ));
+                    memories
+                        .push(reg.starting_address..reg.starting_address + reg.size.unwrap_or(0));
                 }
             } else if stack[depth - 1].is_some_and(|(s, _)| s == "reserved-memory") {
                 // if the node is a reserved-memory node, add it to the list of reserved memory regions
@@ -94,9 +93,8 @@ impl MachineInfo<'_> {
                     .unwrap()
                     .as_regs(stack[depth - 1].unwrap().1);
                 while let Some(reg) = iter.next()? {
-                    reserved_memory.push(Range::from(
-                        reg.starting_address..reg.starting_address + reg.size.unwrap_or(0),
-                    ));
+                    reserved_memory
+                        .push(reg.starting_address..reg.starting_address + reg.size.unwrap_or(0));
                 }
             } else if name.name == "chosen" {
                 // and finally if the node is the chosen node, extract the RNG seed
@@ -119,8 +117,8 @@ impl MachineInfo<'_> {
                     // remove region
                     continue;
                 } else if region.contains(&entry.start) && region.contains(&entry.end) {
-                    memories.push(Range::from(region.start..entry.start));
-                    memories.push(Range::from(entry.end..region.end));
+                    memories.push(region.start..entry.start);
+                    memories.push(entry.end..region.end);
                 } else if entry.contains(&region.start) {
                     region.start = entry.end;
                     memories.push(region);
@@ -138,7 +136,7 @@ impl MachineInfo<'_> {
             let region = {
                 let start = usize::try_from(entry.address)?;
 
-                Range::from(start..start.checked_add(usize::try_from(entry.size)?).unwrap())
+                start..start.checked_add(usize::try_from(entry.size)?).unwrap()
             };
             log::trace!("applying reservation {region:#x?}");
 
@@ -196,7 +194,7 @@ impl MachineInfo<'_> {
         let min_addr = self.memories.first().map(|r| r.start).unwrap_or_default();
         let max_addr = self.memories.last().map(|r| r.end).unwrap_or_default();
 
-        Range::from(min_addr..max_addr)
+        min_addr..max_addr
     }
 }
 

--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -6,7 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::alloc::Layout;
-use core::range::Range;
+use core::ops::Range;
 
 use rand::distr::{Distribution, Uniform};
 use rand::prelude::IteratorRandom;
@@ -117,8 +117,6 @@ impl PageAllocator {
             0
         };
 
-        Range::from(
-            base.checked_add(offset).unwrap()..base.checked_add(offset + layout.size()).unwrap(),
-        )
+        base.checked_add(offset).unwrap()..base.checked_add(offset + layout.size()).unwrap()
     }
 }


### PR DESCRIPTION
The use of the nightly API `core::range::Range` et al hasn't proven to be super helpful and in an effort to reduce the number of nightly features used, this change removes all uses.