### PR TITLE
refactor: clean up `AddressRangeExt` trait

### DIFF
--- a/kernel/src/backtrace/mod.rs
+++ b/kernel/src/backtrace/mod.rs
@@ -74,7 +74,7 @@ impl BacktraceInfo {
                     .unwrap()
                     .as_ptr();
 
-                slice::from_raw_parts(base, boot_info.kernel_phys.size())
+                slice::from_raw_parts(base, boot_info.kernel_phys.len())
             },
             symbolize_context: OnceLock::new(),
             backtrace_style,

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -229,11 +229,7 @@ fn allocatable_memory_regions(boot_info: &BootInfo) -> ArrayVec<Range<PhysicalAd
     let temp: ArrayVec<Range<PhysicalAddress>, 16> = boot_info
         .memory_regions
         .iter()
-        .filter_map(|region| {
-            let range = region.range.start..region.range.end;
-
-            region.kind.is_usable().then_some(range)
-        })
+        .filter_map(|region| region.kind.is_usable().then_some(region.range.clone()))
         .collect();
 
     // merge adjacent regions
@@ -270,6 +266,6 @@ fn locate_device_tree(boot_info: &BootInfo) -> (&'static [u8], Range<PhysicalAdd
         .as_mut_ptr();
 
     // Safety: we need to trust the bootinfo data is correct
-    let slice = unsafe { slice::from_raw_parts(base, fdt.range.size()) };
-    (slice, fdt.range.start..fdt.range.end)
+    let slice = unsafe { slice::from_raw_parts(base, fdt.range.len()) };
+    (slice, fdt.range.clone())
 }

--- a/kernel/src/mem/address_space_region.rs
+++ b/kernel/src/mem/address_space_region.rs
@@ -142,7 +142,7 @@ impl AddressSpaceRegion {
                 batch.queue_map(
                     range.start,
                     range_phys.start,
-                    NonZeroUsize::new(range_phys.size()).unwrap(),
+                    NonZeroUsize::new(range_phys.len()).unwrap(),
                     self.permissions.into(),
                 )?;
             }
@@ -266,16 +266,13 @@ impl AddressSpaceRegion {
             Vmo::Wired => unreachable!("Wired VMO can never page fault"),
             Vmo::Phys(vmo) => {
                 let range_phys = vmo
-                    .lookup_contiguous(
-                        vmo_relative_offset
-                            ..vmo_relative_offset.checked_add(arch::PAGE_SIZE).unwrap(),
-                    )
+                    .lookup_contiguous(vmo_relative_offset..vmo_relative_offset + arch::PAGE_SIZE)
                     .expect("contiguous lookup for wired VMOs should never fail");
 
                 batch.queue_map(
                     addr,
                     range_phys.start,
-                    NonZeroUsize::new(range_phys.size()).unwrap(),
+                    NonZeroUsize::new(range_phys.len()).unwrap(),
                     self.permissions.into(),
                 )?;
             }

--- a/kernel/src/mem/bootstrap_alloc.rs
+++ b/kernel/src/mem/bootstrap_alloc.rs
@@ -59,17 +59,17 @@ impl<'a> BootstrapAllocator<'a> {
 
         for region in self.regions.iter().rev() {
             // only consider regions that we haven't already exhausted
-            if offset < region.size() {
+            if offset < region.len() {
                 // Allocating a contiguous range has different requirements than "regular" allocation
                 // contiguous are rare and often happen in very critical paths where e.g. virtual
                 // memory is not available yet. So we rather waste some memory than outright crash.
-                if region.size() - offset < requested_size {
+                if region.len() - offset < requested_size {
                     tracing::warn!(
                         "Skipped memory region {region:?} since it was too small to fulfill request for {requested_size} bytes. Wasted {} bytes in the process...",
-                        region.size() - offset
+                        region.len() - offset
                     );
 
-                    self.offset += region.size() - offset;
+                    self.offset += region.len() - offset;
                     offset = 0;
                     continue;
                 }
@@ -80,7 +80,7 @@ impl<'a> BootstrapAllocator<'a> {
                 return Some(frame);
             }
 
-            offset -= region.size();
+            offset -= region.len();
         }
 
         None
@@ -122,8 +122,8 @@ impl Iterator for FreeRegions<'_> {
         loop {
             let mut region = self.inner.next()?;
             // keep advancing past already fully used memory regions
-            if self.offset >= region.size() {
-                self.offset -= region.size();
+            if self.offset >= region.len() {
+                self.offset -= region.len();
                 continue;
             } else if self.offset > 0 {
                 region.end = region.end.checked_sub(self.offset).unwrap();

--- a/kernel/src/mem/mmap.rs
+++ b/kernel/src/mem/mmap.rs
@@ -119,7 +119,7 @@ impl Mmap {
                 Permissions::READ | Permissions::WRITE,
                 |range_virt, perms, _batch| {
                     Ok(AddressSpaceRegion::new_phys(
-                        range_virt.clone(),
+                        range_virt,
                         perms,
                         range_phys.clone(),
                         name,
@@ -175,7 +175,7 @@ impl Mmap {
 
         // Safety: checked by caller
         unsafe {
-            let slice = slice::from_raw_parts(self.range.start.as_ptr(), self.range().size());
+            let slice = slice::from_raw_parts(self.range.start.as_ptr(), self.range().len());
 
             f(&slice[range]);
         }
@@ -201,7 +201,7 @@ impl Mmap {
         // Safety: checked by caller
         unsafe {
             let slice =
-                slice::from_raw_parts_mut(self.range.start.as_mut_ptr(), self.range().size());
+                slice::from_raw_parts_mut(self.range.start.as_mut_ptr(), self.range().len());
             f(&mut slice[range]);
         }
 
@@ -236,7 +236,7 @@ impl Mmap {
     #[inline]
     pub fn len(&self) -> usize {
         // Safety: the constructor ensures that the NonNull is valid.
-        self.range.size()
+        self.range.len()
     }
 
     /// Whether this is a mapping of zero bytes
@@ -277,7 +277,7 @@ impl Mmap {
             unsafe {
                 aspace.arch.update_flags(
                     self.range.start,
-                    NonZeroUsize::new(self.range.size()).unwrap(),
+                    NonZeroUsize::new(self.range.len()).unwrap(),
                     new_permissions.into(),
                     &mut flush,
                 )?;

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -86,7 +86,7 @@ fn reserve_wired_regions(aspace: &mut AddressSpace, boot_info: &BootInfo, flush:
     // reserve the physical memory map
     aspace
         .reserve(
-            boot_info.physical_memory_map.start..boot_info.physical_memory_map.end,
+            boot_info.physical_memory_map.clone(),
             Permissions::READ | Permissions::WRITE,
             Some("Physical Memory Map".to_string()),
             flush,
@@ -101,7 +101,7 @@ fn reserve_wired_regions(aspace: &mut AddressSpace, boot_info: &BootInfo, flush:
             .unwrap()
             .as_ptr();
 
-        slice::from_raw_parts(base, boot_info.kernel_phys.size())
+        slice::from_raw_parts(base, boot_info.kernel_phys.len())
     };
     let own_elf = xmas_elf::ElfFile::new(own_elf).unwrap();
 

--- a/kernel/src/mem/vmo.rs
+++ b/kernel/src/mem/vmo.rs
@@ -57,7 +57,7 @@ pub struct PhysVmo {
 
 impl PhysVmo {
     pub fn is_valid_offset(&self, offset: usize) -> bool {
-        offset <= self.range.size()
+        offset <= self.range.len()
     }
 
     pub fn lookup_contiguous(&self, range: Range<usize>) -> crate::Result<Range<PhysicalAddress>> {

--- a/kernel/src/shell.rs
+++ b/kernel/src/shell.rs
@@ -18,12 +18,12 @@ const S: &str = r#"
 use alloc::string::{String, ToString};
 use core::fmt;
 use core::fmt::Write;
-use core::ops::DerefMut;
+use core::ops::{DerefMut, Range};
 use core::str::FromStr;
 
 use fallible_iterator::FallibleIterator;
 use kasync::executor::Executor;
-use kmem::PhysicalAddress;
+use kmem::{AddressRangeExt, PhysicalAddress};
 use spin::{Barrier, OnceLock};
 
 use crate::device_tree::DeviceTree;
@@ -94,10 +94,7 @@ fn init_uart(devtree: &DeviceTree) -> (uart_16550::SerialPort, Mmap, u32) {
             .unwrap()
             .get();
 
-        let range_phys = {
-            let start = PhysicalAddress::new(reg.starting_address);
-            start..start.checked_add(size).unwrap()
-        };
+        let range_phys = Range::from_start_len(PhysicalAddress::new(reg.starting_address), size);
 
         let mmap = Mmap::new_phys(
             aspace.clone(),

--- a/libs/kmem/src/address_range.rs
+++ b/libs/kmem/src/address_range.rs
@@ -1,0 +1,91 @@
+// Copyright 2025. Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use crate::{PhysicalAddress, VirtualAddress};
+
+pub trait AddressRangeExt {
+    type Address;
+    fn from_start_len(start: Self::Address, len: usize) -> Self;
+
+    /// Returns `true` if the range contains no addresses.
+    fn is_empty(&self) -> bool;
+
+    /// Returns the length of the address range, in bytes.
+    fn len(&self) -> usize;
+
+    /// Returns `true` if `address` is contained in the range.
+    fn contains(&self, address: &Self::Address) -> bool;
+
+    /// Returns `true` if there exists an address present in both ranges.
+    fn overlaps(&self, other: &Self) -> bool;
+
+    /// Returns the intersection of `self` and `other`.
+    fn intersect(self, other: Self) -> Self;
+
+    fn checked_align_in(self, align: usize) -> Option<Self>
+    where
+        Self: Sized;
+    fn checked_align_out(self, align: usize) -> Option<Self>
+    where
+        Self: Sized;
+}
+
+macro_rules! impl_address_range {
+    ($address_ty:ident) => {
+        impl AddressRangeExt for ::core::ops::Range<$address_ty> {
+            type Address = $address_ty;
+
+            fn from_start_len(start: Self::Address, len: usize) -> Self {
+                let end = start.checked_add(len).unwrap();
+
+                Self { start, end }
+            }
+
+            fn is_empty(&self) -> bool {
+                self.start >= self.end
+            }
+
+            fn len(&self) -> usize {
+                self.end.checked_sub_addr(self.start).unwrap()
+            }
+
+            fn contains(&self, address: &Self::Address) -> bool {
+                <Self as ::core::ops::RangeBounds<$address_ty>>::contains(self, address)
+            }
+
+            fn overlaps(&self, other: &Self) -> bool {
+                self.start < other.end && other.start < self.end
+            }
+
+            fn intersect(self, other: Self) -> Self {
+                Self {
+                    start: core::cmp::max(self.start, other.start),
+                    end: core::cmp::min(self.end, other.end),
+                }
+            }
+
+            fn checked_align_in(self, align: usize) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                let res = self.start.checked_align_up(align)?..self.end.align_down(align);
+                Some(res)
+            }
+
+            fn checked_align_out(self, align: usize) -> Option<Self>
+            where
+                Self: Sized,
+            {
+                let res = self.start.align_down(align)..self.end.checked_align_up(align)?;
+                Some(res)
+            }
+        }
+    };
+}
+
+impl_address_range!(VirtualAddress);
+impl_address_range!(PhysicalAddress);

--- a/libs/kmem/src/lib.rs
+++ b/libs/kmem/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![feature(step_trait)]
 
-mod addresses;
+mod address;
+mod address_range;
 
-pub use addresses::{AddressRangeExt, PhysicalAddress, VirtualAddress};
+pub use address::{PhysicalAddress, VirtualAddress};
+pub use address_range::AddressRangeExt;

--- a/loader/src/arch/riscv64.rs
+++ b/loader/src/arch/riscv64.rs
@@ -7,7 +7,6 @@
 
 use core::arch::{asm, naked_asm};
 use core::fmt;
-use core::num::NonZero;
 use core::ptr::NonNull;
 
 use bitflags::bitflags;
@@ -267,11 +266,11 @@ pub unsafe fn map_contiguous(
     frame_alloc: &mut FrameAllocator,
     mut virt: VirtualAddress,
     mut phys: PhysicalAddress,
-    len: NonZero<usize>,
+    len: usize,
     flags: Flags,
     phys_off: VirtualAddress,
 ) -> crate::Result<()> {
-    let mut remaining_bytes = len.get();
+    let mut remaining_bytes = len;
     debug_assert!(
         remaining_bytes >= PAGE_SIZE,
         "address range span be at least one page"
@@ -358,10 +357,10 @@ pub unsafe fn remap_contiguous(
     root_pgtable: PhysicalAddress,
     mut virt: VirtualAddress,
     mut phys: PhysicalAddress,
-    len: NonZero<usize>,
+    len: usize,
     phys_off: VirtualAddress,
 ) {
-    let mut remaining_bytes = len.get();
+    let mut remaining_bytes = len;
     debug_assert!(
         remaining_bytes >= PAGE_SIZE,
         "virtual address range must span be at least one page"

--- a/loader/src/kernel.rs
+++ b/loader/src/kernel.rs
@@ -9,7 +9,7 @@ use core::fmt::Formatter;
 use core::ops::Range;
 use core::{fmt, slice};
 
-use kmem::{PhysicalAddress, VirtualAddress};
+use kmem::{AddressRangeExt, PhysicalAddress, VirtualAddress};
 use loader_api::LoaderConfig;
 use xmas_elf::program::{ProgramHeader, Type};
 
@@ -63,8 +63,10 @@ impl Kernel<'static> {
 
 impl Kernel<'_> {
     pub fn phys_range(&self) -> Range<PhysicalAddress> {
-        let fdt = INLINED_KERNEL_BYTES.0.as_ptr_range();
-        PhysicalAddress::from_ptr(fdt.start)..PhysicalAddress::from_ptr(fdt.end)
+        Range::from_start_len(
+            PhysicalAddress::from_ptr(INLINED_KERNEL_BYTES.0.as_ptr()),
+            INLINED_KERNEL_BYTES.0.len(),
+        )
     }
 
     /// Returns the size of the kernel in memory.

--- a/loader/src/page_alloc.rs
+++ b/loader/src/page_alloc.rs
@@ -8,7 +8,7 @@
 use core::alloc::Layout;
 use core::ops::Range;
 
-use kmem::VirtualAddress;
+use kmem::{AddressRangeExt, VirtualAddress};
 use rand::distr::{Distribution, Uniform};
 use rand::prelude::IteratorRandom;
 use rand_chacha::ChaCha20Rng;
@@ -127,6 +127,7 @@ impl PageAllocator {
             0
         };
 
-        base.checked_add(offset).unwrap()..base.checked_add(offset + layout.size()).unwrap()
+        let start = base.checked_add(offset).unwrap();
+        Range::from_start_len(start, layout.size())
     }
 }


### PR DESCRIPTION
The `AddressRangeExt` trait needed some improving and cleaning up, in preparation for making the address types more safe, sane, and compatible with strict provenance.