### PR TITLE
fix kernel test filtering

### DIFF
--- a/kernel/src/tests/mod.rs
+++ b/kernel/src/tests/mod.rs
@@ -13,6 +13,7 @@ mod wast;
 
 use alloc::boxed::Box;
 use alloc::sync::Arc;
+use alloc::vec::Vec;
 use core::any::Any;
 use core::ptr::addr_of;
 use core::sync::atomic::{AtomicU64, Ordering};
@@ -24,6 +25,7 @@ use ktest::Test;
 
 use crate::tests::args::Arguments;
 use crate::tests::printer::Printer;
+use crate::util::either::Either;
 use crate::{arch, state};
 
 /// The outcome of performing a single test.
@@ -90,7 +92,16 @@ pub async fn run_tests(global: &'static state::Global) -> Conclusion {
         Arguments::default()
     };
 
-    let tests = all_tests();
+    let tests = if let Some(test_name) = args.test_name {
+        let tests: Vec<_> = all_tests()
+            .iter()
+            .filter(|test| test.info.ident.contains(test_name))
+            .collect();
+
+        Either::Left(tests.into_iter())
+    } else {
+        Either::Right(all_tests().into_iter())
+    };
 
     // Create printer which is used for all output.
     let printer = Printer::new(args.format);
@@ -107,7 +118,7 @@ pub async fn run_tests(global: &'static state::Global) -> Conclusion {
     let printer = Arc::new(printer);
     let conclusion = Arc::new(Conclusion::empty());
 
-    let tests = tests.iter().map(|test| {
+    let tests = tests.map(|test| {
         if args.is_ignored(test) {
             printer.print_test(&test.info);
             conclusion.num_ignored.fetch_add(1, Ordering::Release);

--- a/kernel/src/tests/printer.rs
+++ b/kernel/src/tests/printer.rs
@@ -36,25 +36,23 @@ impl Printer {
     }
 
     pub(crate) fn print_test(&self, info: &TestInfo) {
-        let TestInfo { module, name, .. } = info;
+        let TestInfo { ident, .. } = info;
         match self.format {
             FormatSetting::Pretty => {
-                tracing::info!("test {module}::{name} ... ",);
+                tracing::info!("test {ident} ... ",);
             }
             FormatSetting::Terse => {
                 // In terse mode, nothing is printed before the job. Only
                 // `print_single_outcome` prints one character.
             }
             FormatSetting::Json => {
-                tracing::info!(
-                    r#"{{ "type": "test", "event": "started", "name": "{module}::{name}" }}"#,
-                )
+                tracing::info!(r#"{{ "type": "test", "event": "started", "name": "{ident}" }}"#,)
             }
         }
     }
 
     pub(crate) fn print_single_outcome(&self, info: &TestInfo, outcome: &Outcome) {
-        let TestInfo { module, name, .. } = info;
+        let TestInfo { ident, .. } = info;
         match self.format {
             FormatSetting::Pretty => {
                 self.print_outcome_pretty(outcome);
@@ -70,7 +68,7 @@ impl Printer {
             }
             FormatSetting::Json => {
                 tracing::info!(
-                    r#"{{ "type": "test", "name": "{module}::{name}", "event": "{}" }}"#,
+                    r#"{{ "type": "test", "name": "{ident}", "event": "{}" }}"#,
                     match outcome {
                         Outcome::Passed => "ok",
                         Outcome::Failed(_) => "failed",
@@ -91,7 +89,7 @@ impl Printer {
         }
     }
 
-    pub(crate) fn print_list(&self, tests: &[Test], ignored: bool) {
+    pub(crate) fn print_list<'a>(&self, tests: impl Iterator<Item = &'a Test>, ignored: bool) {
         for test in tests {
             // libtest prints out:
             // * all tests without `--ignored`
@@ -100,7 +98,7 @@ impl Printer {
                 continue;
             }
 
-            tracing::info!("{}::{}: test", test.info.module, test.info.name,);
+            tracing::info!("{}: test", test.info.ident);
         }
     }
 

--- a/kernel/src/util/either.rs
+++ b/kernel/src/util/either.rs
@@ -26,3 +26,16 @@ where
         }
     }
 }
+
+impl<L, R, T> ExactSizeIterator for Either<L, R>
+where
+    L: ExactSizeIterator<Item = T>,
+    R: ExactSizeIterator<Item = T>,
+{
+    fn len(&self) -> usize {
+        match self {
+            Either::Left(l) => l.len(),
+            Either::Right(r) => r.len(),
+        }
+    }
+}

--- a/libs/test/macros/src/lib.rs
+++ b/libs/test/macros/src/lib.rs
@@ -26,8 +26,7 @@ pub fn test(_args: TokenStream, item: TokenStream) -> TokenStream {
             #crate_path::Test {
                 run: || ::alloc::boxed::Box::pin(#ident()),
                 info: #crate_path::TestInfo {
-                    module: module_path!(),
-                    name: stringify!(#ident),
+                    ident: concat!(module_path!(), "::", stringify!(#ident)),
                     ignored: false
                 }
             }

--- a/libs/test/src/lib.rs
+++ b/libs/test/src/lib.rs
@@ -22,7 +22,6 @@ pub struct Test {
 
 /// Metadata associated with a test case
 pub struct TestInfo<'a> {
-    pub module: &'a str,
-    pub name: &'a str,
+    pub ident: &'a str,
     pub ignored: bool,
 }


### PR DESCRIPTION
You could pass a test name pattern to the kernel test runner for the longest time, but it was silently ignored. This change actually filters tests by the given pattern.