### PR TITLE
refactor: clean up `block_on` implementations

### DIFF
--- a/lib/riscv/src/sbi/ipi.rs
+++ b/lib/riscv/src/sbi/ipi.rs
@@ -9,6 +9,17 @@
 
 use super::{EID_IPI, sbi_call};
 
+/// Send an IPI to harts selected by `hart_mask`, where bit `k` targets hartid
+/// `hart_mask_base + k`. Pass `hart_mask_base = -1` to broadcast to all harts.
+///
+/// The [SBI spec][spec] states the hart_mask_base is the "starting hartid". In
+/// practice [OpenSBI `sbi_ipi_send_many`][opensbi] and [Linux `__sbi_send_ipi_v02`][linux]
+/// treat this as meaning "the bit position(s) in hart_mask PLUS the hart_mask_base" is the final HART ID.
+///
+/// [spec]: https://github.com/riscv-non-isa/riscv-sbi-doc/blob/master/src/ext-ipi.adoc
+/// [opensbi]: https://github.com/riscv-software-src/opensbi/blob/master/lib/sbi/sbi_ipi.c
+/// [linux]: https://github.com/torvalds/linux/blob/master/arch/riscv/kernel/sbi.c
+///
 /// # Errors
 ///
 /// Returns an error if the SBI call fails.

--- a/sys/async/src/block_on.rs
+++ b/sys/async/src/block_on.rs
@@ -1,0 +1,340 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Driving futures to completion by parking the calling thread.
+//!
+//! [`block_on`] polls a future until it returns `Poll::Ready`, parking the
+//! calling thread between polls when the future is `Pending`. What "park"
+//! actually means is platform-specific — `wfi` on a kernel hart,
+//! `thread::park()` on a host — and is supplied by an impl of the [`Park`]
+//! trait. The platform-agnostic part — coalescing multiple wakes into a
+//! single park-and-resume cycle — lives in [`Notify`].
+
+use core::future::Future;
+use core::mem::ManuallyDrop;
+use core::ptr;
+use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+use futures::pin_mut;
+use futures::task::WakerRef;
+use util::loom_const_fn;
+
+use crate::loom::sync::atomic::{AtomicBool, Ordering};
+
+/// Hooks for blocking and unblocking the current thread.
+///
+/// Implementations must satisfy "park-token" semantics: an `unpark` that
+/// races with or precedes a `park` must still cause that `park` to return.
+/// `std::thread::{park, Thread::unpark}` satisfies this directly; on RISC-V
+/// a pending IPI latches and is taken on the next `wfi`, satisfying the
+/// same property at the hardware level.
+pub trait Park {
+    /// Block the current thread until [`unpark`](Self::unpark) is called, or
+    /// until a previously-issued `unpark` token is consumed. Spurious
+    /// returns are permitted; [`block_on`] re-checks state before re-parking.
+    fn park(&self);
+
+    /// Wake the thread that owns this `Park`, even if it is not currently
+    /// parked. Calls that precede a matching `park` must be remembered.
+    fn unpark(&self);
+}
+
+/// Coalesces wake notifications across polls of [`block_on`].
+///
+/// `Notify` owns the "is a wake pending?" flag and decides when to actually
+/// invoke [`Park::park`] / [`Park::unpark`]. Multiple wakes between two
+/// polls collapse into a single `unpark` and a single resume.
+///
+/// Because the `Waker` produced by a `Notify` may be cloned and outlive a
+/// single [`block_on`] call, callers must hold the `Notify` at `'static`.
+/// This lets the `RawWakerVTable` use no-op clone/drop — a stale wake on a
+/// `'static` `Notify` is a wasted `unpark`, not a use-after-free.
+pub struct Notify<P> {
+    parker: P,
+    unparked: AtomicBool,
+}
+
+impl<P: Park> Notify<P> {
+    loom_const_fn! {
+        pub const fn new(parker: P) -> Self {
+            Self {
+                parker,
+                unparked: AtomicBool::new(false),
+            }
+        }
+    }
+
+    /// Record a wake notification and call [`Park::unpark`] if this is the
+    /// first wake since the last [`drain`](Self::drain). Returns `true` if
+    /// an `unpark` was issued.
+    #[inline]
+    pub fn wake(&self) -> bool {
+        // Release: pairs with the Acquire in `drain`.
+        if !self.unparked.swap(true, Ordering::Release) {
+            self.parker.unpark();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Consume any pending wake. Returns `true` if a wake was pending —
+    /// the caller should re-poll without parking.
+    #[inline]
+    pub fn drain(&self) -> bool {
+        // Acquire: pairs with the Release in `wake`.
+        self.unparked.swap(false, Ordering::Acquire)
+    }
+}
+
+impl<P: Park + Sync + 'static> Notify<P> {
+    const VTABLE: RawWakerVTable = RawWakerVTable::new(
+        Self::clone_raw,
+        Self::wake_raw,
+        Self::wake_by_ref_raw,
+        Self::drop_raw,
+    );
+
+    unsafe fn clone_raw(data: *const ()) -> RawWaker {
+        RawWaker::new(data, &Self::VTABLE)
+    }
+
+    unsafe fn wake_raw(data: *const ()) {
+        // Safety: `data` is the `&'static Notify<P>` handed to
+        // `RawWaker::new` in `waker_ref`, so it is live for any lifetime.
+        let n = unsafe { &*data.cast::<Self>() };
+        n.wake();
+    }
+
+    unsafe fn wake_by_ref_raw(data: *const ()) {
+        // Safety: as above.
+        let n = unsafe { &*data.cast::<Self>() };
+        n.wake();
+    }
+
+    unsafe fn drop_raw(_data: *const ()) {}
+
+    /// Build a [`WakerRef`] pointing at this `Notify`. Cloning the resulting
+    /// `Waker` is allocation-free; dropping is a no-op.
+    pub fn waker_ref(&'static self) -> WakerRef<'static> {
+        // Safety: the `RawWaker`'s data pointer is `&'static Self`, so any
+        // waker clone — including ones that outlive the current `block_on`
+        // frame — points at live memory.
+        let waker = ManuallyDrop::new(unsafe {
+            Waker::from_raw(RawWaker::new(
+                ptr::from_ref(self).cast::<()>(),
+                &Self::VTABLE,
+            ))
+        });
+        WakerRef::new_unowned(waker)
+    }
+}
+
+/// Drive `f` to completion on the current thread, parking via `notify` while
+/// `f` is `Pending`.
+///
+/// Tasks the future spawns on a runtime are **not** polled by this
+/// function — it only polls `f` itself. Drive a worker future
+/// (e.g. `Worker::run`) to also poll spawned tasks.
+///
+/// Caller must not nest `block_on` calls on the same `notify`: the inner
+/// `drain()` would swallow the outer's pending wake.
+pub fn block_on<P: Park + Sync + 'static, F: Future>(
+    notify: &'static Notify<P>,
+    f: F,
+) -> F::Output {
+    pin_mut!(f);
+    let waker = notify.waker_ref();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        if let Poll::Ready(t) = f.as_mut().poll(&mut cx) {
+            return t;
+        }
+        while !notify.drain() {
+            notify.parker.park();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::pin::Pin;
+    use core::task::{Context, Poll, Waker};
+
+    use futures::future;
+
+    use super::*;
+    use crate::loom;
+    use crate::loom::sync::atomic::AtomicUsize;
+    use crate::loom::sync::{Arc, Mutex};
+    use crate::loom::thread;
+    use crate::test_util::StdPark;
+
+    /// Wake-from-the-same-thread happy path: `block_on` returns without ever
+    /// parking when the future is immediately `Ready`.
+    #[test]
+    fn ready_returns_immediately() {
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref NOTIFY: Notify<StdPark> = Notify::new(StdPark::current());
+            }
+            assert_eq!(block_on(&NOTIFY, async { 42_u32 }), 42);
+        });
+    }
+
+    /// Two threads race to wake the same `Notify`. The flag must serialize
+    /// them: exactly one `wake()` returns `true` (i.e. exactly one `unpark`
+    /// would be issued), regardless of interleaving.
+    ///
+    /// This is the core invariant the kernel refactor relies on — without
+    /// it, a wake could be silently dropped and a parked hart would never
+    /// resume.
+    ///
+    /// Uses `NoopPark` to isolate the flag mechanic from any thread parking
+    /// state — loom's `Thread::unpark` bookkeeping isn't what we're testing.
+    #[test]
+    fn concurrent_wakes_coalesce() {
+        struct NoopPark;
+        impl Park for NoopPark {
+            fn park(&self) {}
+            fn unpark(&self) {}
+        }
+
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref NOTIFY: Notify<NoopPark> = Notify::new(NoopPark);
+            }
+
+            let unparks = Arc::new(AtomicUsize::new(0));
+            let u_a = unparks.clone();
+            let u_b = unparks.clone();
+
+            let t_a = thread::spawn(move || {
+                if NOTIFY.wake() {
+                    u_a.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+            let t_b = thread::spawn(move || {
+                if NOTIFY.wake() {
+                    u_b.fetch_add(1, Ordering::SeqCst);
+                }
+            });
+
+            t_a.join().unwrap();
+            t_b.join().unwrap();
+
+            assert_eq!(unparks.load(Ordering::SeqCst), 1);
+            assert!(NOTIFY.drain(), "flag should be set after at least one wake");
+            assert!(!NOTIFY.drain(), "flag should be cleared after drain");
+        });
+    }
+
+    /// Future returns `Pending` on first poll (stashing the waker), then
+    /// `Ready` on subsequent polls. A second thread fires the stashed waker.
+    /// `block_on` must observe the wake whether it arrives before the park,
+    /// during the park, or after the next poll has already started.
+    ///
+    /// Loom explores all those interleavings.
+    #[test]
+    fn cross_thread_wake_unblocks() {
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref NOTIFY: Notify<StdPark> = Notify::new(StdPark::current());
+            }
+            let waker_slot: Arc<Mutex<Option<Waker>>> = Arc::new(Mutex::new(None));
+            let slot_for_waker = waker_slot.clone();
+
+            let waker_thread = thread::spawn(move || {
+                // Spin until the future has registered the waker.
+                loop {
+                    if let Some(w) = slot_for_waker.lock().unwrap().take() {
+                        w.wake();
+                        return;
+                    }
+                    thread::yield_now();
+                }
+            });
+
+            let slot_for_future = waker_slot;
+            let polls = Arc::new(AtomicUsize::new(0));
+            let polls_for_future = polls.clone();
+            let fut = future::poll_fn(move |cx: &mut Context<'_>| {
+                let n = polls_for_future.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    *slot_for_future.lock().unwrap() = Some(cx.waker().clone());
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            });
+
+            block_on(&NOTIFY, fut);
+            waker_thread.join().unwrap();
+        });
+    }
+
+    /// A future that wakes itself from inside `poll` and returns `Pending`
+    /// must not park: the wake set the flag, so `drain` returns true on the
+    /// next loop iteration and the future is re-polled immediately.
+    ///
+    /// This is the simplest concrete case of the wake-before-park race —
+    /// single-threaded, so any regression in the `poll` -> `drain` -> `park`
+    /// ordering shows up as a hung test.
+    #[test]
+    fn self_wake_does_not_park() {
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref NOTIFY: Notify<StdPark> = Notify::new(StdPark::current());
+            }
+
+            let polls = Arc::new(AtomicUsize::new(0));
+            let polls_for_future = polls.clone();
+            block_on(
+                &NOTIFY,
+                future::poll_fn(move |cx: &mut Context<'_>| {
+                    if polls_for_future.fetch_add(1, Ordering::SeqCst) == 0 {
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    } else {
+                        Poll::Ready::<()>(())
+                    }
+                }),
+            );
+            assert_eq!(polls.load(Ordering::SeqCst), 2);
+        });
+    }
+
+    /// Soundness: the `Waker` may be cloned and used after `block_on`
+    /// returns. With the no-op vtable backing a `&'static Notify`, this
+    /// must not be a use-after-free — the wake just lands as a wasted
+    /// unpark on the still-live `Notify`.
+    #[test]
+    fn waker_outlives_block_on() {
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref NOTIFY: Notify<StdPark> = Notify::new(StdPark::current());
+            }
+            let stashed: Arc<Mutex<Option<Waker>>> = Arc::new(Mutex::new(None));
+            let stashed_c = stashed.clone();
+
+            block_on(
+                &NOTIFY,
+                future::poll_fn(move |cx: &mut Context<'_>| {
+                    *stashed_c.lock().unwrap() = Some(cx.waker().clone());
+                    Poll::Ready::<()>(())
+                }),
+            );
+
+            let waker = stashed.lock().unwrap().take().expect("waker stashed");
+            // Must not UAF; the parker is still live.
+            waker.wake();
+            // Hygiene: drain the wasted-unpark token so it doesn't leak
+            // into another iteration's loom state.
+            assert!(NOTIFY.drain());
+        });
+    }
+}

--- a/sys/async/src/block_on.rs
+++ b/sys/async/src/block_on.rs
@@ -33,14 +33,16 @@ use crate::loom::sync::atomic::{AtomicBool, Ordering};
 /// a pending IPI latches and is taken on the next `wfi`, satisfying the
 /// same property at the hardware level.
 pub trait Park {
+    type Error: core::fmt::Display;
+
     /// Block the current thread until [`unpark`](Self::unpark) is called, or
     /// until a previously-issued `unpark` token is consumed. Spurious
     /// returns are permitted; [`block_on`] re-checks state before re-parking.
-    fn park(&self);
+    fn park(&self) -> Result<(), Self::Error>;
 
     /// Wake the thread that owns this `Park`, even if it is not currently
     /// parked. Calls that precede a matching `park` must be remembered.
-    fn unpark(&self);
+    fn unpark(&self) -> Result<(), Self::Error>;
 }
 
 /// Coalesces wake notifications across polls of [`block_on`].
@@ -75,8 +77,10 @@ impl<P: Park> Notify<P> {
     pub fn wake(&self) -> bool {
         // Release: pairs with the Acquire in `drain`.
         if !self.unparked.swap(true, Ordering::Release) {
-            self.parker.unpark();
-            true
+            self.parker
+                .unpark()
+                .inspect_err(|err| tracing::error!("failed to unpark thread. {err}"))
+                .is_ok()
         } else {
             false
         }
@@ -100,23 +104,29 @@ impl<P: Park + Sync + 'static> Notify<P> {
     );
 
     unsafe fn clone_raw(data: *const ()) -> RawWaker {
+        // NB: `data` the `&'static Notify<P>`, so
+        // no refcounting (like other waker impls) required.
         RawWaker::new(data, &Self::VTABLE)
     }
 
     unsafe fn wake_raw(data: *const ()) {
         // Safety: `data` is the `&'static Notify<P>` handed to
-        // `RawWaker::new` in `waker_ref`, so it is live for any lifetime.
+        // `RawWaker::new` in `waker_ref`.
         let n = unsafe { &*data.cast::<Self>() };
         n.wake();
     }
 
     unsafe fn wake_by_ref_raw(data: *const ()) {
-        // Safety: as above.
+        // Safety: `data` is the `&'static Notify<P>` handed to
+        // `RawWaker::new` in `waker_ref`.
         let n = unsafe { &*data.cast::<Self>() };
         n.wake();
     }
 
-    unsafe fn drop_raw(_data: *const ()) {}
+    unsafe fn drop_raw(_data: *const ()) {
+        // NB: `data` the `&'static Notify<P>`, so nothing to do here.
+        // This mirrors the `Self::clone_raw` impl.
+    }
 
     /// Build a [`WakerRef`] pointing at this `Notify`. Cloning the resulting
     /// `Waker` is allocation-free; dropping is a no-op.
@@ -143,19 +153,21 @@ impl<P: Park + Sync + 'static> Notify<P> {
 ///
 /// Caller must not nest `block_on` calls on the same `notify`: the inner
 /// `drain()` would swallow the outer's pending wake.
+// NB: we require the static lifetime here so we can safely turn this into a ptr in `waker_ref`.
+// instead of forcing callers into an `Arc` allocation they can now simply use `cpu_local!`
 pub fn block_on<P: Park + Sync + 'static, F: Future>(
     notify: &'static Notify<P>,
     f: F,
-) -> F::Output {
+) -> Result<F::Output, P::Error> {
     pin_mut!(f);
     let waker = notify.waker_ref();
     let mut cx = Context::from_waker(&waker);
     loop {
         if let Poll::Ready(t) = f.as_mut().poll(&mut cx) {
-            return t;
+            return Ok(t);
         }
         while !notify.drain() {
-            notify.parker.park();
+            notify.parker.park()?;
         }
     }
 }
@@ -164,6 +176,7 @@ pub fn block_on<P: Park + Sync + 'static, F: Future>(
 mod tests {
     use core::pin::Pin;
     use core::task::{Context, Poll, Waker};
+    use std::convert::Infallible;
 
     use futures::future;
 
@@ -182,7 +195,7 @@ mod tests {
             loom::lazy_static! {
                 static ref NOTIFY: Notify<StdPark> = Notify::new(StdPark::current());
             }
-            assert_eq!(block_on(&NOTIFY, async { 42_u32 }), 42);
+            assert_eq!(block_on(&NOTIFY, async { 42_u32 }).unwrap(), 42);
         });
     }
 
@@ -200,8 +213,13 @@ mod tests {
     fn concurrent_wakes_coalesce() {
         struct NoopPark;
         impl Park for NoopPark {
-            fn park(&self) {}
-            fn unpark(&self) {}
+            type Error = Infallible;
+            fn park(&self) -> Result<(), Self::Error> {
+                Ok(())
+            }
+            fn unpark(&self) -> Result<(), Self::Error> {
+                Ok(())
+            }
         }
 
         loom::model(|| {

--- a/sys/async/src/lib.rs
+++ b/sys/async/src/lib.rs
@@ -15,6 +15,7 @@
 #![feature(allocator_api)]
 extern crate alloc;
 
+pub mod block_on;
 mod error;
 pub mod executor;
 pub mod loom;

--- a/sys/async/src/test_util.rs
+++ b/sys/async/src/test_util.rs
@@ -6,6 +6,7 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::boxed::Box;
+use std::convert::Infallible;
 
 use crate::block_on::{Notify, Park};
 use crate::loom::thread::{self, Thread};
@@ -29,12 +30,16 @@ impl StdPark {
 }
 
 impl Park for StdPark {
-    fn park(&self) {
+    type Error = Infallible;
+
+    fn park(&self) -> Result<(), Self::Error> {
         thread::park();
+        Ok(())
     }
 
-    fn unpark(&self) {
+    fn unpark(&self) -> Result<(), Self::Error> {
         self.thread.unpark();
+        Ok(())
     }
 }
 
@@ -47,5 +52,5 @@ crate::loom::thread_local! {
 }
 
 pub fn block_on<F: Future>(f: F) -> F::Output {
-    NOTIFY.with(|notify| crate::block_on::block_on(*notify, f))
+    NOTIFY.with(|notify| crate::block_on::block_on(*notify, f).unwrap())
 }

--- a/sys/async/src/test_util.rs
+++ b/sys/async/src/test_util.rs
@@ -5,94 +5,47 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use core::mem::ManuallyDrop;
-use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+use alloc::boxed::Box;
 
-use futures::pin_mut;
-use futures::task::WakerRef;
-use util::loom_const_fn;
+use crate::block_on::{Notify, Park};
+use crate::loom::thread::{self, Thread};
 
-use crate::loom::sync::{Arc, Condvar, Mutex as StdMutex};
-
-#[derive(Debug)]
-pub struct ThreadNotify {
-    mutex: StdMutex<bool>,
-    condvar: Condvar,
+/// `Park` implementation backed by `std::thread::{park, Thread::unpark}`
+/// (or the loom equivalent).
+///
+/// `unpark` is a token: a call before a matching `park` causes the next
+/// `park` on the captured thread to return immediately, which is what
+/// [`Notify`] requires.
+pub struct StdPark {
+    thread: Thread,
 }
 
-impl ThreadNotify {
-    loom_const_fn! {
-        const fn new() -> Self {
-            Self {
-                mutex: StdMutex::new(false),
-                condvar: Condvar::new()
-            }
+impl StdPark {
+    pub fn current() -> Self {
+        Self {
+            thread: thread::current(),
         }
-    }
-
-    #[tracing::instrument(level = "trace", skip(self))]
-    fn wait(&self) {
-        let mut notified = self.mutex.lock().unwrap();
-        while !*notified {
-            notified = self.condvar.wait(notified).unwrap();
-        }
-        *notified = false;
-    }
-
-    fn notify(&self) {
-        let mut signaled = self.mutex.lock().unwrap();
-        *signaled = true;
-        self.condvar.notify_one();
     }
 }
 
-fn waker_ref(wake: &Arc<ThreadNotify>) -> WakerRef<'_> {
-    static WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_arc_raw,
-        wake_arc_raw,
-        wake_by_ref_arc_raw,
-        drop_arc_raw,
-    );
-
-    unsafe fn clone_arc_raw(data: *const ()) -> RawWaker {
-        unsafe { Arc::increment_strong_count(data.cast::<ThreadNotify>()) }
-        RawWaker::new(data, &WAKER_VTABLE)
+impl Park for StdPark {
+    fn park(&self) {
+        thread::park();
     }
 
-    unsafe fn wake_arc_raw(data: *const ()) {
-        let arc = unsafe { Arc::from_raw(data.cast::<ThreadNotify>()) };
-        ThreadNotify::notify(&arc);
+    fn unpark(&self) {
+        self.thread.unpark();
     }
+}
 
-    // used by `waker_ref`
-    unsafe fn wake_by_ref_arc_raw(data: *const ()) {
-        // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
-        let arc = ManuallyDrop::new(unsafe { Arc::from_raw(data.cast::<ThreadNotify>()) });
-        ThreadNotify::notify(&arc);
-    }
-
-    unsafe fn drop_arc_raw(data: *const ()) {
-        drop(unsafe { Arc::from_raw(data.cast::<ThreadNotify>()) })
-    }
-
-    // simply copy the pointer instead of using Arc::into_raw,
-    // as we don't actually keep a refcount by using ManuallyDrop.<
-    let ptr = Arc::as_ptr(wake).cast::<()>();
-
-    let waker = ManuallyDrop::new(unsafe { Waker::from_raw(RawWaker::new(ptr, &WAKER_VTABLE)) });
-    WakerRef::new_unowned(waker)
+crate::loom::thread_local! {
+    /// Per-thread `Notify<StdPark>`. Lazily allocated on first use so that
+    /// `StdPark::current()` captures the calling thread, and leaked so the
+    /// `&'static Notify` requirement of `block_on` is satisfied.
+    static NOTIFY: &'static Notify<StdPark> =
+        Box::leak(Box::new(Notify::new(StdPark::current())));
 }
 
 pub fn block_on<F: Future>(f: F) -> F::Output {
-    pin_mut!(f);
-
-    let thread_notify = Arc::new(ThreadNotify::new());
-    let waker = waker_ref(&thread_notify);
-    let mut cx = Context::from_waker(&waker);
-    loop {
-        if let Poll::Ready(t) = f.as_mut().poll(&mut cx) {
-            return t;
-        }
-        thread_notify.wait();
-    }
+    NOTIFY.with(|notify| crate::block_on::block_on(*notify, f))
 }

--- a/sys/kernel/src/arch/riscv64/block_on.rs
+++ b/sys/kernel/src/arch/riscv64/block_on.rs
@@ -5,124 +5,53 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use alloc::sync::Arc;
 use core::arch::asm;
-use core::mem::ManuallyDrop;
-use core::sync::atomic::{AtomicBool, Ordering};
-use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
+use anyhow::ensure;
 use cpu_local::cpu_local;
-use futures::pin_mut;
-use futures::task::WakerRef;
+use kasync::block_on::Notify;
 use riscv::sbi;
 
 use crate::state;
 
-struct HartNotify {
-    hartid: usize,
-    unparked: AtomicBool,
+cpu_local! {
+    static NOTIFY: Notify<RiscvPark> = Notify::new(RiscvPark {
+        cpuid: state::cpu_local().id
+    });
 }
 
-impl HartNotify {
-    fn wake_by_ref(me: &Arc<Self>) {
-        tracing::trace!("waking up hart {}...", me.hartid);
-
-        // Make sure the wakeup is remembered until the next `park()`.
-        let unparked = me.unparked.swap(true, Ordering::Release);
-        if !unparked {
-            // If the thread has not been unparked yet, it must be done
-            // now. If it was actually parked, it will run again,
-            // otherwise the token made available by `unpark`
-            // may be consumed before reaching `park()`, but `unparked`
-            // ensures it is not forgotten.
-            sbi::ipi::send_ipi(1 << me.hartid, 0).unwrap();
-        }
-    }
+pub fn block_on<F: Future>(f: F) -> crate::Result<F::Output> {
+    kasync::block_on::block_on(&*NOTIFY, f)
 }
 
-fn waker_ref(wake: &Arc<HartNotify>) -> WakerRef<'_> {
-    static WAKER_VTABLE: RawWakerVTable = RawWakerVTable::new(
-        clone_arc_raw,
-        wake_arc_raw,
-        wake_by_ref_arc_raw,
-        drop_arc_raw,
-    );
-
-    unsafe fn clone_arc_raw(data: *const ()) -> RawWaker {
-        // Safety: ensured by caller
-        unsafe { Arc::increment_strong_count(data.cast::<HartNotify>()) }
-        RawWaker::new(data, &WAKER_VTABLE)
-    }
-
-    unsafe fn wake_arc_raw(data: *const ()) {
-        // Safety: the `data` pointer is created through `Arc::as_ptr` below.
-        let arc = unsafe { Arc::from_raw(data.cast::<HartNotify>()) };
-        HartNotify::wake_by_ref(&arc);
-    }
-
-    unsafe fn wake_by_ref_arc_raw(data: *const ()) {
-        // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
-        // Safety: the `data` pointer is created through `Arc::as_ptr` below.
-        let arc = ManuallyDrop::new(unsafe { Arc::from_raw(data.cast::<HartNotify>()) });
-        HartNotify::wake_by_ref(&arc);
-    }
-
-    unsafe fn drop_arc_raw(data: *const ()) {
-        // Safety: the `data` pointer is created through `Arc::as_ptr` below.
-        drop(unsafe { Arc::from_raw(data.cast::<HartNotify>()) });
-    }
-
-    // simply copy the pointer instead of using Arc::into_raw,
-    // as we don't actually keep a refcount by using ManuallyDrop.<
-    let ptr = Arc::as_ptr(wake).cast::<()>();
-
-    // Safety: TODO
-    let waker = ManuallyDrop::new(unsafe { Waker::from_raw(RawWaker::new(ptr, &WAKER_VTABLE)) });
-    WakerRef::new_unowned(waker)
+struct RiscvPark {
+    cpuid: usize,
 }
 
-/// Blocks the calling hart until the give future completes and yielding its
-/// resolved result.
-///
-/// Any tasks or timers which the future spawns internally, will **not** be executed unless there
-/// are running executor workers available. This makes this function mostly suitable to drive
-/// the top-level main loop future returned by `Worker::run`, since that will take care of
-/// driving the tasks and timers to completion.
-///
-/// When the given future cannot make progress and returned `Poll::Pending`, the calling hart
-/// will automatically be put into a low-power suspend state to conserve energy by using the builtin
-/// "wait for interrupt" (`wfi`) instruction until woken by the [`Waker`]. When using this function
-/// to drive the worker loop the `Waker` should be called for event that might result in tasks becoming
-/// unblocked such as interrupts and "wakeup calls" from other harts.
-pub fn block_on<F: Future>(f: F) -> F::Output {
-    pin_mut!(f);
+impl kasync::block_on::Park for RiscvPark {
+    type Error = anyhow::Error;
 
-    cpu_local! {
-        static CURRENT_THREAD_NOTIFY: Arc<HartNotify> = Arc::new(HartNotify {
-            hartid: state::cpu_local().id,
-            unparked: AtomicBool::new(false),
-        });
+    fn park(&self) -> Result<(), Self::Error> {
+        let calling_cpuid = state::cpu_local().id;
+        ensure!(self.cpuid == calling_cpuid);
+
+        tracing::trace!("parking hart {calling_cpuid}");
+
+        // Safety: wfi (wait for interrupt) halts the calling hart until an interrupt is received.
+        // The calling hart will therefore not make any progress until woken by an IPI (from `unpark` below)
+        // or through any other external interrupt.
+        // We also need S-mode interrupts to be enabled on the calling hart (RISC-V Privileged §3.2.3), the HART init
+        // procedure ensures this.
+        unsafe { asm!("wfi", options(nomem, nostack, preserves_flags)) };
+
+        tracing::trace!("hart {calling_cpuid} woke up");
+
+        Ok(())
     }
 
-    let waker = waker_ref(&CURRENT_THREAD_NOTIFY);
-    let mut cx = Context::from_waker(&waker);
-    loop {
-        if let Poll::Ready(t) = f.as_mut().poll(&mut cx) {
-            return t;
-        }
+    fn unpark(&self) -> Result<(), Self::Error> {
+        sbi::ipi::send_ipi(1, self.cpuid)?;
 
-        // Wait for a wakeup.
-        while !CURRENT_THREAD_NOTIFY
-            .unparked
-            .swap(false, Ordering::Acquire)
-        {
-            // No wakeup occurred. It may occur now, right before parking,
-            // but in that case the token made available by `unpark()`
-            // is guaranteed to still be available and `park()` is a no-op.
-            tracing::trace!("parking hart {}", state::cpu_local().id);
-            // Safety: inline assembly
-            unsafe { asm!("wfi") };
-            tracing::trace!("hart {} woke up", state::cpu_local().id);
-        }
+        Ok(())
     }
 }

--- a/sys/kernel/src/main.rs
+++ b/sys/kernel/src/main.rs
@@ -210,7 +210,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
     cfg_if! {
         if #[cfg(test)] {
             if cpuid == 0 {
-                arch::block_on(worker2.run(tests::run_tests(global))).unwrap().unwrap().exit_if_failed();
+                arch::block_on(worker2.run(tests::run_tests(global))).unwrap().unwrap().unwrap().exit_if_failed();
             } else {
                 arch::block_on(worker2.run(futures::future::pending::<()>())).unwrap_err(); // the only way `run` can return is when the executor is closed
             }

--- a/sys/kernel/src/mem/frame_alloc/frame.rs
+++ b/sys/kernel/src/mem/frame_alloc/frame.rs
@@ -19,7 +19,7 @@ use mem_core::PhysicalAddress;
 use static_assertions::assert_impl_all;
 
 use crate::arch;
-use crate::mem::frame_alloc::{CPU_LOCAL_CACHE, FRAME_ALLOC};
+use crate::mem::frame_alloc::CPU_LOCAL_CACHE;
 
 /// Soft limit on the amount of references that may be made to a `Frame`.
 const MAX_REFCOUNT: usize = isize::MAX as usize;


### PR DESCRIPTION
This change cleans up the `block_on` implementations:
1. moves the bulk of the implementation into the `async` subsystem crate so we can properly test it.
2. makes the existing `test_util` impl also use the new logic.
1. removes the `Arc` allocation from the Riscv implementation (this was the inciting incident) 