### PR TITLE
fix manual publishing

### DIFF
--- a/manual/book.toml
+++ b/manual/book.toml
@@ -1,6 +1,5 @@
 [book]
 authors = ["Jonas Kruckenberg"]
 language = "en"
-multilingual = false
 src = "src"
 title = "k23 Manual"


### PR DESCRIPTION
Removes the depreciated and removed `multilingual` option from the mdbook config.