### PR TITLE
fix: do not error on unknown bootarg

### DIFF
--- a/sys/kernel/src/bootargs.rs
+++ b/sys/kernel/src/bootargs.rs
@@ -44,8 +44,6 @@ pub fn parse(devtree: &DeviceTree) -> crate::Result<Bootargs> {
             bootargs.backtrace = v.parse().context(BACKTRACE.name)?;
         } else if let Some(v) = HEAP_MAX.consume(tok, &mut tokens) {
             bootargs.heap_max = Some(parse_size(v).context(HEAP_MAX.name)?);
-        } else {
-            bail!("unexpected input \"{tok}\"");
         }
     }
 

--- a/sys/kernel/src/tests/args.rs
+++ b/sys/kernel/src/tests/args.rs
@@ -64,8 +64,6 @@ impl<'a> Arguments<'a> {
                 };
             } else if let Some(v) = TEST_NAME.consume(tok, &mut tokens) {
                 args.test_name = Some(v);
-            } else {
-                bail!("unexpected input \"{tok}\"");
             }
         }
 


### PR DESCRIPTION
We previously error on unknown bootarg, but that meant we couldn't pass test bootargs without the regular bootargs becoming upset and vice-versa. Remove the erroring branch. This is not a great solution but the bootargs system isn't great either...