### PR TITLE
fix(kernel): auto-resize the kernel heap on OOM

### DIFF
--- a/sys/kernel/src/allocator.rs
+++ b/sys/kernel/src/allocator.rs
@@ -5,29 +5,157 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+//! Kernel heap allocator.
+//!
+//! The heap is backed by `talc` and lives inside the higher-half direct map (HHDM): every
+//! claimed span is just a contiguous physical run reinterpreted via `arch::phys_to_virt`. We
+//! therefore never need to touch the kernel [`AddressSpace`](crate::mem::AddressSpace) when
+//! growing the heap, which sidesteps the deadlock between `KERNEL_ALLOCATOR` and
+//! `KERNEL_ASPACE` (mapping into the kernel address space itself allocates from the heap).
+
 use core::alloc::Layout;
 use core::ops::Range;
 
+use arrayvec::ArrayVec;
 use loader_api::BootInfo;
-use mem_core::{AddressRangeExt, VirtualAddress};
-use talc::{ErrOnOom, Span, Talc, Talck};
+use mem_core::{AddressRangeExt, PhysicalAddress, VirtualAddress};
+use talc::{OomHandler, Span, Talc, Talck};
 
 use crate::mem::bootstrap_alloc::BootstrapAllocator;
+use crate::mem::frame_alloc::FrameAllocator;
 use crate::{INITIAL_HEAP_SIZE_PAGES, arch};
 
-#[global_allocator]
-static KERNEL_ALLOCATOR: Talck<spin::RawMutex, ErrOnOom> = Talc::new(ErrOnOom).lock();
+/// Fixed-size growth chunk: 2 MiB on 4 KiB pages.
+const HEAP_GROW_CHUNK_PAGES: usize = 512;
 
+/// Default cap on total heap size when no `--heap-max` bootarg is provided. 1 GiB on 4 KiB pages.
+const HEAP_DEFAULT_MAX_PAGES: usize = 256 * 1024;
+
+/// Hard upper bound on the number of distinct talc heaps we'll ever claim.
+const MAX_HEAP_CHUNKS: usize = 1024;
+
+#[global_allocator]
+static KERNEL_ALLOCATOR: Talck<spin::RawMutex, KernelOomHandler> =
+    Talc::new(KernelOomHandler::new()).lock();
+
+/// Auto-resizing OOM handler for the kernel heap. See module docs.
+pub struct KernelOomHandler {
+    /// Wired up by [`late_init`] once the frame allocator exists. While `None` the handler
+    /// behaves like `ErrOnOom`, which is the correct fallback during early boot.
+    frame_alloc: Option<&'static FrameAllocator>,
+    /// Soft cap on total claimed pages, including the initial heap. `0` means unlimited.
+    /// Soft because the underlying buddy allocator rounds requests up to a power of two, so
+    /// a single grow may overshoot the cap by up to one chunk; subsequent grows are denied.
+    max_total_pages: usize,
+    /// Pages currently claimed (initial heap + every successful grow).
+    total_pages: usize,
+    /// Per-chunk records for diagnostics and the future shrink path.
+    chunks: ArrayVec<HeapChunk, MAX_HEAP_CHUNKS>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct HeapChunk {
+    phys_start: PhysicalAddress,
+    virt_start: VirtualAddress,
+    pages: usize,
+}
+
+impl KernelOomHandler {
+    const fn new() -> Self {
+        Self {
+            frame_alloc: None,
+            max_total_pages: 0,
+            total_pages: 0,
+            chunks: ArrayVec::new(),
+        }
+    }
+}
+
+impl OomHandler for KernelOomHandler {
+    fn handle_oom(talc: &mut Talc<Self>, layout: Layout) -> Result<(), ()> {
+        // TODO(metrics): increment a "kernel_heap.oom.invocations" counter here.
+
+        // Snapshot what we need from the handler up front so we don't have to juggle reborrows
+        // around the call to `talc.claim`.
+        let fa = talc.oom_handler.frame_alloc.ok_or(())?;
+        if talc.oom_handler.chunks.is_full() {
+            // TODO(metrics): increment "kernel_heap.oom.chunk_table_full".
+            return Err(());
+        }
+        let max_total = talc.oom_handler.max_total_pages;
+        let total = talc.oom_handler.total_pages;
+
+        // Round to whole pages with worst-case alignment slack, plus one page for talc's
+        // per-claim metadata. Without that slack, a layout sized within a few words of a page
+        // boundary would loop: the chunk fits raw bytes but not talc-managed bytes, so talc
+        // retries with the same layout until we hit `max_total_pages`.
+        let needed_pages = layout
+            .size()
+            .saturating_add(layout.align() - 1)
+            .div_ceil(arch::PAGE_SIZE)
+            .saturating_add(1);
+        if max_total != 0 && max_total.saturating_sub(total) < needed_pages {
+            // TODO(metrics): increment "kernel_heap.oom.cap_exceeded".
+            return Err(());
+        }
+        let mut want_pages = needed_pages.max(HEAP_GROW_CHUNK_PAGES);
+        // Trim to the remaining cap budget so one grow can't overshoot by up to a chunk.
+        // The cap check above guarantees `max_total > total` here, so the sub is exact.
+        if max_total != 0 {
+            want_pages = want_pages.min(max_total - total);
+        }
+
+        let chunk_bytes = want_pages.checked_mul(arch::PAGE_SIZE).ok_or(())?;
+        let chunk_layout = Layout::from_size_align(chunk_bytes, arch::PAGE_SIZE).map_err(|_| ())?;
+        let frames = fa.alloc_contiguous(chunk_layout).map_err(|_| {
+            // TODO(metrics): increment "kernel_heap.oom.frame_alloc_failed".
+        })?;
+
+        let phys_start = frames.iter().next().unwrap().addr();
+
+        let virt_start = arch::phys_to_virt(phys_start);
+        let span = Span::from_base_size(virt_start.as_mut_ptr(), frames.len() * arch::PAGE_SIZE);
+
+        // Safety: we just exclusively allocated this physical run from the frame allocator and
+        // the HHDM mapping is wired and stable for the rest of the kernel's lifetime.
+        //
+        // `claim` only fails for spans below talc's `MIN_HEAP_SIZE` (~4 words); we always pass
+        // at least one page, so this is unreachable. If it ever does fail the physical run
+        // stays pinned (`alloc_contiguous_pages_global` `mem::forget`s the frames) until a
+        // matching free path exists — see TODO on that function.
+        unsafe { talc.claim(span).map_err(|_| ())? };
+
+        // Capacity was checked before we did anything observable.
+        // Safety: `chunks.is_full()` returned false above and we hold the talc lock, so no
+        // other task can have pushed in between.
+        unsafe {
+            talc.oom_handler.chunks.push_unchecked(HeapChunk {
+                phys_start,
+                virt_start,
+                pages: frames.len(),
+            });
+        }
+        talc.oom_handler.total_pages = total.saturating_add(frames.len());
+
+        // TODO(metrics): increment "kernel_heap.oom.grew" and update a "kernel_heap.total_pages"
+        // gauge.
+
+        Ok(())
+    }
+}
+
+/// Set up the initial heap from the bootstrap allocator.
+///
+/// Runs before `frame_alloc::init`; the OOM handler stays in fallback mode (returning `Err`)
+/// until [`late_init`] wires up the frame allocator.
 pub fn init(boot_alloc: &mut BootstrapAllocator, boot_info: &BootInfo) {
     let layout =
         Layout::from_size_align(INITIAL_HEAP_SIZE_PAGES * arch::PAGE_SIZE, arch::PAGE_SIZE)
             .unwrap();
 
     let phys = boot_alloc.allocate_contiguous(layout).unwrap();
-
     let virt: Range<VirtualAddress> = {
         let start = boot_info.physical_address_offset.add(phys.get());
-
         Range::from_start_len(start, layout.size())
     };
     tracing::debug!("Kernel Heap: {virt:#x?}");
@@ -35,9 +163,50 @@ pub fn init(boot_alloc: &mut BootstrapAllocator, boot_info: &BootInfo) {
     let mut alloc = KERNEL_ALLOCATOR.lock();
     let span = Span::from_base_size(virt.start.as_mut_ptr(), virt.len());
 
-    // Safety: just allocated the memory region
+    // Safety: just allocated the memory region.
     unsafe {
-        let old_heap = alloc.claim(span).unwrap();
-        alloc.extend(old_heap, span);
+        alloc.claim(span).unwrap();
+    }
+
+    // Safety: `chunks` is empty and `MAX_HEAP_CHUNKS >= 1`.
+    unsafe {
+        alloc.oom_handler.chunks.push_unchecked(HeapChunk {
+            phys_start: phys,
+            virt_start: virt.start,
+            pages: INITIAL_HEAP_SIZE_PAGES,
+        });
+    }
+    alloc.oom_handler.total_pages = INITIAL_HEAP_SIZE_PAGES;
+}
+
+/// Wire up the frame allocator and bootargs-driven cap, enabling automatic heap growth.
+///
+/// Must be called after `frame_alloc::init`. `heap_max_bytes` is the value of the `--heap-max`
+/// bootarg in bytes, or `None` to use the default cap.
+pub fn late_init(fa: &'static FrameAllocator, heap_max_bytes: Option<usize>) {
+    let max_total_pages = match heap_max_bytes {
+        Some(bytes) => bytes / arch::PAGE_SIZE,
+        None => HEAP_DEFAULT_MAX_PAGES,
+    };
+
+    {
+        let mut alloc = KERNEL_ALLOCATOR.lock();
+        alloc.oom_handler.frame_alloc = Some(fa);
+        alloc.oom_handler.max_total_pages = max_total_pages;
+    }
+
+    // Trace outside the lock: tracing macros may allocate, and the kernel allocator's spinlock
+    // is non-reentrant.
+    if max_total_pages == 0 {
+        tracing::debug!(
+            "Kernel heap auto-grow enabled: chunk={} pages, cap=unlimited",
+            HEAP_GROW_CHUNK_PAGES,
+        );
+    } else {
+        tracing::debug!(
+            "Kernel heap auto-grow enabled: chunk={} pages, cap={} pages",
+            HEAP_GROW_CHUNK_PAGES,
+            max_total_pages,
+        );
     }
 }

--- a/sys/kernel/src/bootargs.rs
+++ b/sys/kernel/src/bootargs.rs
@@ -30,6 +30,9 @@ pub const LOG: Flag =
 pub const BACKTRACE: Flag =
     Flag::new_string("--backtrace").with_help("backtrace style on panic: `short` or `full`");
 
+pub const HEAP_MAX: Flag =
+    Flag::new_bytes("--heap-max").with_help("hard cap on the kernel heap, e.g. `512M` or `2G`");
+
 pub fn parse(devtree: &DeviceTree) -> crate::Result<Bootargs> {
     let mut bootargs = Bootargs::default();
     let mut tokens = read_raw(devtree)?.split_ascii_whitespace();
@@ -39,6 +42,8 @@ pub fn parse(devtree: &DeviceTree) -> crate::Result<Bootargs> {
             bootargs.log = v.parse().context(LOG.name)?;
         } else if let Some(v) = BACKTRACE.consume(tok, &mut tokens) {
             bootargs.backtrace = v.parse().context(BACKTRACE.name)?;
+        } else if let Some(v) = HEAP_MAX.consume(tok, &mut tokens) {
+            bootargs.heap_max = Some(parse_size(v).context(HEAP_MAX.name)?);
         } else {
             bail!("unexpected input \"{tok}\"");
         }
@@ -62,6 +67,8 @@ pub fn read_raw(devtree: &DeviceTree) -> crate::Result<&str> {
 pub struct Bootargs {
     pub log: Filter,
     pub backtrace: BacktraceStyle,
+    /// Hard cap on the kernel heap, in bytes. `None` means use the built-in default.
+    pub heap_max: Option<usize>,
 }
 
 /// A bootarg flag declaration. Built with the const-builder, e.g.

--- a/sys/kernel/src/main.rs
+++ b/sys/kernel/src/main.rs
@@ -72,12 +72,7 @@ pub const TRAP_STACK_SIZE_PAGES: usize = 64; // TODO find a lower more appropria
 /// doesn't cause startup slowdown & inefficient mapping, but large enough so we can bootstrap
 /// our own virtual memory subsystem. At that point we are no longer reliant on this initial heap
 /// size and can dynamically grow the heap as needed.
-//
-// FIXME: Talc is wired with `ErrOnOom` (see `allocator.rs`), so this size is
-// in fact the *hard cap*, not the initial size. 32 MiB isn't enough for the
-// selftest build — 10 concurrent cranelift compiles in `tests::run_tests`
-// peak well past it. Bumping to 64 MiB keeps tests running for now.
-pub const INITIAL_HEAP_SIZE_PAGES: usize = 4096 * 4; // 64 MiB
+pub const INITIAL_HEAP_SIZE_PAGES: usize = 4096 * 2; // 32 MiB
 
 pub type Result<T> = anyhow::Result<T>;
 
@@ -168,6 +163,11 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
         // at this point we have parsed and processed the flattened device tree, so we pass it to the
         // frame allocator for reuse
         let frame_alloc = frame_alloc::init(boot_alloc, fdt_region_phys);
+
+        // wire the frame allocator into the kernel heap's OOM handler so the heap can grow
+        // automatically. Must come after `frame_alloc::init`; safe to come before `mem::init`
+        // since the OOM handler doesn't touch the kernel address space.
+        allocator::late_init(frame_alloc, bootargs.heap_max);
 
         // initialize the virtual memory subsystem
         mem::init(boot_info, &mut rng, frame_alloc).unwrap();

--- a/sys/kernel/src/mem/frame_alloc/mod.rs
+++ b/sys/kernel/src/mem/frame_alloc/mod.rs
@@ -141,28 +141,30 @@ impl FrameAllocator {
 
     /// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`.
     pub fn alloc_contiguous(&self, layout: Layout) -> Result<List<FrameInfo>, AllocError> {
-        // try to allocate from the per-cpu cache first
-        let mut cpu_local_cache = CPU_LOCAL_CACHE.borrow_mut();
-        let frames = cpu_local_cache
+        // Fast path: try to satisfy from the per-cpu cache. The borrow must be
+        // released before the slow path runs, otherwise the slow path's re-borrow
+        // panics with "RefCell already borrowed" — non-reentrant by design.
+        if let Some(frames) = CPU_LOCAL_CACHE.borrow_mut().allocate_contiguous(layout) {
+            return Ok(frames);
+        }
+
+        tracing::trace!(
+            "CPU-local cache exhausted, refilling {} frames...",
+            layout.size() / arch::PAGE_SIZE
+        );
+        let mut refill = self
+            .global
+            .lock()
             .allocate_contiguous(layout)
-            .or_else(|| {
-                let mut global_alloc = self.global.lock();
-
-                tracing::trace!(
-                    "CPU-local cache exhausted, refilling {} frames...",
-                    layout.size() / arch::PAGE_SIZE
-                );
-                let mut frames = global_alloc.allocate_contiguous(layout)?;
-                CPU_LOCAL_CACHE.borrow_mut().free_list.append(&mut frames);
-
-                tracing::trace!("retrying allocation...");
-                // If this fails then we failed to pull enough frames from the global allocator
-                // which means we're fully out of frames
-                CPU_LOCAL_CACHE.borrow_mut().allocate_contiguous(layout)
-            })
             .ok_or(AllocError)?;
 
-        Ok(frames)
+        let mut cpu_local_cache = CPU_LOCAL_CACHE.borrow_mut();
+        cpu_local_cache.free_list.append(&mut refill);
+
+        tracing::trace!("retrying allocation...");
+        // If this fails then we failed to pull enough frames from the global allocator
+        // which means we're fully out of frames.
+        cpu_local_cache.allocate_contiguous(layout).ok_or(AllocError)
     }
 
     /// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`
@@ -219,55 +221,49 @@ impl CpuLocalFrameCache {
     }
 
     fn allocate_contiguous(&mut self, layout: Layout) -> Option<List<FrameInfo>> {
-        let frames = layout.size() / arch::PAGE_SIZE;
-
-        // short-circuit if the cache doesn't even have enough pages
-        if self.free_list.len() < frames {
+        let frames_needed = layout.size() / arch::PAGE_SIZE;
+        if frames_needed == 0 || self.free_list.len() < frames_needed {
             return None;
         }
+        let start = self.find_contiguous_run(frames_needed, layout.align())?;
 
-        let mut index = 0;
-        let mut base = self.free_list.iter();
-        'outer: while let Some(base_frame) = base.next() {
-            let address_alignment = base_frame.addr().get() & (!base_frame.addr().get() + 1);
+        let mut split = self.free_list.split_off(start);
+        let mut rest = split.split_off(frames_needed);
+        self.free_list.append(&mut rest);
+        Some(split)
+    }
 
-            if address_alignment >= layout.align() {
-                let mut prev_addr = base_frame.addr();
+    /// Locate the index of a window of `frames_needed` cache entries that is
+    /// contiguous in physical memory and starts on an `align`-aligned address.
+    ///
+    /// The cache is in insertion order, not address order, so we walk it once and
+    /// grow a candidate run whenever the next entry sits exactly one page above the
+    /// previous one. `wrapping_sub` is required for the contiguity test:
+    /// `offset_from_unsigned` panics on out-of-order pairs, and historically that
+    /// panic fired under the talc lock and deadlocked the kernel.
+    fn find_contiguous_run(&self, frames_needed: usize, align: usize) -> Option<usize> {
+        let mut start = 0;
+        let mut run = 0;
+        let mut prev: Option<PhysicalAddress> = None;
+        for (i, frame) in self.free_list.iter().enumerate() {
+            let addr = frame.addr();
+            let extends_run =
+                prev.is_some_and(|p| addr.get().wrapping_sub(p.get()) == arch::PAGE_SIZE);
+            prev = Some(addr);
 
-                let mut c = 0;
-                for frame in base.by_ref() {
-                    // we found a contiguous block
-                    if c == frames {
-                        break 'outer;
-                    }
-
-                    if frame.addr().offset_from_unsigned(prev_addr) > arch::PAGE_SIZE {
-                        // frames aren't contiguous, so let's try the next one
-                        tracing::trace!("frames not contiguous, trying next");
-                        continue 'outer;
-                    }
-
-                    c += 1;
-                    prev_addr = frame.addr();
-                }
+            if run > 0 && extends_run {
+                run += 1;
+            } else if addr.is_aligned_to(align) {
+                (start, run) = (i, 1);
+            } else {
+                run = 0;
             }
 
-            tracing::trace!("base frame not aligned, trying next");
-            // the base wasn't aligned, try the next one
-            index += 1;
+            if run == frames_needed {
+                return Some(start);
+            }
         }
-
-        tracing::trace!("found contiguous block at index {index}");
-
-        // split the cache first at the start of the contiguous block. This will return the contiguous block
-        // plus everything after it
-        let mut split = self.free_list.split_off(index);
-        // the split the contiguous block after the number of frames we need
-        // and return the rest back to the cache
-        let mut rest = split.split_off(frames);
-        self.free_list.append(&mut rest);
-
-        Some(split)
+        None
     }
 }
 

--- a/sys/kernel/src/mem/frame_alloc/mod.rs
+++ b/sys/kernel/src/mem/frame_alloc/mod.rs
@@ -164,7 +164,9 @@ impl FrameAllocator {
         tracing::trace!("retrying allocation...");
         // If this fails then we failed to pull enough frames from the global allocator
         // which means we're fully out of frames.
-        cpu_local_cache.allocate_contiguous(layout).ok_or(AllocError)
+        cpu_local_cache
+            .allocate_contiguous(layout)
+            .ok_or(AllocError)
     }
 
     /// Allocate a contiguous runs of [`Frame`] meeting the size and alignment requirements of `layout`


### PR DESCRIPTION
Replace the kernel allocator's `ErrOnOom` policy with a `KernelOomHandler` that grows the heap on demand by claiming a fresh contiguous run of frames from the global frame allocator and reinterpreting it through the HHDM as a new disjoint talc heap. Growth is in fixed 2 MiB chunks; the total cap is configurable via a new `heap_max=` bootarg (default 1 GiB) parsed with a reusable K/M/G suffix helper. `late_init` wires the frame allocator into the OOM handler once the frame allocator is up.

Because talc invokes `handle_oom` with its lock held, the handler must not allocate from the heap.

Living in the HHDM means we never need to acquire `KERNEL_ASPACE` from the OOM path, avoiding the heap↔aspace deadlock entirely. Termination is structural: each `Ok` strictly increases the live heap and the cap is finite. Reclaim hooks and shrink remain as documented follow-ups.

Also drops a dead `extend(old, span)` call in the initial heap setup and threads the new metric TODOs at the points a future metrics pass should hook in.