### PR TITLE
Add profiling and testing tools to flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,16 @@
 
             # for testing the kernel
             qemu
+
+            # To profile the code or benchmarks
+            samply
+          ] ++ lib.optionals pkgs.stdenv.isLinux [
+            # To profile the code or benchmarks
+            perf
+
+            # For valgrind
+            valgrind
+            cargo-valgrind
           ];
 
           LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";


### PR DESCRIPTION
Added profiling tools 'samply', 'perf', 'valgrind', and 'cargo-valgrind' for testing and performance analysis.