### PR TITLE
wire up kasync benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target
 /buck-out
+/bench-artifacts
 target
 .DS_Store
 .local

--- a/build/bench.bzl
+++ b/build/bench.bzl
@@ -1,5 +1,3 @@
-load("@prelude//test:inject_test_run_info.bzl", "inject_test_run_info")
-
 _DEFAULT_MODIFIERS = [
     "constraints//:opt-level[3]",
     "constraints//:debuginfo[line-tables-only]",
@@ -7,30 +5,34 @@ _DEFAULT_MODIFIERS = [
 ]
 
 def _rust_benchmark_runner_impl(ctx: AnalysisContext) -> list[Provider]:
-    run_info = ctx.attrs.binary[RunInfo]
-    cmd = cmd_args(run_info.args, "--bench")
+    bin_run = ctx.attrs.binary[RunInfo]
 
-    return inject_test_run_info(
-            ctx,
-            ExternalRunnerTestInfo(
-                type = "rust",
-                command = [cmd],
-                # env = ctx.attrs.env | ctx.attrs.run_env,
-                labels = ctx.attrs.labels,
-                # contacts = ctx.attrs.contacts,
-                # default_executor = re_executor,
-                # executor_overrides = executor_overrides,
-                run_from_project_root = True,
-                use_project_relative_paths = True,
-            ),
-        ) + [ctx.attrs.binary[DefaultInfo]]
+    script = cmd_args(
+        "#!/bin/sh",
+        "set -e",
+        'export CRITERION_HOME="$(pwd)/bench-artifacts"',
+        'mkdir -p "$CRITERION_HOME"',
+        cmd_args(bin_run.args, format = 'exec {} --bench "$@"'),
+        delimiter = "\n",
+    )
+
+    wrapper, hidden = ctx.actions.write(
+        "run_bench.sh",
+        script,
+        is_executable = True,
+        allow_args = True,
+        with_inputs = True
+    )
+
+    return [
+        DefaultInfo(default_output = wrapper, other_outputs = hidden),
+        RunInfo(args = cmd_args(wrapper, hidden = hidden)),
+    ]
 
 _rust_benchmark_runner = rule(
     impl = _rust_benchmark_runner_impl,
     attrs = {
         "binary": attrs.dep(providers = [RunInfo]),
-        "labels": attrs.list(attrs.string(), default = []),
-        "_inject_test_env": attrs.default_only(attrs.dep(default = "prelude//test/tools:inject_test_env")),
     },
 )
 
@@ -45,6 +47,5 @@ def rust_benchmark(name, modifiers = [], visibility = None, **kwargs):
     _rust_benchmark_runner(
         name = name,
         binary = ":" + bin_name,
-        labels = ["micro_benchmark"],
         visibility = visibility,
     )

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 set unstable
 
 platform := ""
-_platform_args := if platform != "" { "--target-platforms " + platform } else { "" }
+_platform_args := if platform != "" { f"--target-platforms {{platform}}" } else { "" }
 
 _buck2 := require("buck2")
 _typos := require("typos")
@@ -21,20 +21,20 @@ run target buck2_args="" *qemu_args="":
     {{ _buck2 }} run {{target}} {{buck2_args}} {{qemu_args}}
 
 # quick check for development
-@check targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} build {{append("[check]", targets)}} {{_platform_args}} {{buck2_args}}
+@check targets="" *buck2_args:
+    {{ _buck2 }} build {{append("[check]", _uquery(_q_buildables(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}}
 
 # run all lints and tests on a crate or the entire workspace.
-preflight targets=_all_rust_targets() *buck2_args: (lint targets buck2_args) (unittests targets buck2_args) (miri targets buck2_args) # (loom targets buck2_args)
+preflight targets="" *buck2_args: (lint targets buck2_args) (unittests targets buck2_args) (miri targets buck2_args) # (loom targets buck2_args)
 
 # run linters on a crate or the entire workspace.
-lint targets=_all_rust_targets() *buck2_args: (clippy targets buck2_args) (check-fmt targets buck2_args) (typos)
+lint targets="" *buck2_args: (clippy targets buck2_args) (check-fmt targets buck2_args) (typos)
 
 # ===== linting =====
 
 # run clippy on a crate or the entire workspace.
-@clippy targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} build {{append("[clippy.txt]", targets)}} {{_platform_args}} {{buck2_args}}
+@clippy targets="" *buck2_args:
+    {{ _buck2 }} build {{append("[clippy.txt]", _uquery(_q_buildables(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}}
 
 # check the workspace for typos
 @typos:
@@ -43,46 +43,44 @@ lint targets=_all_rust_targets() *buck2_args: (clippy targets buck2_args) (check
 # ===== testing =====
 
 # run unit tests for a crate or the entire workspace.
-@unittests targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} test {{_unit_tests(targets)}} {{_platform_args}} {{buck2_args}}
+@unittests targets="" *buck2_args:
+    {{ _buck2 }} test {{_uquery(_q_unit_tests(_targets_query(targets)))}} {{_platform_args}} {{buck2_args}}
 
 # run miri tests for a crate or the entire workspace.
-@miri targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} test {{append("[miri]", _unit_tests(targets))}} {{_platform_args}} {{buck2_args}}
+@miri targets="" *buck2_args:
+    {{ _buck2 }} test {{append("[miri]", _uquery(_q_unit_tests(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}}
 
 # run loom tests for a crate or the entire workspace.
-@loom targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} test {{_loom_tests(targets)}} {{_platform_args}} {{buck2_args}}
+@loom targets="" *buck2_args:
+    {{ _buck2 }} test {{_uquery(_q_loom_tests(_targets_query(targets)))}} {{_platform_args}} {{buck2_args}}
 
 # ===== formatting =====
 
 # check formatting for a crate or the entire workspace.
-@check-fmt targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} run 'toolchains//:rust_toolchain[rustfmt]' -- --edition 2024 --check {{ _source_files(targets) }} {{buck2_args}}
+@check-fmt targets="" *buck2_args:
+    {{ _buck2 }} run 'toolchains//:rust_toolchain[rustfmt]' -- --edition 2024 --check {{ _uquery(_q_inputs(_q_buildables(_targets_query(targets)))) }} {{buck2_args}}
 
 # format a crate or the entire workspace.
-@format targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} run 'toolchains//:rust_toolchain[rustfmt]' -- --edition 2024 {{ _source_files(targets) }} {{buck2_args}}
+@format targets="" *buck2_args:
+    {{ _buck2 }} run 'toolchains//:rust_toolchain[rustfmt]' -- --edition 2024 {{ _uquery(_q_inputs(_q_buildables(_targets_query(targets)))) }} {{buck2_args}}
 
 # ===== documentation =====
 
 # build the documentation for a crate or the entire workspace.
-@doc targets=_all_rust_targets() *buck2_args:
-    {{ _buck2 }} build {{append("[doc]", targets)}} --show-output {{_platform_args}} {{buck2_args}}
+@doc targets="" *buck2_args:
+    {{ _buck2 }} build {{append("[doc]", _uquery(_q_buildables(_targets_query(targets))))}} --show-output {{_platform_args}} {{buck2_args}}
 
 manual:
     {{ _buck2 }} run //manual:manual
 
 # ===== benchmarking =====
 
-benchmark targets=_all_rust_targets() *buck2_args:
-    # echo "{{_micro_benchmarks(targets)}}"
-    {{ _buck2 }} run {{_micro_benchmarks(targets)}} {{_platform_args}} {{buck2_args}}
-
-# ===== target set construction helpers =====
-
-_rust_targets_query := "kind(rust_binary, '//...') + kind(rust_library, '//...') except '//third-party/...'"
-_all_rust_targets() := _replace_newlines(shell('buck2 uquery "$1"', _rust_targets_query))
+benchmark targets="" *buck2_args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for t in {{_uquery(_q_benchmarks(_targets_query(targets)))}}; do
+        {{ _buck2 }} run "$t" {{_platform_args}} {{buck2_args}}
+    done
 
 # ===== changed-targets (powered by buck2-change-detector) =====
 #
@@ -119,19 +117,32 @@ changed-targets CHANGES BASE_JSONL UNIVERSE='root//...':
       | tr '\n' ' '
     echo
 
-# turns the buck2 default newline-delimited output into space-delimited
+
+# ===== query helpers =====
+#
+# Recipes accept `targets` as a space-separated list of buck2 target patterns;
+# empty (the default) means the entire workspace. Helpers compose buck2 query
+# expressions as strings, and `_uquery` resolves the final expression in a
+# single `buck2 uquery` call — one shell-out per recipe regardless of how many
+# filters are stacked.
+
+# Default workspace target set: rust binaries, libraries, and benchmark runners (no third-party).
+# _default_query := "(kind(rust_binary, '//...') + kind(rust_library, '//...') + kind(_rust_benchmark_runner, '//...')) except '//third-party/...'"
+_default_query := "'//...' except '//third-party/...'"
+
+# Build a query expression from the recipe's `targets` argument.
+_targets_query(targets) := if targets == "" { _default_query } else { f"set({{targets}})" }
+
+# Refinements: each takes a query expression and returns a more specific one.
+_q_buildables(q) := f"kind(rust_binary, {{q}}) + kind(rust_library, {{q}})"
+_q_tests(q)      := f"kind(rust_test, {{q}}) + kind(rust_test, testsof({{q}}))"
+_q_unit_tests(q) := f"nattrfilter(labels, loom, ({{_q_tests(q)}}))"
+_q_loom_tests(q) := f"attrfilter(labels, loom, ({{_q_tests(q)}}))"
+_q_benchmarks(q) := f"kind(_rust_benchmark_runner, {{q}})"
+_q_inputs(q)     := f"inputs({{q}})"
+
+# Resolve a query expression into a space-separated list of targets.
+_uquery(q) := _replace_newlines(shell('buck2 uquery "$1"', q))
+
+# Turn buck2's newline-delimited output into space-delimited.
 _replace_newlines(str) := replace_regex(str, "(\r\n|\r|\n)", " ")
-
-# obtain all the rust tests from an input set of targets
-_rust_tests(targets) := _replace_newlines(shell('buck2 uquery "kind(rust_test, set($1)) + kind(rust_test, testsof(set($1)))"', targets))
-
-# filter an input set of targets down to only the regular rust unit tests
-_unit_tests(targets) := _replace_newlines(shell('buck2 uquery "nattrfilter(labels, loom, (set($1)))"', _rust_tests(targets)))
-
-# filter an input set of targets down to only the loom tests
-_loom_tests(targets) := _replace_newlines(shell('buck2 uquery "attrfilter(labels, loom, (set($1)))"', _rust_tests(targets)))
-
-# filter an input set of targets down to only the micro-benchmarks
-_micro_benchmarks(targets) := _replace_newlines(shell('buck2 uquery "kind(rust_benchmark, set($1)) + kind(rust_benchmark, testsof(set($1)))"', targets))
-
-_source_files(targets) := _replace_newlines(shell('buck2 uquery "inputs(set($1))"', targets))

--- a/sys/async/BUCK
+++ b/sys/async/BUCK
@@ -1,4 +1,5 @@
 load("@prelude//platforms:defs.bzl", "host_configuration")
+load("//build:bench.bzl", "rust_benchmark")
 
 rust_library(
     name = "kasync",
@@ -25,7 +26,7 @@ rust_library(
         "constraints//:env[kernel]": ["//lib/panic-unwind:panic-unwind"],
         "DEFAULT": [],
     }),
-    tests = [":kasync_tests"],
+    tests = [":kasync_tests", ":kasync_benchmarks"],
     visibility = ["PUBLIC"],
 )
 
@@ -52,6 +53,46 @@ rust_test(
         "//third-party:criterion",
     ],
     features = ["counters"],
+    visibility = ["PUBLIC"],
+    target_compatible_with = [host_configuration.cpu, host_configuration.os],
+)
+
+# Host-only rebuild of kasync with the `__bench` feature enabled, which
+# exposes `kasync::test_util` (used by criterion benches).
+rust_library(
+    name = "kasync_bench",
+    srcs = glob(["src/**/*.rs"]),
+    crate = "kasync",
+    features = ["__bench"],
+    deps = [
+        "//lib/util:util",
+        "//lib/cpu-local:cpu-local",
+        "//lib/spin:spin",
+        "//lib/fastrand:fastrand",
+        "//lib/arrayvec:arrayvec",
+        "//third-party:cordyceps",
+        "//third-party:static_assertions",
+        "//third-party:cfg-if",
+        "//third-party:mycelium-bitfield",
+        "//third-party:tracing",
+        "//third-party:bitflags",
+        "//third-party:pin-project",
+        "//third-party:futures",
+    ],
+    visibility = ["PUBLIC"],
+    target_compatible_with = [host_configuration.cpu, host_configuration.os],
+)
+
+rust_benchmark(
+    name = "kasync_benchmarks",
+    srcs = ["./benches/spawn.rs"],
+    crate_root = "./benches/spawn.rs",
+    deps = [
+        ":kasync_bench",
+        "//lib/fastrand:fastrand",
+        "//third-party:criterion",
+        "//third-party:lazy_static",
+    ],
     visibility = ["PUBLIC"],
     target_compatible_with = [host_configuration.cpu, host_configuration.os],
 )

--- a/sys/async/benches/spawn.rs
+++ b/sys/async/benches/spawn.rs
@@ -2,21 +2,24 @@ use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use fastrand::FastRand;
-use kasync2::executor::{Executor, Worker};
+use kasync::executor::{Executor, Worker};
+use lazy_static::lazy_static;
 
 async fn work() -> usize {
     let val = 1 + 1;
-    kasync2::task::yield_now().await;
+    kasync::task::yield_now().await;
     black_box(val)
 }
 
 fn single_threaded_spawn(c: &mut Criterion) {
-    static EXEC: Executor = Executor::new();
-    let mut worker = Worker::new(&EXEC, FastRand::from_seed(0));
+    lazy_static! {
+        static ref EXEC: Executor = Executor::new().unwrap();
+    }
+    let mut worker = Worker::new(&EXEC, FastRand::from_seed(0)).unwrap();
 
     c.bench_function("single_threaded_spawn", |b| {
         b.iter(|| {
-            kasync2::test_util::block_on(worker.run(async {
+            kasync::test_util::block_on(worker.run(async {
                 let h = EXEC.try_spawn(work()).unwrap();
                 assert_eq!(h.await.unwrap(), 2);
             }))
@@ -25,12 +28,14 @@ fn single_threaded_spawn(c: &mut Criterion) {
 }
 
 fn single_threaded_spawn10(c: &mut Criterion) {
-    static EXEC: Executor = Executor::new();
-    let mut worker = Worker::new(&EXEC, FastRand::from_seed(0));
+    lazy_static! {
+        static ref EXEC: Executor = Executor::new().unwrap();
+    }
+    let mut worker = Worker::new(&EXEC, FastRand::from_seed(0)).unwrap();
 
     c.bench_function("single_threaded_spawn10", |b| {
         b.iter(|| {
-            kasync2::test_util::block_on(worker.run(async {
+            kasync::test_util::block_on(worker.run(async {
                 let mut handles = Vec::with_capacity(10);
                 for _ in 0..10 {
                     let h = EXEC.build_task().try_spawn(work()).unwrap();


### PR DESCRIPTION
This change wires up the `kasync` crate benchmarks which we missed before.