### PR TITLE
chore: update Rust nightly version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755615617,
-        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "lastModified": 1765186076,
+        "narHash": "sha256-hM20uyap1a0M9d344I692r+ik4gTMyj60cQWO+hAYP8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "rev": "addf7cf5f383a3101ecfba091b98d0a1263dc9b8",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1756003222,
-        "narHash": "sha256-lmEMhIIbjt8Wp1EYbNqCojuU9ygyDFv8Tu0X1k8qIMc=",
+        "lastModified": 1765507345,
+        "narHash": "sha256-fq34mBLvAgv93EuZjGp7cVV633pxnph9AVuB/Ql5y5Q=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "88ceedecde53e809b4bf8b5fd10d181889d9bac7",
+        "rev": "a9471b23bf656d69ceb2d5ddccdc5082d51fc0e3",
         "type": "github"
       },
       "original": {

--- a/loader/src/main.rs
+++ b/loader/src/main.rs
@@ -7,7 +7,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(maybe_uninit_slice)]
 #![feature(alloc_layout_extra)]
 
 use core::ffi::c_void;

--- a/profile/riscv64/riscv64gc-k23-none-kernel.json
+++ b/profile/riscv64/riscv64gc-k23-none-kernel.json
@@ -19,5 +19,5 @@
     "shadow-call-stack",
     "kernel-address"
   ],
-  "target-pointer-width": "64"
+  "target-pointer-width": 64
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2025-07-11"
+channel = "nightly-2025-12-12"
 components = ["rustfmt", "miri", "clippy", "rust-src", "llvm-tools"]
 targets = ["wasm32-unknown-unknown", "riscv64gc-unknown-none-elf"]
 profile = "minimal"


### PR DESCRIPTION
This change updates the Rust nightly version used by the k23 from `nightly-2025-07-11` to `nightly-2025-12-12` and makes the necessary changes for the project to compile.