### PR TITLE
Create Rust library for ECMA-119 ISO images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iso9660"
+version = "0.1.0"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ util = { path = "libs/util" }
 kasync = { path = "libs/kasync" }
 kmem = { path = "libs/kmem" }
 arrayvec = { path = "libs/arrayvec" }
+iso9660 = { path = "libs/iso9660" }
 
 # 3rd-party dependencies
 cfg-if = "1.0.0"

--- a/libs/iso9660/Cargo.toml
+++ b/libs/iso9660/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "iso9660"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "ECMA-119 (ISO 9660) filesystem image creation with El Torito boot support"
+
+[dependencies]
+
+[dev-dependencies]
+
+[lints]
+workspace = true

--- a/libs/iso9660/src/builder.rs
+++ b/libs/iso9660/src/builder.rs
@@ -1,0 +1,766 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! ISO 9660 image builder.
+//!
+//! This module provides a builder API for creating ISO 9660 filesystem images
+//! with optional El Torito boot support.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use iso9660::{IsoBuilder, BootImage, PlatformId, BootMediaType};
+//!
+//! let mut builder = IsoBuilder::new("MY_VOLUME");
+//!
+//! // Add files
+//! builder.add_file("README.TXT", b"Hello, World!");
+//! builder.add_file("DATA/FILE.DAT", &file_data);
+//!
+//! // Add boot image for BIOS boot
+//! let boot_image = BootImage::bios_no_emulation(bootloader_data);
+//! builder.set_boot_image(boot_image);
+//!
+//! // Build the ISO
+//! let iso_data = builder.build()?;
+//! ```
+
+extern crate alloc;
+
+use alloc::collections::BTreeMap;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::directory::{
+    iso9660_name_length, to_iso9660_name, DirectoryRecordBuilder, MAX_FILE_IDENTIFIER_LENGTH,
+};
+use crate::eltorito::BootCatalogBuilder;
+pub use crate::eltorito::BootImage;
+use crate::error::{Error, Result};
+use crate::path_table::PathTableBuilder;
+use crate::types::{VolumeDateTime, SECTOR_SIZE, SYSTEM_AREA_SECTORS};
+use crate::volume::{
+    BootRecordVolumeDescriptor, PrimaryVolumeDescriptor, VolumeDescriptorSetTerminator,
+};
+
+/// A file entry to be included in the ISO.
+#[derive(Clone)]
+struct FileEntry {
+    /// ISO 9660 filename (uppercase, 8.3 format with version)
+    iso_name: [u8; 32],
+    /// File data
+    data: Vec<u8>,
+    /// Assigned sector location (set during build)
+    location: u32,
+}
+
+/// A directory entry in the ISO filesystem.
+#[derive(Clone, Default)]
+struct DirectoryEntry {
+    /// ISO 9660 directory name (uppercase)
+    iso_name: [u8; 32],
+    /// Child directories
+    children: BTreeMap<String, DirectoryEntry>,
+    /// Files in this directory
+    files: BTreeMap<String, FileEntry>,
+    /// Assigned sector location (set during build)
+    location: u32,
+    /// Directory size in bytes (set during build)
+    size: u32,
+    /// Path table directory number (set during build)
+    dir_number: u16,
+}
+
+/// Builder for creating ISO 9660 filesystem images.
+///
+/// This builder supports:
+/// - Adding files and directories
+/// - El Torito boot support (BIOS and EFI)
+/// - Volume metadata (identifiers, dates)
+pub struct IsoBuilder {
+    /// Volume identifier (up to 32 characters)
+    volume_id: String,
+    /// System identifier
+    system_id: String,
+    /// Publisher identifier
+    publisher_id: String,
+    /// Application identifier
+    application_id: String,
+    /// Root directory
+    root: DirectoryEntry,
+    /// Primary boot image (for El Torito)
+    boot_image: Option<BootImage>,
+    /// Additional boot images for multi-platform boot
+    additional_boot_images: Vec<BootImage>,
+    /// Volume creation date
+    creation_date: Option<VolumeDateTime>,
+}
+
+impl IsoBuilder {
+    /// Creates a new ISO builder with the specified volume identifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `volume_id` - Volume identifier (up to 32 characters, will be uppercased)
+    #[must_use]
+    pub fn new(volume_id: &str) -> Self {
+        Self {
+            volume_id: volume_id.to_ascii_uppercase(),
+            system_id: String::new(),
+            publisher_id: String::new(),
+            application_id: String::from("ISO9660-RS"),
+            root: DirectoryEntry::default(),
+            boot_image: None,
+            additional_boot_images: Vec::new(),
+            creation_date: None,
+        }
+    }
+
+    /// Sets the system identifier.
+    pub fn system_id(&mut self, id: &str) -> &mut Self {
+        self.system_id = id.to_string();
+        self
+    }
+
+    /// Sets the publisher identifier.
+    pub fn publisher_id(&mut self, id: &str) -> &mut Self {
+        self.publisher_id = id.to_string();
+        self
+    }
+
+    /// Sets the application identifier.
+    pub fn application_id(&mut self, id: &str) -> &mut Self {
+        self.application_id = id.to_string();
+        self
+    }
+
+    /// Sets the volume creation date.
+    pub fn creation_date(&mut self, date: VolumeDateTime) -> &mut Self {
+        self.creation_date = Some(date);
+        self
+    }
+
+    /// Sets the primary boot image for El Torito boot.
+    ///
+    /// This enables bootable ISO creation. The boot image will be stored
+    /// in the ISO and referenced by the El Torito boot catalog.
+    pub fn set_boot_image(&mut self, image: BootImage) -> &mut Self {
+        self.boot_image = Some(image);
+        self
+    }
+
+    /// Adds an additional boot image for multi-platform boot.
+    ///
+    /// Use this to add EFI boot support alongside BIOS boot.
+    pub fn add_boot_image(&mut self, image: BootImage) -> &mut Self {
+        self.additional_boot_images.push(image);
+        self
+    }
+
+    /// Adds a file to the ISO image.
+    ///
+    /// The path should use forward slashes as separators. Parent directories
+    /// will be created automatically.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path within the ISO (e.g., "DIR/FILE.TXT")
+    /// * `data` - File contents
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the filename is too long or contains invalid characters.
+    pub fn add_file(&mut self, path: &str, data: &[u8]) -> Result<&mut Self> {
+        let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+        if parts.is_empty() {
+            return Err(Error::InvalidIdentifier("empty path"));
+        }
+
+        // Navigate to the parent directory, creating intermediate directories
+        let mut current_dir = &mut self.root;
+        for &dir_name in &parts[..parts.len() - 1] {
+            if dir_name.len() > MAX_FILE_IDENTIFIER_LENGTH {
+                return Err(Error::IdentifierTooLong {
+                    identifier: "directory name",
+                    max_length: MAX_FILE_IDENTIFIER_LENGTH,
+                });
+            }
+
+            let dir_key = dir_name.to_ascii_uppercase();
+            current_dir = current_dir
+                .children
+                .entry(dir_key.clone())
+                .or_insert_with(|| {
+                    let mut entry = DirectoryEntry::default();
+                    entry.iso_name = to_iso9660_name(dir_name, true);
+                    entry
+                });
+        }
+
+        // Add the file
+        let file_name = parts.last().unwrap();
+        if file_name.len() > MAX_FILE_IDENTIFIER_LENGTH {
+            return Err(Error::IdentifierTooLong {
+                identifier: "file name",
+                max_length: MAX_FILE_IDENTIFIER_LENGTH,
+            });
+        }
+
+        let file_key = file_name.to_ascii_uppercase();
+        current_dir.files.insert(
+            file_key,
+            FileEntry {
+                iso_name: to_iso9660_name(file_name, false),
+                data: data.to_vec(),
+                location: 0,
+            },
+        );
+
+        Ok(self)
+    }
+
+    /// Adds a directory to the ISO image.
+    ///
+    /// Parent directories will be created automatically.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Directory path within the ISO
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory name is too long.
+    pub fn add_directory(&mut self, path: &str) -> Result<&mut Self> {
+        let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+        if parts.is_empty() {
+            return Ok(self);
+        }
+
+        let mut current_dir = &mut self.root;
+        for &dir_name in &parts {
+            if dir_name.len() > MAX_FILE_IDENTIFIER_LENGTH {
+                return Err(Error::IdentifierTooLong {
+                    identifier: "directory name",
+                    max_length: MAX_FILE_IDENTIFIER_LENGTH,
+                });
+            }
+
+            let dir_key = dir_name.to_ascii_uppercase();
+            current_dir = current_dir
+                .children
+                .entry(dir_key.clone())
+                .or_insert_with(|| {
+                    let mut entry = DirectoryEntry::default();
+                    entry.iso_name = to_iso9660_name(dir_name, true);
+                    entry
+                });
+        }
+
+        Ok(self)
+    }
+
+    /// Builds the ISO 9660 image.
+    ///
+    /// Returns the complete ISO image as a byte vector.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the image cannot be built.
+    pub fn build(&mut self) -> Result<Vec<u8>> {
+        // Calculate layout
+        // Sectors 0-15: System Area (32 KB)
+        // Sector 16: Primary Volume Descriptor
+        // Sector 17: Boot Record (if bootable) or Terminator
+        // Sector 18: Terminator (if bootable)
+        // Following sectors: Path tables, directories, boot catalog, boot images, files
+
+        let has_boot = self.boot_image.is_some();
+        let mut current_sector = SYSTEM_AREA_SECTORS;
+
+        // Volume descriptors
+        let pvd_sector = current_sector;
+        current_sector += 1;
+
+        let boot_record_sector = if has_boot {
+            let sector = current_sector;
+            current_sector += 1;
+            Some(sector)
+        } else {
+            None
+        };
+
+        let terminator_sector = current_sector;
+        current_sector += 1;
+
+        // Path tables (L and M)
+        let path_table_l_sector = current_sector;
+        current_sector += 1; // Reserve at least one sector for L path table
+
+        let path_table_m_sector = current_sector;
+        current_sector += 1; // Reserve at least one sector for M path table
+
+        // Root directory
+        let root_directory_sector = current_sector;
+        self.root.location = root_directory_sector;
+
+        // Build path table and assign directory locations
+        let mut path_table = PathTableBuilder::new();
+        self.root.dir_number = path_table.add_root(root_directory_sector);
+
+        // Assign directory locations (breadth-first)
+        self.assign_directory_locations(&mut current_sector, &mut path_table)?;
+
+        // Boot catalog location (if bootable)
+        let boot_catalog_sector = if has_boot {
+            let sector = current_sector;
+            current_sector += 1;
+            Some(sector)
+        } else {
+            None
+        };
+
+        // Boot image location (if bootable)
+        let boot_image_sector = if let Some(ref image) = self.boot_image {
+            let sector = current_sector;
+            current_sector += image.iso_sector_count();
+            Some(sector)
+        } else {
+            None
+        };
+
+        // Additional boot images
+        let mut additional_boot_sectors = Vec::new();
+        for image in &self.additional_boot_images {
+            additional_boot_sectors.push(current_sector);
+            current_sector += image.iso_sector_count();
+        }
+
+        // Assign file locations
+        self.assign_file_locations(&mut current_sector)?;
+
+        // Total volume size
+        let volume_size = current_sector;
+
+        // Path table size
+        let path_table_size = path_table.size() as u32;
+
+        // Now build the actual ISO image
+        let mut iso = vec![0u8; volume_size as usize * SECTOR_SIZE];
+
+        // Write Primary Volume Descriptor
+        let mut pvd = PrimaryVolumeDescriptor::new();
+        pvd.set_volume_identifier(&self.volume_id);
+        if !self.system_id.is_empty() {
+            pvd.set_system_identifier(&self.system_id);
+        }
+        if !self.publisher_id.is_empty() {
+            pvd.set_publisher_identifier(&self.publisher_id);
+        }
+        pvd.set_application_identifier(&self.application_id);
+        pvd.set_volume_space_size(volume_size);
+        pvd.set_path_table(path_table_size, path_table_l_sector, path_table_m_sector);
+
+        // Set root directory info
+        let root_size = self.calculate_directory_size(&self.root);
+        pvd.set_root_directory(root_directory_sector, root_size);
+
+        if let Some(date) = &self.creation_date {
+            pvd.set_creation_date(*date);
+        }
+
+        self.write_sector(&mut iso, pvd_sector, pvd.as_bytes());
+
+        // Write Boot Record (if bootable)
+        if let Some(sector) = boot_record_sector {
+            let boot_record =
+                BootRecordVolumeDescriptor::new(boot_catalog_sector.unwrap());
+            self.write_sector(&mut iso, sector, boot_record.as_bytes());
+        }
+
+        // Write Volume Descriptor Set Terminator
+        let terminator = VolumeDescriptorSetTerminator::new();
+        self.write_sector(&mut iso, terminator_sector, terminator.as_bytes());
+
+        // Write path tables
+        let mut path_table_buf = vec![0u8; SECTOR_SIZE];
+        path_table.write_le(&mut path_table_buf);
+        self.write_sector(&mut iso, path_table_l_sector, &path_table_buf);
+
+        path_table_buf.fill(0);
+        path_table.write_be(&mut path_table_buf);
+        self.write_sector(&mut iso, path_table_m_sector, &path_table_buf);
+
+        // Write directories
+        self.write_directories(&mut iso, &self.root.clone(), root_directory_sector)?;
+
+        // Write boot catalog (if bootable)
+        if let (Some(catalog_sector), Some(image_sector)) =
+            (boot_catalog_sector, boot_image_sector)
+        {
+            let boot_image = self.boot_image.as_ref().unwrap();
+            let mut catalog_builder = BootCatalogBuilder::new();
+            catalog_builder
+                .platform(boot_image.platform)
+                .id_string(&self.volume_id)
+                .default_boot_entry(
+                    boot_image.media_type,
+                    image_sector,
+                    boot_image.sector_count(),
+                );
+
+            // Add additional boot images as sections
+            for (i, image) in self.additional_boot_images.iter().enumerate() {
+                let entry = crate::eltorito::SectionEntry::new(
+                    image.media_type,
+                    additional_boot_sectors[i],
+                    image.sector_count(),
+                );
+                catalog_builder.add_section(image.platform, alloc::vec![entry]);
+            }
+
+            let catalog = catalog_builder.build();
+            self.write_data(&mut iso, catalog_sector, &catalog);
+
+            // Write boot images
+            self.write_data(&mut iso, image_sector, &boot_image.data);
+        }
+
+        // Write additional boot images
+        for (i, image) in self.additional_boot_images.iter().enumerate() {
+            self.write_data(&mut iso, additional_boot_sectors[i], &image.data);
+        }
+
+        // Write file data
+        self.write_files(&mut iso)?;
+
+        Ok(iso)
+    }
+
+    /// Assigns sector locations to all directories.
+    fn assign_directory_locations(
+        &mut self,
+        current_sector: &mut u32,
+        path_table: &mut PathTableBuilder,
+    ) -> Result<()> {
+        // Process directories level by level (breadth-first)
+        let mut to_process: Vec<(String, u16)> = Vec::new();
+
+        // First, assign location to root and collect its children
+        let root_size = self.calculate_directory_size(&self.root);
+        self.root.size = root_size;
+        *current_sector += sectors_for_size(root_size);
+
+        for (name, child) in &mut self.root.children {
+            child.location = *current_sector;
+            let child_size = calculate_directory_size(child);
+            child.size = child_size;
+            *current_sector += sectors_for_size(child_size);
+
+            child.dir_number = path_table.add_directory(
+                core::str::from_utf8(&child.iso_name)
+                    .unwrap_or("")
+                    .trim_end_matches('\0'),
+                child.location,
+                self.root.dir_number,
+            );
+            to_process.push((name.clone(), child.dir_number));
+        }
+
+        // Process remaining directories
+        while !to_process.is_empty() {
+            let mut next_level = Vec::new();
+
+            for (dir_path, parent_num) in to_process {
+                let dir = self.find_directory_mut(&dir_path);
+                if let Some(dir) = dir {
+                    for (name, child) in &mut dir.children {
+                        child.location = *current_sector;
+                        let child_size = calculate_directory_size(child);
+                        child.size = child_size;
+                        *current_sector += sectors_for_size(child_size);
+
+                        child.dir_number = path_table.add_directory(
+                            core::str::from_utf8(&child.iso_name)
+                                .unwrap_or("")
+                                .trim_end_matches('\0'),
+                            child.location,
+                            parent_num,
+                        );
+                        next_level.push((format!("{dir_path}/{name}"), child.dir_number));
+                    }
+                }
+            }
+
+            to_process = next_level;
+        }
+
+        Ok(())
+    }
+
+    /// Finds a directory by path.
+    fn find_directory_mut(&mut self, path: &str) -> Option<&mut DirectoryEntry> {
+        let parts: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+        let mut current = &mut self.root;
+
+        for part in parts {
+            current = current.children.get_mut(part)?;
+        }
+
+        Some(current)
+    }
+
+    /// Calculates the size of a directory entry table.
+    fn calculate_directory_size(&self, dir: &DirectoryEntry) -> u32 {
+        calculate_directory_size(dir)
+    }
+
+    /// Assigns sector locations to all files.
+    fn assign_file_locations(&mut self, current_sector: &mut u32) -> Result<()> {
+        self.assign_file_locations_recursive(&mut self.root.clone(), current_sector)?;
+        self.apply_file_locations(&self.root.clone())?;
+        Ok(())
+    }
+
+    fn assign_file_locations_recursive(
+        &self,
+        dir: &mut DirectoryEntry,
+        current_sector: &mut u32,
+    ) -> Result<()> {
+        for file in dir.files.values_mut() {
+            file.location = *current_sector;
+            let file_sectors = sectors_for_size(file.data.len() as u32);
+            *current_sector += file_sectors;
+        }
+
+        for child in dir.children.values_mut() {
+            self.assign_file_locations_recursive(child, current_sector)?;
+        }
+
+        Ok(())
+    }
+
+    fn apply_file_locations(&mut self, template: &DirectoryEntry) -> Result<()> {
+        // Apply file locations from template to actual root
+        apply_file_locations_recursive(&mut self.root, template);
+        Ok(())
+    }
+
+    /// Writes a sector to the ISO image.
+    fn write_sector(&self, iso: &mut [u8], sector: u32, data: &[u8]) {
+        let offset = sector as usize * SECTOR_SIZE;
+        let len = data.len().min(SECTOR_SIZE);
+        iso[offset..offset + len].copy_from_slice(&data[..len]);
+    }
+
+    /// Writes data spanning multiple sectors.
+    fn write_data(&self, iso: &mut [u8], start_sector: u32, data: &[u8]) {
+        let offset = start_sector as usize * SECTOR_SIZE;
+        iso[offset..offset + data.len()].copy_from_slice(data);
+    }
+
+    /// Writes all directory entries.
+    fn write_directories(
+        &self,
+        iso: &mut [u8],
+        dir: &DirectoryEntry,
+        parent_location: u32,
+    ) -> Result<()> {
+        let offset = dir.location as usize * SECTOR_SIZE;
+        let mut pos = 0;
+
+        // "." entry
+        let self_entry = DirectoryRecordBuilder::new_self_entry(dir.location, dir.size);
+        pos += self_entry.write_to(&mut iso[offset + pos..]);
+
+        // ".." entry
+        let parent_entry = DirectoryRecordBuilder::new_parent_entry(
+            parent_location,
+            SECTOR_SIZE as u32, // Parent size (simplified)
+        );
+        pos += parent_entry.write_to(&mut iso[offset + pos..]);
+
+        // Child directories
+        for child in dir.children.values() {
+            let name = core::str::from_utf8(&child.iso_name)
+                .unwrap_or("")
+                .trim_end_matches('\0');
+            let entry = DirectoryRecordBuilder::new_directory(name, child.location, child.size);
+            pos += entry.write_to(&mut iso[offset + pos..]);
+        }
+
+        // Files
+        for file in dir.files.values() {
+            let name = core::str::from_utf8(&file.iso_name)
+                .unwrap_or("")
+                .trim_end_matches('\0');
+            let entry =
+                DirectoryRecordBuilder::new_file(name, file.location, file.data.len() as u32);
+            pos += entry.write_to(&mut iso[offset + pos..]);
+        }
+
+        // Recursively write child directories
+        for child in dir.children.values() {
+            self.write_directories(iso, child, dir.location)?;
+        }
+
+        Ok(())
+    }
+
+    /// Writes all file data.
+    fn write_files(&self, iso: &mut [u8]) -> Result<()> {
+        self.write_files_recursive(&self.root, iso)
+    }
+
+    fn write_files_recursive(&self, dir: &DirectoryEntry, iso: &mut [u8]) -> Result<()> {
+        for file in dir.files.values() {
+            self.write_data(iso, file.location, &file.data);
+        }
+
+        for child in dir.children.values() {
+            self.write_files_recursive(child, iso)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Calculates the number of sectors needed for the given size.
+fn sectors_for_size(size: u32) -> u32 {
+    (size + SECTOR_SIZE as u32 - 1) / SECTOR_SIZE as u32
+}
+
+/// Calculates the size of a directory entry table.
+fn calculate_directory_size(dir: &DirectoryEntry) -> u32 {
+    let mut size = 0u32;
+
+    // "." entry (34 bytes)
+    size += 34;
+
+    // ".." entry (34 bytes)
+    size += 34;
+
+    // Child directories
+    for child in dir.children.values() {
+        let name_len = iso9660_name_length(&child.iso_name) as u32;
+        let record_size = 33 + name_len;
+        // Pad to even length
+        size += if record_size % 2 == 0 {
+            record_size
+        } else {
+            record_size + 1
+        };
+    }
+
+    // Files
+    for file in dir.files.values() {
+        let name_len = iso9660_name_length(&file.iso_name) as u32;
+        let record_size = 33 + name_len;
+        // Pad to even length
+        size += if record_size % 2 == 0 {
+            record_size
+        } else {
+            record_size + 1
+        };
+    }
+
+    size
+}
+
+/// Recursively applies file locations from a template to the target directory.
+fn apply_file_locations_recursive(target: &mut DirectoryEntry, source: &DirectoryEntry) {
+    for (name, source_file) in &source.files {
+        if let Some(target_file) = target.files.get_mut(name) {
+            target_file.location = source_file.location;
+        }
+    }
+
+    for (name, source_child) in &source.children {
+        if let Some(target_child) = target.children.get_mut(name) {
+            apply_file_locations_recursive(target_child, source_child);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_iso_builder_new() {
+        let builder = IsoBuilder::new("TEST_VOLUME");
+        assert_eq!(builder.volume_id, "TEST_VOLUME");
+    }
+
+    #[test]
+    fn test_add_file() {
+        let mut builder = IsoBuilder::new("TEST");
+        builder.add_file("README.TXT", b"Hello").unwrap();
+        assert!(!builder.root.files.is_empty());
+    }
+
+    #[test]
+    fn test_add_nested_file() {
+        let mut builder = IsoBuilder::new("TEST");
+        builder.add_file("DIR/SUBDIR/FILE.TXT", b"Nested").unwrap();
+        assert!(!builder.root.children.is_empty());
+    }
+
+    #[test]
+    fn test_build_minimal_iso() {
+        let mut builder = IsoBuilder::new("MINIMAL");
+        let iso = builder.build().unwrap();
+
+        // Check minimum size (system area + PVD + terminator + path tables + root dir)
+        assert!(iso.len() >= 20 * SECTOR_SIZE);
+
+        // Check PVD magic
+        let pvd_offset = 16 * SECTOR_SIZE;
+        assert_eq!(iso[pvd_offset], 1); // Type code
+        assert_eq!(&iso[pvd_offset + 1..pvd_offset + 6], b"CD001");
+    }
+
+    #[test]
+    fn test_build_with_file() {
+        let mut builder = IsoBuilder::new("WITHFILE");
+        builder.add_file("TEST.TXT", b"Hello, ISO!").unwrap();
+        let iso = builder.build().unwrap();
+
+        // Verify ISO is valid
+        let pvd_offset = 16 * SECTOR_SIZE;
+        assert_eq!(&iso[pvd_offset + 1..pvd_offset + 6], b"CD001");
+    }
+
+    #[test]
+    fn test_build_bootable_iso() {
+        let mut builder = IsoBuilder::new("BOOTABLE");
+
+        // Add a simple boot image
+        let boot_data = vec![0xEB, 0xFE]; // Infinite loop (JMP $)
+        builder.set_boot_image(BootImage::bios_no_emulation(boot_data));
+
+        let iso = builder.build().unwrap();
+
+        // Check Boot Record at sector 17
+        let br_offset = 17 * SECTOR_SIZE;
+        assert_eq!(iso[br_offset], 0); // Type code for boot record
+        assert_eq!(&iso[br_offset + 1..br_offset + 6], b"CD001");
+        assert_eq!(&iso[br_offset + 7..br_offset + 30], b"EL TORITO SPECIFICATION");
+    }
+
+    #[test]
+    fn test_sectors_for_size() {
+        assert_eq!(sectors_for_size(0), 0);
+        assert_eq!(sectors_for_size(1), 1);
+        assert_eq!(sectors_for_size(2048), 1);
+        assert_eq!(sectors_for_size(2049), 2);
+        assert_eq!(sectors_for_size(4096), 2);
+    }
+}

--- a/libs/iso9660/src/directory.rs
+++ b/libs/iso9660/src/directory.rs
@@ -1,0 +1,420 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Directory Record structures for ISO 9660 filesystems.
+//!
+//! Directory records describe files and directories within the filesystem.
+//! Each record has a variable length (minimum 34 bytes) and contains
+//! metadata about the file/directory including location, size, and attributes.
+//!
+//! Reference: ECMA-119 Section 9.1
+
+use crate::types::{BothEndian16, BothEndian32, DirectoryDateTime};
+
+/// File flags for directory records.
+///
+/// Reference: ECMA-119 Section 9.1.6
+pub mod flags {
+    /// File is hidden (existence bit).
+    pub const HIDDEN: u8 = 0x01;
+    /// Entry is a directory.
+    pub const DIRECTORY: u8 = 0x02;
+    /// Entry is an associated file.
+    pub const ASSOCIATED: u8 = 0x04;
+    /// Extended attribute record contains information about the format of the record.
+    pub const RECORD: u8 = 0x08;
+    /// Owner and group permissions are specified in the extended attribute record.
+    pub const PROTECTION: u8 = 0x10;
+    /// Reserved bits 5-6.
+    pub const RESERVED_5: u8 = 0x20;
+    pub const RESERVED_6: u8 = 0x40;
+    /// This is not the final directory record for this file (multi-extent).
+    pub const MULTI_EXTENT: u8 = 0x80;
+}
+
+/// Maximum length of a file identifier in ISO 9660 Level 1.
+pub const MAX_FILE_IDENTIFIER_LENGTH: usize = 30;
+
+/// Maximum length of a directory identifier in ISO 9660 Level 1.
+pub const MAX_DIRECTORY_IDENTIFIER_LENGTH: usize = 31;
+
+/// Directory Record structure.
+///
+/// This structure has a fixed 33-byte header followed by a variable-length
+/// file identifier and optional padding.
+///
+/// Reference: ECMA-119 Section 9.1
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct DirectoryRecord {
+    /// Length of this directory record
+    pub length: u8,
+    /// Extended Attribute Record length
+    pub extended_attribute_length: u8,
+    /// Location of extent (first sector of file data)
+    pub location: BothEndian32,
+    /// Data length (file size in bytes)
+    pub data_length: BothEndian32,
+    /// Recording date and time
+    pub recording_date_time: DirectoryDateTime,
+    /// File flags
+    pub file_flags: u8,
+    /// File unit size (for interleaved files, 0 otherwise)
+    pub file_unit_size: u8,
+    /// Interleave gap size (for interleaved files, 0 otherwise)
+    pub interleave_gap_size: u8,
+    /// Volume sequence number where this extent is recorded
+    pub volume_sequence_number: BothEndian16,
+    /// Length of file identifier
+    pub file_identifier_length: u8,
+    /// File identifier (variable length, followed by padding if even length).
+    /// For the root directory entry in the PVD, this is a single byte (0x00).
+    pub file_identifier: [u8; 1],
+}
+
+/// Minimum size of a directory record (header only, with 1-byte identifier).
+pub const DIRECTORY_RECORD_MIN_SIZE: usize = 34;
+
+impl DirectoryRecord {
+    /// Creates a new root directory record.
+    ///
+    /// The root directory record uses a single 0x00 byte as the identifier.
+    #[must_use]
+    pub fn new_root() -> Self {
+        Self {
+            length: 34,
+            extended_attribute_length: 0,
+            location: BothEndian32::new(0),
+            data_length: BothEndian32::new(0),
+            recording_date_time: DirectoryDateTime::unspecified(),
+            file_flags: flags::DIRECTORY,
+            file_unit_size: 0,
+            interleave_gap_size: 0,
+            volume_sequence_number: BothEndian16::new(1),
+            file_identifier_length: 1,
+            file_identifier: [0x00],
+        }
+    }
+
+    /// Returns the actual size of this directory record.
+    #[must_use]
+    pub fn record_length(&self) -> usize {
+        self.length as usize
+    }
+
+    /// Returns whether this record represents a directory.
+    #[must_use]
+    pub fn is_directory(&self) -> bool {
+        self.file_flags & flags::DIRECTORY != 0
+    }
+}
+
+const _: () = assert!(size_of::<DirectoryRecord>() == DIRECTORY_RECORD_MIN_SIZE);
+
+/// Builder for creating directory records.
+///
+/// This builder handles the variable-length nature of directory records,
+/// including proper padding.
+pub struct DirectoryRecordBuilder {
+    /// Sector location of the file/directory data
+    location: u32,
+    /// Size of the file/directory data in bytes
+    data_length: u32,
+    /// File flags
+    file_flags: u8,
+    /// Recording date/time
+    recording_date_time: DirectoryDateTime,
+    /// File identifier (name)
+    identifier: [u8; MAX_FILE_IDENTIFIER_LENGTH + 2],
+    /// Length of the identifier
+    identifier_length: u8,
+}
+
+impl DirectoryRecordBuilder {
+    /// Creates a new builder for a file.
+    #[must_use]
+    pub fn new_file(name: &str, location: u32, size: u32) -> Self {
+        let mut builder = Self {
+            location,
+            data_length: size,
+            file_flags: 0,
+            recording_date_time: DirectoryDateTime::unspecified(),
+            identifier: [0; MAX_FILE_IDENTIFIER_LENGTH + 2],
+            identifier_length: 0,
+        };
+        builder.set_identifier(name);
+        builder
+    }
+
+    /// Creates a new builder for a directory.
+    #[must_use]
+    pub fn new_directory(name: &str, location: u32, size: u32) -> Self {
+        let mut builder = Self {
+            location,
+            data_length: size,
+            file_flags: flags::DIRECTORY,
+            recording_date_time: DirectoryDateTime::unspecified(),
+            identifier: [0; MAX_FILE_IDENTIFIER_LENGTH + 2],
+            identifier_length: 0,
+        };
+        builder.set_identifier(name);
+        builder
+    }
+
+    /// Creates a "." (self) directory entry.
+    #[must_use]
+    pub fn new_self_entry(location: u32, size: u32) -> Self {
+        Self {
+            location,
+            data_length: size,
+            file_flags: flags::DIRECTORY,
+            recording_date_time: DirectoryDateTime::unspecified(),
+            identifier: [0; MAX_FILE_IDENTIFIER_LENGTH + 2],
+            identifier_length: 1,
+        }
+    }
+
+    /// Creates a ".." (parent) directory entry.
+    #[must_use]
+    pub fn new_parent_entry(location: u32, size: u32) -> Self {
+        let mut identifier = [0; MAX_FILE_IDENTIFIER_LENGTH + 2];
+        identifier[0] = 0x01;
+        Self {
+            location,
+            data_length: size,
+            file_flags: flags::DIRECTORY,
+            recording_date_time: DirectoryDateTime::unspecified(),
+            identifier,
+            identifier_length: 1,
+        }
+    }
+
+    /// Sets the file identifier (name).
+    fn set_identifier(&mut self, name: &str) {
+        let bytes = name.as_bytes();
+        let len = bytes.len().min(MAX_FILE_IDENTIFIER_LENGTH);
+        self.identifier[..len].copy_from_slice(&bytes[..len]);
+        self.identifier_length = len as u8;
+    }
+
+    /// Sets the recording date/time.
+    pub fn set_date_time(&mut self, date_time: DirectoryDateTime) {
+        self.recording_date_time = date_time;
+    }
+
+    /// Sets the hidden flag.
+    pub fn set_hidden(&mut self, hidden: bool) {
+        if hidden {
+            self.file_flags |= flags::HIDDEN;
+        } else {
+            self.file_flags &= !flags::HIDDEN;
+        }
+    }
+
+    /// Calculates the total size of the directory record.
+    #[must_use]
+    pub fn record_size(&self) -> usize {
+        // Base size (33 bytes) + identifier length + padding (if even length)
+        let base = 33 + self.identifier_length as usize;
+        if base % 2 == 0 {
+            base
+        } else {
+            base + 1
+        }
+    }
+
+    /// Writes the directory record to a buffer.
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is too small.
+    pub fn write_to(&self, buf: &mut [u8]) -> usize {
+        let record_size = self.record_size();
+        assert!(buf.len() >= record_size, "buffer too small for directory record");
+
+        // Zero the buffer first
+        buf[..record_size].fill(0);
+
+        // Length of directory record
+        buf[0] = record_size as u8;
+        // Extended attribute record length
+        buf[1] = 0;
+        // Location of extent (both-endian: 4 bytes LE + 4 bytes BE)
+        let location = BothEndian32::new(self.location);
+        buf[2..6].copy_from_slice(&location.le_bytes()[..]);
+        buf[6..10].copy_from_slice(&location.be_bytes()[..]);
+        // Data length (both-endian: 4 bytes LE + 4 bytes BE)
+        let data_length = BothEndian32::new(self.data_length);
+        buf[10..14].copy_from_slice(&data_length.le_bytes()[..]);
+        buf[14..18].copy_from_slice(&data_length.be_bytes()[..]);
+        // Recording date and time
+        buf[18] = self.recording_date_time.years_since_1900;
+        buf[19] = self.recording_date_time.month;
+        buf[20] = self.recording_date_time.day;
+        buf[21] = self.recording_date_time.hour;
+        buf[22] = self.recording_date_time.minute;
+        buf[23] = self.recording_date_time.second;
+        buf[24] = self.recording_date_time.gmt_offset as u8;
+        // File flags
+        buf[25] = self.file_flags;
+        // File unit size
+        buf[26] = 0;
+        // Interleave gap size
+        buf[27] = 0;
+        // Volume sequence number (both-endian: 2 bytes LE + 2 bytes BE)
+        let vsn = BothEndian16::new(1);
+        buf[28..30].copy_from_slice(vsn.le_bytes());
+        buf[30..32].copy_from_slice(vsn.be_bytes());
+        // File identifier length
+        buf[32] = self.identifier_length;
+        // File identifier
+        let id_len = self.identifier_length as usize;
+        buf[33..33 + id_len].copy_from_slice(&self.identifier[..id_len]);
+
+        record_size
+    }
+}
+
+/// Converts a filename to ISO 9660 Level 1 format.
+///
+/// ISO 9660 Level 1 filenames:
+/// - Maximum 8 characters for the name
+/// - Maximum 3 characters for the extension
+/// - Separated by a dot
+/// - Only uppercase A-Z, 0-9, and underscore
+/// - Files must end with ";1" version number
+///
+/// # Arguments
+///
+/// * `name` - The input filename
+/// * `is_directory` - Whether this is a directory name
+///
+/// # Returns
+///
+/// The converted ISO 9660 filename.
+#[must_use]
+pub fn to_iso9660_name(name: &str, is_directory: bool) -> [u8; 32] {
+    let mut result = [0u8; 32];
+    let mut pos = 0;
+
+    // Convert to uppercase and filter invalid characters
+    let name_upper = name.to_ascii_uppercase();
+    let (base, ext) = if let Some(dot_pos) = name_upper.rfind('.') {
+        (&name_upper[..dot_pos], Some(&name_upper[dot_pos + 1..]))
+    } else {
+        (name_upper.as_str(), None)
+    };
+
+    // Write base name (max 8 chars for files, 31 for directories)
+    let max_base = if is_directory { 31 } else { 8 };
+    for ch in base.chars().take(max_base) {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            result[pos] = ch as u8;
+            pos += 1;
+        }
+    }
+
+    if !is_directory {
+        // Add dot and extension for files
+        result[pos] = b'.';
+        pos += 1;
+
+        if let Some(ext) = ext {
+            for ch in ext.chars().take(3) {
+                if ch.is_ascii_alphanumeric() || ch == '_' {
+                    result[pos] = ch as u8;
+                    pos += 1;
+                }
+            }
+        }
+
+        // Add version number
+        result[pos] = b';';
+        pos += 1;
+        result[pos] = b'1';
+    }
+
+    result
+}
+
+/// Calculates the ISO 9660 filename length.
+#[must_use]
+pub fn iso9660_name_length(name: &[u8; 32]) -> u8 {
+    name.iter()
+        .position(|&b| b == 0)
+        .unwrap_or(32) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_directory_record_size() {
+        assert_eq!(size_of::<DirectoryRecord>(), DIRECTORY_RECORD_MIN_SIZE);
+    }
+
+    #[test]
+    fn test_root_record() {
+        let root = DirectoryRecord::new_root();
+        assert_eq!(root.length, 34);
+        assert!(root.is_directory());
+        assert_eq!(root.file_identifier_length, 1);
+        assert_eq!(root.file_identifier[0], 0x00);
+    }
+
+    #[test]
+    fn test_directory_record_builder() {
+        let builder = DirectoryRecordBuilder::new_file("TEST.TXT", 100, 512);
+        let size = builder.record_size();
+        assert!(size >= DIRECTORY_RECORD_MIN_SIZE);
+
+        let mut buf = [0u8; 128];
+        let written = builder.write_to(&mut buf);
+        assert_eq!(written, size);
+        assert_eq!(buf[0], size as u8);
+    }
+
+    #[test]
+    fn test_self_entry() {
+        let builder = DirectoryRecordBuilder::new_self_entry(100, 2048);
+        let _size = builder.record_size();
+
+        let mut buf = [0u8; 64];
+        builder.write_to(&mut buf);
+
+        // Self entry has identifier 0x00
+        assert_eq!(buf[32], 1); // identifier length
+        assert_eq!(buf[33], 0x00); // identifier (.)
+    }
+
+    #[test]
+    fn test_parent_entry() {
+        let builder = DirectoryRecordBuilder::new_parent_entry(50, 2048);
+        let _size = builder.record_size();
+
+        let mut buf = [0u8; 64];
+        builder.write_to(&mut buf);
+
+        // Parent entry has identifier 0x01
+        assert_eq!(buf[32], 1); // identifier length
+        assert_eq!(buf[33], 0x01); // identifier (..)
+    }
+
+    #[test]
+    fn test_to_iso9660_name() {
+        let name = to_iso9660_name("readme.txt", false);
+        let len = iso9660_name_length(&name);
+        assert_eq!(&name[..len as usize], b"README.TXT;1");
+
+        let name = to_iso9660_name("subdir", true);
+        let len = iso9660_name_length(&name);
+        assert_eq!(&name[..len as usize], b"SUBDIR");
+    }
+}

--- a/libs/iso9660/src/eltorito.rs
+++ b/libs/iso9660/src/eltorito.rs
@@ -1,0 +1,669 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! El Torito Boot Catalog structures for bootable ISO 9660 images.
+//!
+//! El Torito is an extension to ISO 9660 that allows booting from CD-ROM/DVD.
+//! The boot catalog contains entries describing available boot images and
+//! how they should be loaded.
+//!
+//! Boot Catalog Structure:
+//! 1. Validation Entry (required, first entry)
+//! 2. Initial/Default Entry (required, second entry)
+//! 3. Section Header Entry (optional, for multi-platform boot)
+//! 4. Section Entry (optional, additional boot images)
+//!
+//! Reference: "El Torito" Bootable CD-ROM Format Specification Version 1.0
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+/// Size of each boot catalog entry in bytes.
+pub const BOOT_CATALOG_ENTRY_SIZE: usize = 32;
+
+/// Platform IDs for El Torito.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PlatformId {
+    /// 80x86 (BIOS)
+    X86 = 0x00,
+    /// PowerPC
+    PowerPC = 0x01,
+    /// Mac
+    Mac = 0x02,
+    /// EFI (UEFI systems)
+    Efi = 0xEF,
+}
+
+impl Default for PlatformId {
+    fn default() -> Self {
+        Self::X86
+    }
+}
+
+/// Boot media types for El Torito.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum BootMediaType {
+    /// No emulation - boot image is loaded directly
+    NoEmulation = 0x00,
+    /// 1.2 MB floppy emulation
+    Floppy1_2M = 0x01,
+    /// 1.44 MB floppy emulation
+    Floppy1_44M = 0x02,
+    /// 2.88 MB floppy emulation
+    Floppy2_88M = 0x03,
+    /// Hard disk emulation
+    HardDisk = 0x04,
+}
+
+impl Default for BootMediaType {
+    fn default() -> Self {
+        Self::NoEmulation
+    }
+}
+
+/// Validation Entry (first entry in boot catalog).
+///
+/// The validation entry verifies the integrity of the boot catalog and
+/// identifies the platform. The checksum is computed such that all 16-bit
+/// words sum to zero.
+///
+/// Reference: El Torito Specification Section 2.1
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct ValidationEntry {
+    /// Header ID (must be 0x01)
+    pub header_id: u8,
+    /// Platform ID
+    pub platform_id: u8,
+    /// Reserved (0)
+    pub reserved: u16,
+    /// ID string (24 bytes, manufacturer/developer)
+    pub id_string: [u8; 24],
+    /// Checksum (sum of all 16-bit words must be 0)
+    pub checksum: u16,
+    /// Key byte 1 (must be 0x55)
+    pub key_byte_1: u8,
+    /// Key byte 2 (must be 0xAA)
+    pub key_byte_2: u8,
+}
+
+impl ValidationEntry {
+    /// Key bytes that must be present for a valid entry.
+    pub const KEY_BYTES: (u8, u8) = (0x55, 0xAA);
+
+    /// Creates a new validation entry for the specified platform.
+    #[must_use]
+    pub fn new(platform: PlatformId, id_string: &str) -> Self {
+        let mut entry = Self {
+            header_id: 0x01,
+            platform_id: platform as u8,
+            reserved: 0,
+            id_string: [0; 24],
+            checksum: 0,
+            key_byte_1: Self::KEY_BYTES.0,
+            key_byte_2: Self::KEY_BYTES.1,
+        };
+
+        // Copy ID string
+        let id_bytes = id_string.as_bytes();
+        let copy_len = id_bytes.len().min(24);
+        entry.id_string[..copy_len].copy_from_slice(&id_bytes[..copy_len]);
+
+        // Calculate checksum
+        entry.checksum = entry.calculate_checksum();
+
+        entry
+    }
+
+    /// Calculates the checksum for the validation entry.
+    ///
+    /// The checksum is the two's complement of the sum of all 16-bit words
+    /// in the entry (excluding the checksum field).
+    fn calculate_checksum(&self) -> u16 {
+        let bytes = self.as_bytes_without_checksum();
+        let mut sum: u32 = 0;
+
+        // Sum all 16-bit words except checksum (bytes 28-29)
+        for i in (0..28).step_by(2) {
+            sum += u16::from_le_bytes([bytes[i], bytes[i + 1]]) as u32;
+        }
+        // Add key bytes
+        sum += u16::from_le_bytes([self.key_byte_1, self.key_byte_2]) as u32;
+
+        // Two's complement
+        ((!sum + 1) & 0xFFFF) as u16
+    }
+
+    /// Returns the entry as bytes without the checksum field set.
+    fn as_bytes_without_checksum(&self) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = self.header_id;
+        bytes[1] = self.platform_id;
+        bytes[2..4].copy_from_slice(&self.reserved.to_le_bytes());
+        bytes[4..28].copy_from_slice(&self.id_string);
+        // bytes[28..30] = checksum (leave as 0 for calculation)
+        bytes[30] = self.key_byte_1;
+        bytes[31] = self.key_byte_2;
+        bytes
+    }
+
+    /// Serializes the entry to a byte array.
+    #[must_use]
+    pub fn as_bytes(&self) -> [u8; 32] {
+        let mut bytes = self.as_bytes_without_checksum();
+        bytes[28..30].copy_from_slice(&self.checksum.to_le_bytes());
+        bytes
+    }
+}
+
+const _: () = assert!(size_of::<ValidationEntry>() == BOOT_CATALOG_ENTRY_SIZE);
+
+/// Initial/Default Entry (second entry in boot catalog).
+///
+/// Describes the default boot image to be loaded. This entry is required
+/// for any bootable CD-ROM.
+///
+/// Reference: El Torito Specification Section 2.2
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct InitialEntry {
+    /// Boot indicator (0x88 = bootable, 0x00 = not bootable)
+    pub boot_indicator: u8,
+    /// Boot media type
+    pub boot_media_type: u8,
+    /// Load segment (0 = use default 0x7C0)
+    pub load_segment: u16,
+    /// System type (from partition table)
+    pub system_type: u8,
+    /// Unused (0)
+    pub unused1: u8,
+    /// Number of 512-byte virtual sectors to load
+    pub sector_count: u16,
+    /// Logical block address of the boot image
+    pub load_rba: u32,
+    /// Reserved/unused (20 bytes)
+    pub reserved: [u8; 20],
+}
+
+impl InitialEntry {
+    /// Boot indicator value for bootable entry.
+    pub const BOOTABLE: u8 = 0x88;
+    /// Boot indicator value for not bootable entry.
+    pub const NOT_BOOTABLE: u8 = 0x00;
+
+    /// Creates a new initial entry for a bootable image.
+    ///
+    /// # Arguments
+    ///
+    /// * `media_type` - The boot media emulation type
+    /// * `load_rba` - The logical block address of the boot image
+    /// * `sector_count` - Number of 512-byte sectors to load (for no emulation)
+    #[must_use]
+    pub fn new(media_type: BootMediaType, load_rba: u32, sector_count: u16) -> Self {
+        Self {
+            boot_indicator: Self::BOOTABLE,
+            boot_media_type: media_type as u8,
+            load_segment: 0, // Use default 0x7C0
+            system_type: 0,
+            unused1: 0,
+            sector_count,
+            load_rba: load_rba.to_le(),
+            reserved: [0; 20],
+        }
+    }
+
+    /// Creates a no-emulation boot entry.
+    ///
+    /// This is the most common type for modern bootloaders.
+    ///
+    /// # Arguments
+    ///
+    /// * `load_rba` - The logical block address of the boot image
+    /// * `sector_count` - Number of 512-byte sectors to load
+    #[must_use]
+    pub fn no_emulation(load_rba: u32, sector_count: u16) -> Self {
+        Self::new(BootMediaType::NoEmulation, load_rba, sector_count)
+    }
+
+    /// Sets the load segment for the boot image.
+    ///
+    /// Only meaningful for no-emulation boot.
+    /// Default is 0, which means 0x7C0.
+    pub fn set_load_segment(&mut self, segment: u16) {
+        self.load_segment = segment.to_le();
+    }
+
+    /// Serializes the entry to a byte array.
+    #[must_use]
+    pub fn as_bytes(&self) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = self.boot_indicator;
+        bytes[1] = self.boot_media_type;
+        bytes[2..4].copy_from_slice(&self.load_segment.to_le_bytes());
+        bytes[4] = self.system_type;
+        bytes[5] = self.unused1;
+        bytes[6..8].copy_from_slice(&self.sector_count.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.load_rba.to_le_bytes());
+        bytes[12..32].copy_from_slice(&self.reserved);
+        bytes
+    }
+}
+
+const _: () = assert!(size_of::<InitialEntry>() == BOOT_CATALOG_ENTRY_SIZE);
+
+/// Section Header Entry for multi-platform boot support.
+///
+/// Section headers introduce additional boot entries for different platforms.
+/// Each section header is followed by one or more section entries.
+///
+/// Reference: El Torito Specification Section 2.3
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct SectionHeaderEntry {
+    /// Header indicator (0x90 = more headers follow, 0x91 = last header)
+    pub header_indicator: u8,
+    /// Platform ID
+    pub platform_id: u8,
+    /// Number of section entries following this header
+    pub section_entries: u16,
+    /// ID string (28 bytes)
+    pub id_string: [u8; 28],
+}
+
+impl SectionHeaderEntry {
+    /// Header indicator for non-final section header.
+    pub const MORE_HEADERS: u8 = 0x90;
+    /// Header indicator for final section header.
+    pub const FINAL_HEADER: u8 = 0x91;
+
+    /// Creates a new section header entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `platform` - Platform ID for this section
+    /// * `section_entries` - Number of boot entries following this header
+    /// * `is_final` - Whether this is the last section header
+    #[must_use]
+    pub fn new(platform: PlatformId, section_entries: u16, is_final: bool) -> Self {
+        Self {
+            header_indicator: if is_final {
+                Self::FINAL_HEADER
+            } else {
+                Self::MORE_HEADERS
+            },
+            platform_id: platform as u8,
+            section_entries: section_entries.to_le(),
+            id_string: [0; 28],
+        }
+    }
+
+    /// Sets the ID string for this section.
+    pub fn set_id_string(&mut self, id: &str) {
+        let id_bytes = id.as_bytes();
+        let copy_len = id_bytes.len().min(28);
+        self.id_string[..copy_len].copy_from_slice(&id_bytes[..copy_len]);
+    }
+
+    /// Serializes the entry to a byte array.
+    #[must_use]
+    pub fn as_bytes(&self) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = self.header_indicator;
+        bytes[1] = self.platform_id;
+        bytes[2..4].copy_from_slice(&self.section_entries.to_le_bytes());
+        bytes[4..32].copy_from_slice(&self.id_string);
+        bytes
+    }
+}
+
+const _: () = assert!(size_of::<SectionHeaderEntry>() == BOOT_CATALOG_ENTRY_SIZE);
+
+/// Section Entry for additional boot images.
+///
+/// Section entries follow section headers and describe additional boot
+/// images for the specified platform.
+///
+/// Reference: El Torito Specification Section 2.4
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct SectionEntry {
+    /// Boot indicator (0x88 = bootable, 0x00 = not bootable)
+    pub boot_indicator: u8,
+    /// Boot media type
+    pub boot_media_type: u8,
+    /// Load segment (0 = use default 0x7C0)
+    pub load_segment: u16,
+    /// System type (from partition table)
+    pub system_type: u8,
+    /// Unused (0)
+    pub unused1: u8,
+    /// Number of 512-byte virtual sectors to load
+    pub sector_count: u16,
+    /// Logical block address of the boot image
+    pub load_rba: u32,
+    /// Selection criteria type
+    pub selection_criteria_type: u8,
+    /// Vendor-unique selection criteria (19 bytes)
+    pub selection_criteria: [u8; 19],
+}
+
+impl SectionEntry {
+    /// Creates a new section entry for a bootable image.
+    #[must_use]
+    pub fn new(media_type: BootMediaType, load_rba: u32, sector_count: u16) -> Self {
+        Self {
+            boot_indicator: InitialEntry::BOOTABLE,
+            boot_media_type: media_type as u8,
+            load_segment: 0,
+            system_type: 0,
+            unused1: 0,
+            sector_count: sector_count.to_le(),
+            load_rba: load_rba.to_le(),
+            selection_criteria_type: 0,
+            selection_criteria: [0; 19],
+        }
+    }
+
+    /// Creates a no-emulation boot section entry.
+    #[must_use]
+    pub fn no_emulation(load_rba: u32, sector_count: u16) -> Self {
+        Self::new(BootMediaType::NoEmulation, load_rba, sector_count)
+    }
+
+    /// Serializes the entry to a byte array.
+    #[must_use]
+    pub fn as_bytes(&self) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[0] = self.boot_indicator;
+        bytes[1] = self.boot_media_type;
+        bytes[2..4].copy_from_slice(&self.load_segment.to_le_bytes());
+        bytes[4] = self.system_type;
+        bytes[5] = self.unused1;
+        bytes[6..8].copy_from_slice(&self.sector_count.to_le_bytes());
+        bytes[8..12].copy_from_slice(&self.load_rba.to_le_bytes());
+        bytes[12] = self.selection_criteria_type;
+        bytes[13..32].copy_from_slice(&self.selection_criteria);
+        bytes
+    }
+}
+
+const _: () = assert!(size_of::<SectionEntry>() == BOOT_CATALOG_ENTRY_SIZE);
+
+/// Boot Catalog builder.
+///
+/// Builds a complete boot catalog with validation entry, initial/default
+/// entry, and optional section headers and entries for multi-platform boot.
+#[derive(Default)]
+pub struct BootCatalogBuilder {
+    /// Platform for the default boot entry
+    platform: PlatformId,
+    /// ID string for the validation entry
+    id_string: [u8; 24],
+    /// Default boot entry
+    default_entry: Option<InitialEntry>,
+    /// Additional sections for multi-platform boot
+    sections: Vec<(SectionHeaderEntry, Vec<SectionEntry>)>,
+}
+
+impl BootCatalogBuilder {
+    /// Creates a new boot catalog builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the platform ID for the default boot entry.
+    pub fn platform(&mut self, platform: PlatformId) -> &mut Self {
+        self.platform = platform;
+        self
+    }
+
+    /// Sets the ID string for the validation entry.
+    pub fn id_string(&mut self, id: &str) -> &mut Self {
+        let id_bytes = id.as_bytes();
+        let copy_len = id_bytes.len().min(24);
+        self.id_string = [0; 24];
+        self.id_string[..copy_len].copy_from_slice(&id_bytes[..copy_len]);
+        self
+    }
+
+    /// Sets the default boot entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `media_type` - Boot media emulation type
+    /// * `load_rba` - Logical block address of the boot image
+    /// * `sector_count` - Number of 512-byte sectors to load
+    pub fn default_boot_entry(
+        &mut self,
+        media_type: BootMediaType,
+        load_rba: u32,
+        sector_count: u16,
+    ) -> &mut Self {
+        self.default_entry = Some(InitialEntry::new(media_type, load_rba, sector_count));
+        self
+    }
+
+    /// Adds a section for multi-platform boot.
+    ///
+    /// # Arguments
+    ///
+    /// * `platform` - Platform ID for this section
+    /// * `entries` - Boot entries for this platform
+    pub fn add_section(&mut self, platform: PlatformId, entries: Vec<SectionEntry>) -> &mut Self {
+        let header = SectionHeaderEntry::new(platform, entries.len() as u16, false);
+        self.sections.push((header, entries));
+        self
+    }
+
+    /// Returns the total size of the boot catalog in bytes.
+    #[must_use]
+    pub fn size(&self) -> usize {
+        let mut size = BOOT_CATALOG_ENTRY_SIZE * 2; // Validation + Initial entries
+
+        for (_, entries) in &self.sections {
+            size += BOOT_CATALOG_ENTRY_SIZE; // Section header
+            size += entries.len() * BOOT_CATALOG_ENTRY_SIZE; // Section entries
+        }
+
+        size
+    }
+
+    /// Returns the number of sectors required for the boot catalog.
+    #[must_use]
+    pub fn sectors(&self) -> u32 {
+        let size = self.size();
+        ((size + crate::types::SECTOR_SIZE - 1) / crate::types::SECTOR_SIZE) as u32
+    }
+
+    /// Builds the boot catalog.
+    ///
+    /// Returns the catalog as a vector of bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no default boot entry has been set.
+    #[must_use]
+    pub fn build(&mut self) -> Vec<u8> {
+        let default_entry = self
+            .default_entry
+            .take()
+            .expect("default boot entry must be set");
+
+        // Create validation entry
+        let id_str = core::str::from_utf8(&self.id_string)
+            .unwrap_or("")
+            .trim_end_matches('\0');
+        let validation = ValidationEntry::new(self.platform, id_str);
+
+        let mut catalog = Vec::with_capacity(self.size());
+
+        // Write validation entry
+        catalog.extend_from_slice(&validation.as_bytes());
+
+        // Write initial/default entry
+        catalog.extend_from_slice(&default_entry.as_bytes());
+
+        // Write sections
+        let num_sections = self.sections.len();
+        for (i, (mut header, entries)) in self.sections.drain(..).enumerate() {
+            // Mark the last section header
+            if i == num_sections - 1 {
+                header.header_indicator = SectionHeaderEntry::FINAL_HEADER;
+            }
+            catalog.extend_from_slice(&header.as_bytes());
+
+            for entry in entries {
+                catalog.extend_from_slice(&entry.as_bytes());
+            }
+        }
+
+        // Pad to sector boundary
+        let padding = crate::types::SECTOR_SIZE - (catalog.len() % crate::types::SECTOR_SIZE);
+        if padding < crate::types::SECTOR_SIZE {
+            catalog.resize(catalog.len() + padding, 0);
+        }
+
+        catalog
+    }
+}
+
+/// Boot image descriptor.
+///
+/// Represents a boot image to be included in the ISO.
+#[derive(Clone)]
+pub struct BootImage {
+    /// Platform this boot image is for
+    pub platform: PlatformId,
+    /// Boot media emulation type
+    pub media_type: BootMediaType,
+    /// Boot image data
+    pub data: Vec<u8>,
+    /// Load segment (0 = default 0x7C0)
+    pub load_segment: u16,
+}
+
+impl BootImage {
+    /// Creates a new boot image.
+    #[must_use]
+    pub fn new(platform: PlatformId, media_type: BootMediaType, data: Vec<u8>) -> Self {
+        Self {
+            platform,
+            media_type,
+            data,
+            load_segment: 0,
+        }
+    }
+
+    /// Creates a no-emulation boot image for x86 BIOS.
+    #[must_use]
+    pub fn bios_no_emulation(data: Vec<u8>) -> Self {
+        Self::new(PlatformId::X86, BootMediaType::NoEmulation, data)
+    }
+
+    /// Creates a no-emulation boot image for EFI.
+    #[must_use]
+    pub fn efi_no_emulation(data: Vec<u8>) -> Self {
+        Self::new(PlatformId::Efi, BootMediaType::NoEmulation, data)
+    }
+
+    /// Returns the number of 512-byte virtual sectors for this image.
+    #[must_use]
+    pub fn sector_count(&self) -> u16 {
+        let sectors = (self.data.len() + 511) / 512;
+        sectors.min(0xFFFF) as u16
+    }
+
+    /// Returns the number of 2048-byte ISO sectors for this image.
+    #[must_use]
+    pub fn iso_sector_count(&self) -> u32 {
+        ((self.data.len() + crate::types::SECTOR_SIZE - 1) / crate::types::SECTOR_SIZE) as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validation_entry_size() {
+        assert_eq!(size_of::<ValidationEntry>(), BOOT_CATALOG_ENTRY_SIZE);
+    }
+
+    #[test]
+    fn test_initial_entry_size() {
+        assert_eq!(size_of::<InitialEntry>(), BOOT_CATALOG_ENTRY_SIZE);
+    }
+
+    #[test]
+    fn test_section_header_size() {
+        assert_eq!(size_of::<SectionHeaderEntry>(), BOOT_CATALOG_ENTRY_SIZE);
+    }
+
+    #[test]
+    fn test_section_entry_size() {
+        assert_eq!(size_of::<SectionEntry>(), BOOT_CATALOG_ENTRY_SIZE);
+    }
+
+    #[test]
+    fn test_validation_entry_checksum() {
+        let entry = ValidationEntry::new(PlatformId::X86, "TEST");
+        let bytes = entry.as_bytes();
+
+        // Verify checksum - sum of all 16-bit words should be 0
+        let mut sum: u32 = 0;
+        for i in (0..32).step_by(2) {
+            sum += u16::from_le_bytes([bytes[i], bytes[i + 1]]) as u32;
+        }
+        assert_eq!(sum & 0xFFFF, 0, "checksum validation failed");
+    }
+
+    #[test]
+    fn test_validation_entry_key_bytes() {
+        let entry = ValidationEntry::new(PlatformId::X86, "TEST");
+        let bytes = entry.as_bytes();
+        assert_eq!(bytes[30], 0x55);
+        assert_eq!(bytes[31], 0xAA);
+    }
+
+    #[test]
+    fn test_initial_entry() {
+        let entry = InitialEntry::no_emulation(100, 4);
+        let bytes = entry.as_bytes();
+        assert_eq!(bytes[0], 0x88); // bootable
+        assert_eq!(bytes[1], 0x00); // no emulation
+        assert_eq!(u16::from_le_bytes([bytes[6], bytes[7]]), 4); // sector count
+        assert_eq!(
+            u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+            100
+        ); // load_rba
+    }
+
+    #[test]
+    fn test_boot_catalog_builder() {
+        let mut builder = BootCatalogBuilder::new();
+        builder
+            .platform(PlatformId::X86)
+            .id_string("TEST ISO")
+            .default_boot_entry(BootMediaType::NoEmulation, 100, 4);
+
+        let catalog = builder.build();
+        assert!(!catalog.is_empty());
+        assert_eq!(catalog.len() % crate::types::SECTOR_SIZE, 0);
+    }
+
+    #[test]
+    fn test_boot_image() {
+        let data = vec![0u8; 4096]; // 8 virtual sectors
+        let image = BootImage::bios_no_emulation(data);
+        assert_eq!(image.sector_count(), 8);
+        assert_eq!(image.iso_sector_count(), 2);
+    }
+}

--- a/libs/iso9660/src/error.rs
+++ b/libs/iso9660/src/error.rs
@@ -1,0 +1,95 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Error types for ISO 9660 image creation.
+
+use core::fmt;
+
+/// Errors that can occur during ISO 9660 image creation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Error {
+    /// The file identifier exceeds the maximum length (222 bytes for ISO level 1,
+    /// 207 bytes for directory identifiers).
+    IdentifierTooLong {
+        /// The identifier that was too long
+        identifier: &'static str,
+        /// The maximum allowed length
+        max_length: usize,
+    },
+    /// The file identifier contains invalid characters.
+    InvalidIdentifier(&'static str),
+    /// The directory nesting exceeds the maximum depth (8 levels for ISO level 1).
+    DirectoryTooDeep,
+    /// The path table exceeds the maximum size.
+    PathTableTooLarge,
+    /// The volume space exceeds the maximum size (2^32 - 1 sectors).
+    VolumeSpaceTooLarge,
+    /// No boot image was provided for a bootable ISO.
+    NoBootImage,
+    /// The boot image is too large.
+    BootImageTooLarge,
+    /// A required field was not set.
+    MissingField(&'static str),
+    /// The buffer is too small for the operation.
+    BufferTooSmall {
+        /// The required size
+        required: usize,
+        /// The actual size
+        actual: usize,
+    },
+    /// An I/O error occurred during writing.
+    WriteError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::IdentifierTooLong {
+                identifier,
+                max_length,
+            } => {
+                write!(
+                    f,
+                    "identifier '{identifier}' exceeds maximum length of {max_length} bytes"
+                )
+            }
+            Error::InvalidIdentifier(id) => {
+                write!(f, "invalid identifier: {id}")
+            }
+            Error::DirectoryTooDeep => {
+                write!(f, "directory nesting exceeds maximum depth")
+            }
+            Error::PathTableTooLarge => {
+                write!(f, "path table exceeds maximum size")
+            }
+            Error::VolumeSpaceTooLarge => {
+                write!(f, "volume space exceeds maximum size")
+            }
+            Error::NoBootImage => {
+                write!(f, "no boot image provided for bootable ISO")
+            }
+            Error::BootImageTooLarge => {
+                write!(f, "boot image exceeds maximum size")
+            }
+            Error::MissingField(field) => {
+                write!(f, "missing required field: {field}")
+            }
+            Error::BufferTooSmall { required, actual } => {
+                write!(
+                    f,
+                    "buffer too small: required {required} bytes, got {actual}"
+                )
+            }
+            Error::WriteError => {
+                write!(f, "write error")
+            }
+        }
+    }
+}
+
+/// Result type for ISO 9660 operations.
+pub type Result<T> = core::result::Result<T, Error>;

--- a/libs/iso9660/src/lib.rs
+++ b/libs/iso9660/src/lib.rs
@@ -1,0 +1,227 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! ISO 9660 (ECMA-119) filesystem image creation library with El Torito boot support.
+//!
+//! This library provides functionality to create ISO 9660 filesystem images,
+//! commonly used for CD-ROMs, DVDs, and bootable disk images. It supports:
+//!
+//! - **ECMA-119 compliant filesystem structure**: System area, volume descriptors,
+//!   path tables, and directory records following the ISO 9660 standard.
+//!
+//! - **El Torito boot specification**: Create bootable ISO images for BIOS and
+//!   UEFI systems with support for multiple boot images.
+//!
+//! # Quick Start
+//!
+//! ```rust,ignore
+//! use iso9660::{IsoBuilder, BootImage};
+//!
+//! // Create a simple ISO image
+//! let mut builder = IsoBuilder::new("MY_VOLUME");
+//! builder.add_file("README.TXT", b"Hello, World!")?;
+//!
+//! let iso_data = builder.build()?;
+//! ```
+//!
+//! # Creating a Bootable ISO
+//!
+//! ```rust,ignore
+//! use iso9660::{IsoBuilder, BootImage};
+//!
+//! let mut builder = IsoBuilder::new("BOOTABLE");
+//!
+//! // Add your bootloader
+//! let bootloader = std::fs::read("bootloader.bin")?;
+//! builder.set_boot_image(BootImage::bios_no_emulation(bootloader));
+//!
+//! // Optionally add EFI boot support
+//! let efi_bootloader = std::fs::read("efi_boot.efi")?;
+//! builder.add_boot_image(BootImage::efi_no_emulation(efi_bootloader));
+//!
+//! // Add files
+//! builder.add_file("KERNEL.BIN", &kernel_data)?;
+//!
+//! let iso_data = builder.build()?;
+//! ```
+//!
+//! # ISO 9660 Structure
+//!
+//! An ISO 9660 filesystem consists of:
+//!
+//! 1. **System Area** (sectors 0-15): 32KB reserved for system use
+//! 2. **Volume Descriptors** (starting at sector 16):
+//!    - Primary Volume Descriptor (required)
+//!    - Boot Record (for El Torito bootable ISOs)
+//!    - Volume Descriptor Set Terminator (required)
+//! 3. **Path Tables**: Index of directories for fast lookup
+//! 4. **Directory Records**: File and directory metadata
+//! 5. **File Data**: Actual file contents
+//!
+//! # El Torito Boot Support
+//!
+//! El Torito is the standard for bootable CD-ROMs. This library supports:
+//!
+//! - **No Emulation mode**: Direct boot of a loader image (most common)
+//! - **Floppy Emulation**: Emulate a 1.2MB, 1.44MB, or 2.88MB floppy
+//! - **Hard Disk Emulation**: Emulate a hard disk
+//!
+//! The boot catalog supports multiple platforms:
+//! - x86 BIOS (Platform ID 0x00)
+//! - EFI/UEFI (Platform ID 0xEF)
+//! - PowerPC (Platform ID 0x01)
+//! - Mac (Platform ID 0x02)
+//!
+//! # References
+//!
+//! - [ECMA-119](https://www.ecma-international.org/publications-and-standards/standards/ecma-119/):
+//!   Volume and File Structure of CDROM for Information Interchange
+//! - [El Torito Specification](https://pdos.csail.mit.edu/6.828/2014/readings/boot-cdrom.pdf):
+//!   Bootable CD-ROM Format Specification Version 1.0
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+mod builder;
+mod directory;
+mod eltorito;
+mod error;
+mod path_table;
+mod types;
+mod volume;
+
+// Re-export main builder API
+pub use builder::IsoBuilder;
+
+// Re-export El Torito types
+pub use eltorito::{
+    BootCatalogBuilder, BootImage, BootMediaType, InitialEntry, PlatformId, SectionEntry,
+    SectionHeaderEntry, ValidationEntry,
+};
+
+// Re-export error types
+pub use error::{Error, Result};
+
+// Re-export volume descriptor types
+pub use volume::{
+    BootRecordVolumeDescriptor, PrimaryVolumeDescriptor, VolumeDescriptorSetTerminator,
+    VolumeDescriptorType, STANDARD_IDENTIFIER,
+};
+
+// Re-export directory types
+pub use directory::{
+    flags as file_flags, iso9660_name_length, to_iso9660_name, DirectoryRecord,
+    DirectoryRecordBuilder, DIRECTORY_RECORD_MIN_SIZE, MAX_DIRECTORY_IDENTIFIER_LENGTH,
+    MAX_FILE_IDENTIFIER_LENGTH,
+};
+
+// Re-export path table types
+pub use path_table::{PathTableBuilder, PathTableRecord};
+
+// Re-export primitive types
+pub use types::{
+    BothEndian16, BothEndian32, DirectoryDateTime, StrA, VolumeDateTime, SECTOR_SIZE,
+    SYSTEM_AREA_SECTORS, SYSTEM_AREA_SIZE,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+
+    #[test]
+    fn test_create_minimal_iso() {
+        let mut builder = IsoBuilder::new("TEST");
+        let iso = builder.build().unwrap();
+
+        // Minimum ISO size: system area (16 sectors) + PVD + terminator + path tables + root dir
+        assert!(iso.len() >= 20 * SECTOR_SIZE);
+    }
+
+    #[test]
+    fn test_create_iso_with_files() {
+        let mut builder = IsoBuilder::new("FILES");
+        builder.add_file("README.TXT", b"Test content").unwrap();
+        builder.add_file("DATA/INFO.DAT", b"Nested file").unwrap();
+
+        let iso = builder.build().unwrap();
+        assert!(!iso.is_empty());
+    }
+
+    #[test]
+    fn test_create_bootable_iso() {
+        let mut builder = IsoBuilder::new("BOOTABLE");
+
+        // Minimal bootloader (infinite loop)
+        let boot_code = vec![0xEB, 0xFE, 0x00, 0x00];
+        builder.set_boot_image(BootImage::bios_no_emulation(boot_code));
+
+        let iso = builder.build().unwrap();
+
+        // Verify boot record exists at sector 17
+        let br_offset = 17 * SECTOR_SIZE;
+        assert_eq!(iso[br_offset], 0); // Boot record type
+        assert_eq!(&iso[br_offset + 1..br_offset + 6], b"CD001");
+    }
+
+    #[test]
+    fn test_create_multi_boot_iso() {
+        let mut builder = IsoBuilder::new("MULTIBOOT");
+
+        // BIOS boot image
+        let bios_boot = vec![0xEB, 0xFE];
+        builder.set_boot_image(BootImage::bios_no_emulation(bios_boot));
+
+        // EFI boot image
+        let efi_boot = vec![0x00; 512]; // Placeholder EFI image
+        builder.add_boot_image(BootImage::efi_no_emulation(efi_boot));
+
+        let iso = builder.build().unwrap();
+        assert!(!iso.is_empty());
+    }
+
+    #[test]
+    fn test_volume_identifiers() {
+        let mut builder = IsoBuilder::new("VOLID");
+        builder
+            .system_id("LINUX")
+            .publisher_id("PUBLISHER")
+            .application_id("MY_APP");
+
+        let iso = builder.build().unwrap();
+
+        // Check PVD contains our identifiers
+        let pvd_offset = 16 * SECTOR_SIZE;
+
+        // System identifier at offset 8, 32 bytes
+        let sys_id = &iso[pvd_offset + 8..pvd_offset + 40];
+        assert!(sys_id.starts_with(b"LINUX"));
+
+        // Volume identifier at offset 40, 32 bytes
+        let vol_id = &iso[pvd_offset + 40..pvd_offset + 72];
+        assert!(vol_id.starts_with(b"VOLID"));
+    }
+
+    #[test]
+    fn test_both_endian_types() {
+        let val16 = BothEndian16::new(0x1234);
+        assert_eq!(val16.get(), 0x1234);
+
+        let val32 = BothEndian32::new(0x12345678);
+        assert_eq!(val32.get(), 0x12345678);
+    }
+
+    #[test]
+    fn test_datetime_types() {
+        let dir_dt = DirectoryDateTime::new(2025, 6, 15, 12, 30, 45, 0);
+        assert_eq!(dir_dt.year(), 2025);
+
+        let vol_dt = VolumeDateTime::new(2025, 6, 15, 12, 30, 45, 0, 0);
+        assert_eq!(&vol_dt.year, b"2025");
+    }
+}

--- a/libs/iso9660/src/path_table.rs
+++ b/libs/iso9660/src/path_table.rs
@@ -1,0 +1,280 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Path Table structures for ISO 9660 filesystems.
+//!
+//! Path tables provide a fast way to locate directories without traversing
+//! the directory hierarchy. Each entry contains the directory name, its
+//! location, and the index of its parent directory.
+//!
+//! Two path tables are stored: one in little-endian format (Type L) and
+//! one in big-endian format (Type M).
+//!
+//! Reference: ECMA-119 Section 9.4
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+/// Path Table Record.
+///
+/// Each path table record identifies a directory in the hierarchy.
+/// The table is ordered by directory level, then alphabetically.
+///
+/// Reference: ECMA-119 Section 9.4
+#[derive(Debug, Clone)]
+pub struct PathTableRecord {
+    /// Length of the directory identifier
+    pub identifier_length: u8,
+    /// Extended attribute record length
+    pub extended_attribute_length: u8,
+    /// Location of the directory extent
+    pub location: u32,
+    /// Directory number of the parent directory
+    pub parent_directory_number: u16,
+    /// Directory identifier
+    pub identifier: [u8; 31],
+}
+
+impl PathTableRecord {
+    /// Creates a new path table record.
+    #[must_use]
+    pub fn new(identifier: &str, location: u32, parent: u16) -> Self {
+        let mut id_buf = [0u8; 31];
+        let id_bytes = identifier.as_bytes();
+        let id_len = id_bytes.len().min(31);
+        id_buf[..id_len].copy_from_slice(&id_bytes[..id_len]);
+
+        Self {
+            identifier_length: id_len as u8,
+            extended_attribute_length: 0,
+            location,
+            parent_directory_number: parent,
+            identifier: id_buf,
+        }
+    }
+
+    /// Creates a root directory path table record.
+    #[must_use]
+    pub fn root(location: u32) -> Self {
+        Self {
+            identifier_length: 1,
+            extended_attribute_length: 0,
+            location,
+            parent_directory_number: 1,
+            identifier: [0; 31], // Root has identifier of single 0x00 byte
+        }
+    }
+
+    /// Returns the size of this record in bytes.
+    #[must_use]
+    pub fn size(&self) -> usize {
+        // Base size: 1 + 1 + 4 + 2 = 8 bytes
+        // Plus identifier length
+        // Plus padding byte if identifier length is odd
+        let base = 8 + self.identifier_length as usize;
+        if self.identifier_length % 2 == 1 {
+            base + 1
+        } else {
+            base
+        }
+    }
+
+    /// Writes the record in little-endian format (Type L).
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is too small.
+    pub fn write_le(&self, buf: &mut [u8]) -> usize {
+        let size = self.size();
+        assert!(buf.len() >= size, "buffer too small for path table record");
+
+        buf[0] = self.identifier_length;
+        buf[1] = self.extended_attribute_length;
+        buf[2..6].copy_from_slice(&self.location.to_le_bytes());
+        buf[6..8].copy_from_slice(&self.parent_directory_number.to_le_bytes());
+        let id_len = self.identifier_length as usize;
+        buf[8..8 + id_len].copy_from_slice(&self.identifier[..id_len]);
+
+        // Add padding byte if needed
+        if self.identifier_length % 2 == 1 {
+            buf[8 + id_len] = 0;
+        }
+
+        size
+    }
+
+    /// Writes the record in big-endian format (Type M).
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is too small.
+    pub fn write_be(&self, buf: &mut [u8]) -> usize {
+        let size = self.size();
+        assert!(buf.len() >= size, "buffer too small for path table record");
+
+        buf[0] = self.identifier_length;
+        buf[1] = self.extended_attribute_length;
+        buf[2..6].copy_from_slice(&self.location.to_be_bytes());
+        buf[6..8].copy_from_slice(&self.parent_directory_number.to_be_bytes());
+        let id_len = self.identifier_length as usize;
+        buf[8..8 + id_len].copy_from_slice(&self.identifier[..id_len]);
+
+        // Add padding byte if needed
+        if self.identifier_length % 2 == 1 {
+            buf[8 + id_len] = 0;
+        }
+
+        size
+    }
+}
+
+/// Builder for creating path tables.
+///
+/// Path tables must be built in directory level order, with directories
+/// at the same level sorted alphabetically.
+#[derive(Default)]
+pub struct PathTableBuilder {
+    records: Vec<PathTableRecord>,
+}
+
+impl PathTableBuilder {
+    /// Creates a new path table builder.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            records: Vec::new(),
+        }
+    }
+
+    /// Adds a directory to the path table.
+    ///
+    /// Returns the directory number (1-indexed) of the added directory.
+    pub fn add_directory(&mut self, identifier: &str, location: u32, parent: u16) -> u16 {
+        let dir_num = (self.records.len() + 1) as u16;
+        self.records.push(PathTableRecord::new(identifier, location, parent));
+        dir_num
+    }
+
+    /// Adds the root directory to the path table.
+    ///
+    /// This should be called first. Returns the directory number (1).
+    pub fn add_root(&mut self, location: u32) -> u16 {
+        self.records.push(PathTableRecord::root(location));
+        1
+    }
+
+    /// Returns the total size of the path table in bytes.
+    #[must_use]
+    pub fn size(&self) -> usize {
+        self.records.iter().map(PathTableRecord::size).sum()
+    }
+
+    /// Returns the number of records in the path table.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    /// Returns whether the path table is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+
+    /// Writes the path table in little-endian format (Type L).
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is too small.
+    pub fn write_le(&self, buf: &mut [u8]) -> usize {
+        let mut offset = 0;
+        for record in &self.records {
+            offset += record.write_le(&mut buf[offset..]);
+        }
+        offset
+    }
+
+    /// Writes the path table in big-endian format (Type M).
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is too small.
+    pub fn write_be(&self, buf: &mut [u8]) -> usize {
+        let mut offset = 0;
+        for record in &self.records {
+            offset += record.write_be(&mut buf[offset..]);
+        }
+        offset
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_path_table_record_size() {
+        // Root record: 8 + 1 (id) + 1 (padding) = 10
+        let root = PathTableRecord::root(20);
+        assert_eq!(root.size(), 10);
+
+        // "TEST" = 4 chars: 8 + 4 = 12 (even, no padding)
+        let test = PathTableRecord::new("TEST", 25, 1);
+        assert_eq!(test.size(), 12);
+
+        // "ABC" = 3 chars: 8 + 3 + 1 (padding) = 12
+        let abc = PathTableRecord::new("ABC", 30, 1);
+        assert_eq!(abc.size(), 12);
+    }
+
+    #[test]
+    fn test_path_table_builder() {
+        let mut builder = PathTableBuilder::new();
+        let root_num = builder.add_root(20);
+        assert_eq!(root_num, 1);
+
+        let subdir_num = builder.add_directory("SUBDIR", 25, 1);
+        assert_eq!(subdir_num, 2);
+
+        assert_eq!(builder.len(), 2);
+        assert!(builder.size() > 0);
+    }
+
+    #[test]
+    fn test_write_le() {
+        let record = PathTableRecord::root(20);
+        let mut buf = [0u8; 16];
+        let size = record.write_le(&mut buf);
+
+        assert_eq!(size, 10);
+        assert_eq!(buf[0], 1); // identifier length
+        assert_eq!(buf[1], 0); // extended attribute length
+        assert_eq!(&buf[2..6], &20u32.to_le_bytes()); // location
+        assert_eq!(&buf[6..8], &1u16.to_le_bytes()); // parent
+        assert_eq!(buf[8], 0); // root identifier
+    }
+
+    #[test]
+    fn test_write_be() {
+        let record = PathTableRecord::root(20);
+        let mut buf = [0u8; 16];
+        let size = record.write_be(&mut buf);
+
+        assert_eq!(size, 10);
+        assert_eq!(&buf[2..6], &20u32.to_be_bytes()); // location
+        assert_eq!(&buf[6..8], &1u16.to_be_bytes()); // parent
+    }
+}

--- a/libs/iso9660/src/types.rs
+++ b/libs/iso9660/src/types.rs
@@ -1,0 +1,499 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! ECMA-119 primitive types with both-endian encoding.
+//!
+//! The ISO 9660 standard specifies three ways to encode 16 and 32-bit integers:
+//! - Little-endian (LSB first) - Section 7.2.1/7.3.1
+//! - Big-endian (MSB first) - Section 7.2.2/7.3.2
+//! - Both-endian (LSB followed by MSB) - Section 7.2.3/7.3.3
+//!
+//! Path tables use either little-endian or big-endian, while volume descriptors
+//! and directory records use both-endian format.
+
+use core::fmt;
+
+/// Sector size in bytes (2048 bytes = 2 KiB).
+pub const SECTOR_SIZE: usize = 2048;
+
+/// Size of the system area in sectors (16 sectors = 32 KiB).
+pub const SYSTEM_AREA_SECTORS: u32 = 16;
+
+/// Size of the system area in bytes.
+pub const SYSTEM_AREA_SIZE: usize = SYSTEM_AREA_SECTORS as usize * SECTOR_SIZE;
+
+/// A 16-bit integer stored in both-endian format (LSB-MSB).
+///
+/// This type stores both little-endian and big-endian representations
+/// of the same 16-bit value, as required by ECMA-119 Section 7.2.3.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C, packed)]
+pub struct BothEndian16 {
+    /// Little-endian representation
+    le: [u8; 2],
+    /// Big-endian representation
+    be: [u8; 2],
+}
+
+impl BothEndian16 {
+    /// Creates a new both-endian 16-bit integer.
+    #[must_use]
+    pub const fn new(value: u16) -> Self {
+        Self {
+            le: value.to_le_bytes(),
+            be: value.to_be_bytes(),
+        }
+    }
+
+    /// Returns the value as a native integer.
+    #[must_use]
+    pub const fn get(self) -> u16 {
+        u16::from_le_bytes(self.le)
+    }
+
+    /// Returns a reference to the little-endian bytes.
+    #[must_use]
+    pub const fn le_bytes(&self) -> &[u8; 2] {
+        &self.le
+    }
+
+    /// Returns a reference to the big-endian bytes.
+    #[must_use]
+    pub const fn be_bytes(&self) -> &[u8; 2] {
+        &self.be
+    }
+}
+
+impl From<u16> for BothEndian16 {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<BothEndian16> for u16 {
+    fn from(value: BothEndian16) -> Self {
+        value.get()
+    }
+}
+
+impl fmt::Debug for BothEndian16 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BothEndian16({})", self.get())
+    }
+}
+
+/// A 32-bit integer stored in both-endian format (LSB-MSB).
+///
+/// This type stores both little-endian and big-endian representations
+/// of the same 32-bit value, as required by ECMA-119 Section 7.3.3.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C, packed)]
+pub struct BothEndian32 {
+    /// Little-endian representation
+    le: [u8; 4],
+    /// Big-endian representation
+    be: [u8; 4],
+}
+
+impl BothEndian32 {
+    /// Creates a new both-endian 32-bit integer.
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self {
+            le: value.to_le_bytes(),
+            be: value.to_be_bytes(),
+        }
+    }
+
+    /// Returns the value as a native integer.
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        u32::from_le_bytes(self.le)
+    }
+
+    /// Returns a reference to the little-endian bytes.
+    #[must_use]
+    pub const fn le_bytes(&self) -> &[u8; 4] {
+        &self.le
+    }
+
+    /// Returns a reference to the big-endian bytes.
+    #[must_use]
+    pub const fn be_bytes(&self) -> &[u8; 4] {
+        &self.be
+    }
+}
+
+impl From<u32> for BothEndian32 {
+    fn from(value: u32) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<BothEndian32> for u32 {
+    fn from(value: BothEndian32) -> Self {
+        value.get()
+    }
+}
+
+impl fmt::Debug for BothEndian32 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "BothEndian32({})", self.get())
+    }
+}
+
+/// Date and time format used in directory records (7 bytes).
+///
+/// This is the short date/time format defined in ECMA-119 Section 9.1.5.
+/// All values except GMT offset are binary values.
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[repr(C, packed)]
+pub struct DirectoryDateTime {
+    /// Number of years since 1900
+    pub years_since_1900: u8,
+    /// Month of the year (1-12)
+    pub month: u8,
+    /// Day of the month (1-31)
+    pub day: u8,
+    /// Hour of the day (0-23)
+    pub hour: u8,
+    /// Minute of the hour (0-59)
+    pub minute: u8,
+    /// Second of the minute (0-59)
+    pub second: u8,
+    /// Offset from GMT in 15 minute intervals (-48 to +52)
+    pub gmt_offset: i8,
+}
+
+impl DirectoryDateTime {
+    /// Creates a new directory date/time from components.
+    #[must_use]
+    pub const fn new(
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        gmt_offset: i8,
+    ) -> Self {
+        Self {
+            years_since_1900: (year - 1900) as u8,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            gmt_offset,
+        }
+    }
+
+    /// Creates a date/time representing "not specified" (all zeros).
+    #[must_use]
+    pub const fn unspecified() -> Self {
+        Self {
+            years_since_1900: 0,
+            month: 0,
+            day: 0,
+            hour: 0,
+            minute: 0,
+            second: 0,
+            gmt_offset: 0,
+        }
+    }
+
+    /// Returns the year (1900-2155).
+    #[must_use]
+    pub const fn year(&self) -> u16 {
+        self.years_since_1900 as u16 + 1900
+    }
+}
+
+impl fmt::Debug for DirectoryDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:04}-{:02}-{:02} {:02}:{:02}:{:02} GMT{:+}",
+            self.year(),
+            self.month,
+            self.day,
+            self.hour,
+            self.minute,
+            self.second,
+            i16::from(self.gmt_offset) * 15 / 60
+        )
+    }
+}
+
+/// Date and time format used in volume descriptors (17 bytes).
+///
+/// This is the long date/time format defined in ECMA-119 Section 8.4.26.1.
+/// All fields except GMT offset are ASCII digit strings.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(C, packed)]
+pub struct VolumeDateTime {
+    /// Year from 1 to 9999 (4 ASCII digits)
+    pub year: [u8; 4],
+    /// Month from 1 to 12 (2 ASCII digits)
+    pub month: [u8; 2],
+    /// Day from 1 to 31 (2 ASCII digits)
+    pub day: [u8; 2],
+    /// Hour from 0 to 23 (2 ASCII digits)
+    pub hour: [u8; 2],
+    /// Minute from 0 to 59 (2 ASCII digits)
+    pub minute: [u8; 2],
+    /// Second from 0 to 59 (2 ASCII digits)
+    pub second: [u8; 2],
+    /// Hundredths of a second from 0 to 99 (2 ASCII digits)
+    pub centiseconds: [u8; 2],
+    /// Offset from GMT in 15 minute intervals (-48 to +52)
+    pub gmt_offset: i8,
+}
+
+impl VolumeDateTime {
+    /// Creates a new volume date/time from components.
+    #[must_use]
+    pub fn new(
+        year: u16,
+        month: u8,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        second: u8,
+        centiseconds: u8,
+        gmt_offset: i8,
+    ) -> Self {
+        let mut result = Self::unspecified();
+        result.set_year(year);
+        result.set_month(month);
+        result.set_day(day);
+        result.set_hour(hour);
+        result.set_minute(minute);
+        result.set_second(second);
+        result.set_centiseconds(centiseconds);
+        result.gmt_offset = gmt_offset;
+        result
+    }
+
+    /// Creates a date/time representing "not specified".
+    ///
+    /// Per ECMA-119 Section 8.4.26.1, when not specified all string fields
+    /// are ASCII '0' and the GMT offset is binary zero.
+    #[must_use]
+    pub const fn unspecified() -> Self {
+        Self {
+            year: [b'0'; 4],
+            month: [b'0'; 2],
+            day: [b'0'; 2],
+            hour: [b'0'; 2],
+            minute: [b'0'; 2],
+            second: [b'0'; 2],
+            centiseconds: [b'0'; 2],
+            gmt_offset: 0,
+        }
+    }
+
+    /// Sets the year field.
+    pub fn set_year(&mut self, year: u16) {
+        write_decimal_4(&mut self.year, year);
+    }
+
+    /// Sets the month field.
+    pub fn set_month(&mut self, month: u8) {
+        write_decimal_2(&mut self.month, month);
+    }
+
+    /// Sets the day field.
+    pub fn set_day(&mut self, day: u8) {
+        write_decimal_2(&mut self.day, day);
+    }
+
+    /// Sets the hour field.
+    pub fn set_hour(&mut self, hour: u8) {
+        write_decimal_2(&mut self.hour, hour);
+    }
+
+    /// Sets the minute field.
+    pub fn set_minute(&mut self, minute: u8) {
+        write_decimal_2(&mut self.minute, minute);
+    }
+
+    /// Sets the second field.
+    pub fn set_second(&mut self, second: u8) {
+        write_decimal_2(&mut self.second, second);
+    }
+
+    /// Sets the centiseconds field.
+    pub fn set_centiseconds(&mut self, centiseconds: u8) {
+        write_decimal_2(&mut self.centiseconds, centiseconds);
+    }
+}
+
+impl Default for VolumeDateTime {
+    fn default() -> Self {
+        Self::unspecified()
+    }
+}
+
+impl fmt::Debug for VolumeDateTime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}{}{}{}-{}{}-{}{} {}{}:{}{}:{}{}.{}{} GMT{:+}",
+            self.year[0] as char,
+            self.year[1] as char,
+            self.year[2] as char,
+            self.year[3] as char,
+            self.month[0] as char,
+            self.month[1] as char,
+            self.day[0] as char,
+            self.day[1] as char,
+            self.hour[0] as char,
+            self.hour[1] as char,
+            self.minute[0] as char,
+            self.minute[1] as char,
+            self.second[0] as char,
+            self.second[1] as char,
+            self.centiseconds[0] as char,
+            self.centiseconds[1] as char,
+            i16::from(self.gmt_offset) * 15 / 60
+        )
+    }
+}
+
+/// Writes a 2-digit decimal number as ASCII.
+fn write_decimal_2(buf: &mut [u8; 2], value: u8) {
+    buf[0] = b'0' + (value / 10);
+    buf[1] = b'0' + (value % 10);
+}
+
+/// Writes a 4-digit decimal number as ASCII.
+fn write_decimal_4(buf: &mut [u8; 4], value: u16) {
+    buf[0] = b'0' + (value / 1000) as u8;
+    buf[1] = b'0' + ((value / 100) % 10) as u8;
+    buf[2] = b'0' + ((value / 10) % 10) as u8;
+    buf[3] = b'0' + (value % 10) as u8;
+}
+
+/// A fixed-size string buffer padded with spaces.
+///
+/// ISO 9660 uses space-padded strings for identifiers in volume descriptors.
+/// This type provides a convenient way to create such strings.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct StrA<const N: usize> {
+    bytes: [u8; N],
+}
+
+impl<const N: usize> StrA<N> {
+    /// Creates a new string buffer filled with spaces.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self { bytes: [b' '; N] }
+    }
+
+    /// Creates a new string buffer from a string slice.
+    ///
+    /// The string is truncated if longer than N bytes, and padded with spaces
+    /// if shorter.
+    #[must_use]
+    pub fn from_str(s: &str) -> Self {
+        let mut bytes = [b' '; N];
+        let copy_len = s.len().min(N);
+        bytes[..copy_len].copy_from_slice(&s.as_bytes()[..copy_len]);
+        Self { bytes }
+    }
+
+    /// Returns the underlying bytes.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; N] {
+        &self.bytes
+    }
+
+    /// Returns the string content without trailing spaces.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        let trimmed = self
+            .bytes
+            .iter()
+            .rposition(|&b| b != b' ')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        // SAFETY: We only allow ASCII characters which are valid UTF-8
+        unsafe { core::str::from_utf8_unchecked(&self.bytes[..trimmed]) }
+    }
+}
+
+impl<const N: usize> Default for StrA<N> {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl<const N: usize> fmt::Debug for StrA<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "\"{}\"", self.as_str())
+    }
+}
+
+impl<const N: usize> AsRef<[u8]> for StrA<N> {
+    fn as_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_both_endian_16() {
+        let value = BothEndian16::new(0x1234);
+        assert_eq!(value.get(), 0x1234);
+        assert_eq!(value.le_bytes(), &[0x34, 0x12]);
+        assert_eq!(value.be_bytes(), &[0x12, 0x34]);
+    }
+
+    #[test]
+    fn test_both_endian_32() {
+        let value = BothEndian32::new(0x12345678);
+        assert_eq!(value.get(), 0x12345678);
+        assert_eq!(value.le_bytes(), &[0x78, 0x56, 0x34, 0x12]);
+        assert_eq!(value.be_bytes(), &[0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn test_directory_datetime() {
+        let dt = DirectoryDateTime::new(2025, 6, 15, 14, 30, 45, 0);
+        assert_eq!(dt.year(), 2025);
+        assert_eq!(dt.month, 6);
+        assert_eq!(dt.day, 15);
+    }
+
+    #[test]
+    fn test_volume_datetime() {
+        let dt = VolumeDateTime::new(2025, 6, 15, 14, 30, 45, 0, 0);
+        assert_eq!(&dt.year, b"2025");
+        assert_eq!(&dt.month, b"06");
+        assert_eq!(&dt.day, b"15");
+    }
+
+    #[test]
+    fn test_str_a() {
+        let s: StrA<32> = StrA::from_str("TEST");
+        assert_eq!(s.as_str(), "TEST");
+        assert_eq!(&s.as_bytes()[..4], b"TEST");
+        assert_eq!(s.as_bytes()[4], b' ');
+    }
+
+    #[test]
+    fn test_sizes() {
+        assert_eq!(size_of::<BothEndian16>(), 4);
+        assert_eq!(size_of::<BothEndian32>(), 8);
+        assert_eq!(size_of::<DirectoryDateTime>(), 7);
+        assert_eq!(size_of::<VolumeDateTime>(), 17);
+    }
+}

--- a/libs/iso9660/src/volume.rs
+++ b/libs/iso9660/src/volume.rs
@@ -1,0 +1,383 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Volume Descriptor structures for ISO 9660 filesystems.
+//!
+//! Volume descriptors are located starting at sector 16 (after the 32KB system area).
+//! Each descriptor is exactly 2048 bytes (one sector).
+//!
+//! The volume descriptor set must contain:
+//! - At least one Primary Volume Descriptor (type 1)
+//! - A Volume Descriptor Set Terminator (type 255)
+//!
+//! For bootable ISOs using El Torito, a Boot Record (type 0) must also be present.
+
+use crate::directory::DirectoryRecord;
+use crate::types::{BothEndian16, BothEndian32, StrA, VolumeDateTime, SECTOR_SIZE};
+
+/// Standard identifier for ISO 9660 volume descriptors.
+pub const STANDARD_IDENTIFIER: &[u8; 5] = b"CD001";
+
+/// Volume descriptor type codes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum VolumeDescriptorType {
+    /// Boot Record (El Torito)
+    BootRecord = 0,
+    /// Primary Volume Descriptor
+    Primary = 1,
+    /// Supplementary Volume Descriptor (Joliet)
+    Supplementary = 2,
+    /// Volume Partition Descriptor
+    Partition = 3,
+    /// Volume Descriptor Set Terminator
+    Terminator = 255,
+}
+
+/// Primary Volume Descriptor (PVD).
+///
+/// The PVD contains essential information about the ISO 9660 volume including
+/// identifiers, size, and pointers to the root directory and path tables.
+///
+/// Located at sector 16 (byte offset 32768).
+///
+/// Reference: ECMA-119 Section 8.4
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct PrimaryVolumeDescriptor {
+    /// Volume Descriptor Type (1 for Primary)
+    pub type_code: u8,
+    /// Standard Identifier ("CD001")
+    pub standard_identifier: [u8; 5],
+    /// Volume Descriptor Version (1)
+    pub version: u8,
+    /// Unused field (0)
+    pub unused1: u8,
+    /// System Identifier (32 bytes, a-characters)
+    pub system_identifier: StrA<32>,
+    /// Volume Identifier (32 bytes, d-characters)
+    pub volume_identifier: StrA<32>,
+    /// Unused field (zeros)
+    pub unused2: [u8; 8],
+    /// Volume Space Size (number of logical blocks)
+    pub volume_space_size: BothEndian32,
+    /// Unused field (zeros)
+    pub unused3: [u8; 32],
+    /// Volume Set Size (typically 1)
+    pub volume_set_size: BothEndian16,
+    /// Volume Sequence Number (typically 1)
+    pub volume_sequence_number: BothEndian16,
+    /// Logical Block Size (2048)
+    pub logical_block_size: BothEndian16,
+    /// Path Table Size in bytes
+    pub path_table_size: BothEndian32,
+    /// Location of Type L Path Table (little-endian)
+    pub type_l_path_table_location: u32,
+    /// Location of Optional Type L Path Table (0 if not present)
+    pub optional_type_l_path_table_location: u32,
+    /// Location of Type M Path Table (big-endian)
+    pub type_m_path_table_location: u32,
+    /// Location of Optional Type M Path Table (0 if not present)
+    pub optional_type_m_path_table_location: u32,
+    /// Root Directory Record (34 bytes)
+    pub root_directory_record: DirectoryRecord,
+    /// Volume Set Identifier (128 bytes)
+    pub volume_set_identifier: StrA<128>,
+    /// Publisher Identifier (128 bytes)
+    pub publisher_identifier: StrA<128>,
+    /// Data Preparer Identifier (128 bytes)
+    pub data_preparer_identifier: StrA<128>,
+    /// Application Identifier (128 bytes)
+    pub application_identifier: StrA<128>,
+    /// Copyright File Identifier (37 bytes)
+    pub copyright_file_identifier: StrA<37>,
+    /// Abstract File Identifier (37 bytes)
+    pub abstract_file_identifier: StrA<37>,
+    /// Bibliographic File Identifier (37 bytes)
+    pub bibliographic_file_identifier: StrA<37>,
+    /// Volume Creation Date and Time
+    pub volume_creation_date: VolumeDateTime,
+    /// Volume Modification Date and Time
+    pub volume_modification_date: VolumeDateTime,
+    /// Volume Expiration Date and Time
+    pub volume_expiration_date: VolumeDateTime,
+    /// Volume Effective Date and Time
+    pub volume_effective_date: VolumeDateTime,
+    /// File Structure Version (1)
+    pub file_structure_version: u8,
+    /// Reserved (0)
+    pub reserved1: u8,
+    /// Application Use (512 bytes)
+    pub application_use: [u8; 512],
+    /// Reserved (653 bytes)
+    pub reserved2: [u8; 653],
+}
+
+impl PrimaryVolumeDescriptor {
+    /// Creates a new Primary Volume Descriptor with default values.
+    #[must_use]
+    pub fn new() -> Self {
+        let mut pvd = Self {
+            type_code: VolumeDescriptorType::Primary as u8,
+            standard_identifier: *STANDARD_IDENTIFIER,
+            version: 1,
+            unused1: 0,
+            system_identifier: StrA::empty(),
+            volume_identifier: StrA::empty(),
+            unused2: [0; 8],
+            volume_space_size: BothEndian32::new(0),
+            unused3: [0; 32],
+            volume_set_size: BothEndian16::new(1),
+            volume_sequence_number: BothEndian16::new(1),
+            logical_block_size: BothEndian16::new(SECTOR_SIZE as u16),
+            path_table_size: BothEndian32::new(0),
+            type_l_path_table_location: 0,
+            optional_type_l_path_table_location: 0,
+            type_m_path_table_location: 0,
+            optional_type_m_path_table_location: 0,
+            root_directory_record: DirectoryRecord::new_root(),
+            volume_set_identifier: StrA::empty(),
+            publisher_identifier: StrA::empty(),
+            data_preparer_identifier: StrA::empty(),
+            application_identifier: StrA::empty(),
+            copyright_file_identifier: StrA::empty(),
+            abstract_file_identifier: StrA::empty(),
+            bibliographic_file_identifier: StrA::empty(),
+            volume_creation_date: VolumeDateTime::unspecified(),
+            volume_modification_date: VolumeDateTime::unspecified(),
+            volume_expiration_date: VolumeDateTime::unspecified(),
+            volume_effective_date: VolumeDateTime::unspecified(),
+            file_structure_version: 1,
+            reserved1: 0,
+            application_use: [0; 512],
+            reserved2: [0; 653],
+        };
+
+        // Set a default application identifier
+        pvd.application_identifier = StrA::from_str("ISO9660 RUST LIBRARY");
+
+        pvd
+    }
+
+    /// Sets the volume identifier.
+    pub fn set_volume_identifier(&mut self, identifier: &str) {
+        self.volume_identifier = StrA::from_str(identifier);
+    }
+
+    /// Sets the system identifier.
+    pub fn set_system_identifier(&mut self, identifier: &str) {
+        self.system_identifier = StrA::from_str(identifier);
+    }
+
+    /// Sets the publisher identifier.
+    pub fn set_publisher_identifier(&mut self, identifier: &str) {
+        self.publisher_identifier = StrA::from_str(identifier);
+    }
+
+    /// Sets the data preparer identifier.
+    pub fn set_data_preparer_identifier(&mut self, identifier: &str) {
+        self.data_preparer_identifier = StrA::from_str(identifier);
+    }
+
+    /// Sets the application identifier.
+    pub fn set_application_identifier(&mut self, identifier: &str) {
+        self.application_identifier = StrA::from_str(identifier);
+    }
+
+    /// Sets the volume space size in sectors.
+    pub fn set_volume_space_size(&mut self, sectors: u32) {
+        self.volume_space_size = BothEndian32::new(sectors);
+    }
+
+    /// Sets the path table information.
+    pub fn set_path_table(
+        &mut self,
+        size: u32,
+        type_l_location: u32,
+        type_m_location: u32,
+    ) {
+        self.path_table_size = BothEndian32::new(size);
+        self.type_l_path_table_location = type_l_location.to_le();
+        self.type_m_path_table_location = type_m_location.to_be();
+    }
+
+    /// Sets the root directory record location and size.
+    pub fn set_root_directory(&mut self, location: u32, size: u32) {
+        self.root_directory_record.location = BothEndian32::new(location);
+        self.root_directory_record.data_length = BothEndian32::new(size);
+    }
+
+    /// Sets the volume creation date.
+    pub fn set_creation_date(&mut self, date: VolumeDateTime) {
+        self.volume_creation_date = date;
+        self.volume_modification_date = date;
+    }
+
+    /// Serializes the descriptor to a sector-sized buffer.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; SECTOR_SIZE] {
+        // SAFETY: PrimaryVolumeDescriptor is repr(C, packed) and exactly SECTOR_SIZE bytes
+        unsafe { &*(self as *const Self as *const [u8; SECTOR_SIZE]) }
+    }
+}
+
+impl Default for PrimaryVolumeDescriptor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const _: () = assert!(size_of::<PrimaryVolumeDescriptor>() == SECTOR_SIZE);
+
+/// Boot Record Volume Descriptor for El Torito.
+///
+/// The Boot Record contains the identifier "EL TORITO SPECIFICATION" and
+/// a pointer to the Boot Catalog.
+///
+/// Reference: El Torito Specification Section 2.0
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct BootRecordVolumeDescriptor {
+    /// Volume Descriptor Type (0 for Boot Record)
+    pub type_code: u8,
+    /// Standard Identifier ("CD001")
+    pub standard_identifier: [u8; 5],
+    /// Version (1)
+    pub version: u8,
+    /// Boot System Identifier ("EL TORITO SPECIFICATION")
+    pub boot_system_identifier: [u8; 32],
+    /// Unused (zeros)
+    pub unused: [u8; 32],
+    /// Absolute sector number of the Boot Catalog
+    pub boot_catalog_location: u32,
+    /// Reserved (zeros)
+    pub reserved: [u8; 1973],
+}
+
+impl BootRecordVolumeDescriptor {
+    /// El Torito boot system identifier string.
+    pub const BOOT_SYSTEM_ID: &[u8; 23] = b"EL TORITO SPECIFICATION";
+
+    /// Creates a new Boot Record Volume Descriptor.
+    #[must_use]
+    pub fn new(boot_catalog_location: u32) -> Self {
+        let mut boot_system_identifier = [0u8; 32];
+        boot_system_identifier[..23].copy_from_slice(Self::BOOT_SYSTEM_ID);
+
+        Self {
+            type_code: VolumeDescriptorType::BootRecord as u8,
+            standard_identifier: *STANDARD_IDENTIFIER,
+            version: 1,
+            boot_system_identifier,
+            unused: [0; 32],
+            boot_catalog_location: boot_catalog_location.to_le(),
+            reserved: [0; 1973],
+        }
+    }
+
+    /// Returns the boot catalog location.
+    #[must_use]
+    pub fn boot_catalog_location(&self) -> u32 {
+        u32::from_le(self.boot_catalog_location)
+    }
+
+    /// Serializes the descriptor to a sector-sized buffer.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; SECTOR_SIZE] {
+        // SAFETY: BootRecordVolumeDescriptor is repr(C, packed) and exactly SECTOR_SIZE bytes
+        unsafe { &*(self as *const Self as *const [u8; SECTOR_SIZE]) }
+    }
+}
+
+const _: () = assert!(size_of::<BootRecordVolumeDescriptor>() == SECTOR_SIZE);
+
+/// Volume Descriptor Set Terminator.
+///
+/// Marks the end of the volume descriptor set. Must be the last volume descriptor.
+///
+/// Reference: ECMA-119 Section 8.3
+#[derive(Clone, Copy)]
+#[repr(C, packed)]
+pub struct VolumeDescriptorSetTerminator {
+    /// Volume Descriptor Type (255 for Terminator)
+    pub type_code: u8,
+    /// Standard Identifier ("CD001")
+    pub standard_identifier: [u8; 5],
+    /// Version (1)
+    pub version: u8,
+    /// Reserved (zeros)
+    pub reserved: [u8; 2041],
+}
+
+impl VolumeDescriptorSetTerminator {
+    /// Creates a new Volume Descriptor Set Terminator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            type_code: VolumeDescriptorType::Terminator as u8,
+            standard_identifier: *STANDARD_IDENTIFIER,
+            version: 1,
+            reserved: [0; 2041],
+        }
+    }
+
+    /// Serializes the descriptor to a sector-sized buffer.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; SECTOR_SIZE] {
+        // SAFETY: VolumeDescriptorSetTerminator is repr(C, packed) and exactly SECTOR_SIZE bytes
+        unsafe { &*(self as *const Self as *const [u8; SECTOR_SIZE]) }
+    }
+}
+
+impl Default for VolumeDescriptorSetTerminator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+const _: () = assert!(size_of::<VolumeDescriptorSetTerminator>() == SECTOR_SIZE);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_primary_volume_descriptor_size() {
+        assert_eq!(size_of::<PrimaryVolumeDescriptor>(), SECTOR_SIZE);
+    }
+
+    #[test]
+    fn test_boot_record_size() {
+        assert_eq!(size_of::<BootRecordVolumeDescriptor>(), SECTOR_SIZE);
+    }
+
+    #[test]
+    fn test_terminator_size() {
+        assert_eq!(size_of::<VolumeDescriptorSetTerminator>(), SECTOR_SIZE);
+    }
+
+    #[test]
+    fn test_primary_volume_descriptor_fields() {
+        let pvd = PrimaryVolumeDescriptor::new();
+        assert_eq!(pvd.type_code, 1);
+        assert_eq!(&pvd.standard_identifier, b"CD001");
+        assert_eq!(pvd.version, 1);
+        assert_eq!(pvd.logical_block_size.get(), 2048);
+    }
+
+    #[test]
+    fn test_boot_record_fields() {
+        let br = BootRecordVolumeDescriptor::new(20);
+        assert_eq!(br.type_code, 0);
+        assert_eq!(&br.standard_identifier, b"CD001");
+        assert_eq!(br.boot_catalog_location(), 20);
+        assert_eq!(
+            &br.boot_system_identifier[..23],
+            b"EL TORITO SPECIFICATION"
+        );
+    }
+}


### PR DESCRIPTION
Add a new library for creating ECMA-119 (ISO 9660) filesystem images. The library provides a builder API for creating bootable ISO images supporting the El Torito boot specification.

Features:
- Both-endian integer types and date/time formats per ECMA-119
- Volume descriptors (Primary, Boot Record, Terminator)
- Directory records and path table structures
- El Torito boot catalog with validation, initial, and section entries
- Support for multiple boot platforms (BIOS x86, EFI)
- Multiple boot media types (no emulation, floppy, hard disk)
- IsoBuilder API for easy ISO image creation
- 44 unit tests covering all components