### PR TITLE
chore: build kernel with split debuginfo

### DIFF
--- a/build/split_debuginfo.bzl
+++ b/build/split_debuginfo.bzl
@@ -1,0 +1,38 @@
+def _split_debuginfo_impl(ctx: AnalysisContext) -> list[Provider]:
+    src = ctx.attrs.binary[DefaultInfo].default_outputs[0]
+    debug = ctx.actions.declare_output(ctx.attrs.name + ".debug")
+    stripped = ctx.actions.declare_output(ctx.attrs.name)
+
+    ctx.actions.run(
+        cmd_args(ctx.attrs._objcopy[RunInfo], "--only-keep-debug", src, debug.as_output()),
+        category = "objcopy_only_keep_debug",
+    )
+
+    ctx.actions.run(
+        cmd_args(
+            ctx.attrs._objcopy[RunInfo],
+            "--strip-debug",
+            cmd_args(debug, format = "--add-gnu-debuglink={}"),
+            src,
+            stripped.as_output(),
+        ),
+        category = "objcopy_strip",
+    )
+
+    return [DefaultInfo(
+        default_output = stripped,
+        sub_targets = {"debuginfo": [DefaultInfo(default_output = debug)]},
+    )]
+
+split_debuginfo = rule(
+    impl = _split_debuginfo_impl,
+    doc = """
+    Split an incoming debuginfo-containing ELF file into a stripped ELF file and standalone debuginfo ELF file.
+
+    This is effectively the same as Rusts `-Csplit-debuginfo` setting but works more reliably across different architectures.
+    """,
+    attrs = {
+        "binary": attrs.dep(),
+        "_objcopy": attrs.exec_dep(default = "toolchains//:llvm_bintools[llvm-objcopy]"),
+    },
+)

--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -35,6 +35,7 @@ flake.package(
     ],
     package = "clang_20",
     path = "root//:flake",
+    visibility = ["PUBLIC"],
 )
 
 flake.package(
@@ -42,6 +43,15 @@ flake.package(
     package = "lld_20",
     binaries = ["ld.lld", "ld64.lld"],
     path = "root//:flake",
+)
+
+# Target-agnostic, unlike the GNU bintools clang_20's cc-wrapper pulls in.
+flake.package(
+    name = "llvm_bintools",
+    package = "llvmBintools_20",
+    binaries = ["llvm-objcopy", "llvm-strip"],
+    path = "root//:flake",
+    visibility = ["PUBLIC"],
 )
 
 flake.package(

--- a/flake.nix
+++ b/flake.nix
@@ -47,9 +47,13 @@
           # The cxx toolchain bakes its lib dir into binaries as -rpath
           # so they can find it at runtime.
           cxxRuntimeLib = pkgs.stdenv.cc.cc.lib;
+
+          # Target-agnostic LLVM binutils, used to manipulate cross-compiled
+          # ELFs (e.g. riscv64) from the host without a cross-binutils.
+          llvmBintools_20 = pkgs.llvmPackages_20.bintools-unwrapped;
         in
         {
-          inherit rustToolchain cxxRuntimeLib;
+          inherit rustToolchain cxxRuntimeLib llvmBintools_20;
           inherit (pkgs)
             bash
             python3

--- a/sys/BUCK
+++ b/sys/BUCK
@@ -5,14 +5,16 @@ k23_image(
     name = "k23-riscv64",
     loader = "//sys/loader:loader",
     kernel = "//sys/kernel:kernel",
+    kernel_debuginfo = "//sys/kernel:kernel[debuginfo]",
     platform = "//platforms:riscv64"
 )
 
 # Test variant: same image shape, but the loader embeds the test kernel.
 k23_image(
     name = "k23-tests-riscv64",
-    loader = "//sys/loader:loader_tests",
-    kernel = "//sys/kernel:kernel_tests",
+    loader = "//sys/loader:loader-tests",
+    kernel = "//sys/kernel:kernel-tests",
+    kernel_debuginfo = "//sys/kernel:kernel-tests[debuginfo]",
     platform = "//platforms:riscv64"
 )
 

--- a/sys/defs.bzl
+++ b/sys/defs.bzl
@@ -16,36 +16,8 @@ def _k23_image_rule_impl(ctx: AnalysisContext) -> list[Provider]:
     # but because that is hard (requires a working disk image builder AND a working BIOS/UEFI pipeline AND probably more)
     # this temporary "disk image" is just a concatenation of the two binaries.
 
-    lldb_args = ctx.actions.declare_output("lldb_args")
-    ctx.actions.write(
-        lldb_args,
-        [
-            cmd_args("target create", loader_file, delimiter = " "),
-            cmd_args("target modules add", kernel_file, delimiter = " "),
-            cmd_args("target modules load --file", kernel_file, " -s", str(ctx.attrs.kernel_load_address), delimiter = " ")
-        ],
-        with_inputs = True,
-        allow_args = True
-    )
-
-    # Also generate a GDB variant
-    gdb_args = ctx.actions.declare_output("gdb_args")
-    ctx.actions.write(
-        gdb_args,
-        [
-            cmd_args("file", loader_file, delimiter = " "),
-            cmd_args("add-symbol-file", kernel_file, str(ctx.attrs.kernel_load_address), delimiter = " "),
-        ],
-        with_inputs = True,
-        allow_args = True,
-    )
-
     return [DefaultInfo(
         default_output = loader_file,
-        sub_targets =  {
-            "lldb_args": [DefaultInfo(default_output = lldb_args, other_outputs = [loader_file, kernel_file])],
-            "gdb_args": [DefaultInfo(default_output = gdb_args, other_outputs = [loader_file, kernel_file])],
-        }
     )]
 
 _k23_image_rule = rule(
@@ -53,6 +25,7 @@ _k23_image_rule = rule(
     attrs = {
         "loader": attrs.dep(providers = [DefaultInfo]),
         "kernel": attrs.dep(providers = [DefaultInfo]),
+        "kernel_debuginfo": attrs.dep(providers = [DefaultInfo]),
         "kernel_load_address": attrs.option(attrs.int(), default = None)
     },
 )

--- a/sys/kernel/BUCK
+++ b/sys/kernel/BUCK
@@ -1,3 +1,5 @@
+load("//build:split_debuginfo.bzl", "split_debuginfo")
+
 _DEPS = [
     # internal libraries
     "//sys/loader/api:loader-api",
@@ -55,17 +57,25 @@ _DEPS = [
 })
 
 rust_binary(
-    name = "kernel",
+    name = "kernel-unstripped",
+    crate = "k23",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/main.rs",
     default_target_platform = "//platforms:riscv64",
     incoming_transition = "//build:kernel",
     deps = _DEPS,
+)
+
+split_debuginfo(
+    name = "kernel",
+    binary = ":kernel-unstripped",
+    default_target_platform = "//platforms:riscv64",
     visibility = ["PUBLIC"],
 )
 
 rust_binary(
-    name = "kernel_tests",
+    name = "kernel-tests-unstripped",
+    crate = "k23",
     srcs = glob(["src/**/*.rs"]),
     mapped_srcs = {"//:wast_tests": "wast"},
     crate_root = "src/main.rs",
@@ -73,5 +83,11 @@ rust_binary(
     incoming_transition = "//build:kernel-tests",
     rustc_flags = ["--cfg=test"],
     deps = _DEPS,
+)
+
+split_debuginfo(
+    name = "kernel-tests",
+    binary = ":kernel-tests-unstripped",
+    default_target_platform = "//platforms:riscv64",
     visibility = ["PUBLIC"],
 )

--- a/sys/kernel/src/backtrace/mod.rs
+++ b/sys/kernel/src/backtrace/mod.rs
@@ -34,8 +34,8 @@ struct BacktraceInfo {
     /// but the kernel is located at some address in the higher half. This offset is used to convert
     /// between the two.
     kernel_virt_base: u64,
-    /// The memory of our own ELF
-    elf: &'static [u8],
+    /// The kernel's debuginfo ELF.
+    debuginfo: &'static [u8],
     /// The actual state required for converting addresses into symbols. This is *very* heavy to
     /// compute though, so we only construct it lazily in [`BacktraceInfo::symbolize_context`].
     symbolize_context: OnceLock<SymbolizeContext<'static>>,
@@ -66,14 +66,17 @@ impl BacktraceInfo {
     fn new(boot_info: &'static BootInfo, backtrace_style: BacktraceStyle) -> Self {
         BacktraceInfo {
             kernel_virt_base: boot_info.kernel_virt.start.get() as u64,
+            // The kernel itself is always stripped with  DWARF and `.symtab` info
+            // living in a separate debuginfo ELF that the loader points us at.
+            //
             // Safety: we have to trust the loaders BootInfo here
-            elf: unsafe {
+            debuginfo: unsafe {
                 let base = boot_info
                     .physical_address_offset
-                    .add(boot_info.kernel_phys.start.get())
+                    .add(boot_info.kernel_debuginfo_phys.start.get())
                     .as_ptr();
 
-                slice::from_raw_parts(base, boot_info.kernel_phys.len())
+                slice::from_raw_parts(base, boot_info.kernel_debuginfo_phys.len())
             },
             symbolize_context: OnceLock::new(),
             backtrace_style,
@@ -84,8 +87,8 @@ impl BacktraceInfo {
         self.symbolize_context.get_or_init(|| {
             tracing::debug!("Setting up symbolize context...");
 
-            let elf = xmas_elf::ElfFile::new(self.elf).unwrap();
-            SymbolizeContext::new(elf, self.kernel_virt_base).unwrap()
+            let debuginfo = xmas_elf::ElfFile::new(self.debuginfo).unwrap();
+            SymbolizeContext::new(debuginfo, self.kernel_virt_base).unwrap()
         })
     }
 }

--- a/sys/kernel/src/main.rs
+++ b/sys/kernel/src/main.rs
@@ -212,7 +212,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
             if cpuid == 0 {
                 arch::block_on(worker2.run(tests::run_tests(global))).unwrap().unwrap().unwrap().exit_if_failed();
             } else {
-                arch::block_on(worker2.run(futures::future::pending::<()>())).unwrap_err(); // the only way `run` can return is when the executor is closed
+                arch::block_on(worker2.run(futures::future::pending::<()>())).unwrap().unwrap_err(); // the only way `run` can return is when the executor is closed
             }
         } else {
             shell::init(
@@ -220,7 +220,7 @@ fn kmain(cpuid: usize, boot_info: &'static BootInfo, boot_ticks: u64) {
                 &global.executor,
                 boot_info.cpu_mask.count_ones() as usize,
             );
-            arch::block_on(worker2.run(futures::future::pending::<()>())).unwrap_err(); // the only way `run` can return is when the executor is closed
+            arch::block_on(worker2.run(futures::future::pending::<()>())).unwrap().unwrap_err(); // the only way `run` can return is when the executor is closed
         }
     }
 }

--- a/sys/loader/BUCK
+++ b/sys/loader/BUCK
@@ -34,7 +34,10 @@ rust_binary(
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/main.rs",
     default_target_platform = "//platforms:riscv64",
-    env = {"KERNEL": "$(location //sys/kernel:kernel)"},
+    env = {
+        "KERNEL": "$(location //sys/kernel:kernel)",
+        "KERNEL_DEBUGINFO": "$(location //sys/kernel:kernel[debuginfo])"
+    },
     rustc_flags = _RUSTC_FLAGS,
     deps = _DEPS,
     incoming_transition = "//build:loader",
@@ -43,11 +46,14 @@ rust_binary(
 
 # Loader variant that embeds the test kernel; consumed by `:k23-tests-riscv64`.
 rust_binary(
-    name = "loader_tests",
+    name = "loader-tests",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/main.rs",
     default_target_platform = "//platforms:riscv64",
-    env = {"KERNEL": "$(location //sys/kernel:kernel_tests)"},
+    env = {
+        "KERNEL": "$(location //sys/kernel:kernel-tests)",
+        "KERNEL_DEBUGINFO": "$(location //sys/kernel:kernel-tests[debuginfo])"
+    },
     rustc_flags = _RUSTC_FLAGS,
     deps = _DEPS,
     incoming_transition = "//build:loader-tests",

--- a/sys/loader/api/src/info.rs
+++ b/sys/loader/api/src/info.rs
@@ -35,10 +35,15 @@ pub struct BootInfo {
     pub tls_template: Option<TlsTemplate>,
     /// Virtual address of the loaded kernel image.
     pub kernel_virt: Range<VirtualAddress>,
-    /// Physical memory region where the kernel ELF file resides.
+    /// Physical memory region where the (stripped) kernel ELF file resides.
     ///
     /// This field can be used by the kernel to perform introspection of its own ELF file.
     pub kernel_phys: Range<PhysicalAddress>,
+    /// Physical memory region where the kernel's debuginfo ELF resides.
+    ///
+    /// Contains the `.symtab` and `.debug_*` sections stripped from the runnable kernel
+    /// image. Reachable via [`Self::physical_address_offset`].
+    pub kernel_debuginfo_phys: Range<PhysicalAddress>,
 
     pub rng_seed: [u8; 32],
 }
@@ -58,6 +63,7 @@ impl BootInfo {
             tls_template: None,
             kernel_virt: Default::default(),
             kernel_phys: Default::default(),
+            kernel_debuginfo_phys: Default::default(),
             rng_seed: [0; 32],
         }
     }
@@ -159,6 +165,13 @@ impl fmt::Display for BootInfo {
             f,
             "{:<23} : {}..{}",
             "KERNEL PHYS", self.kernel_phys.start, self.kernel_phys.end
+        )?;
+        writeln!(
+            f,
+            "{:<23} : {}..{}",
+            "KERNEL DEBUGINFO PHYS",
+            self.kernel_debuginfo_phys.start,
+            self.kernel_debuginfo_phys.end
         )?;
         if let Some(tls) = self.tls_template.as_ref() {
             writeln!(

--- a/sys/loader/src/boot_info.rs
+++ b/sys/loader/src/boot_info.rs
@@ -25,6 +25,7 @@ pub fn prepare_boot_info(
     maybe_tls_template: Option<TlsTemplate>,
     loader_phys: Range<PhysicalAddress>,
     kernel_phys: Range<PhysicalAddress>,
+    kernel_debuginfo_phys: Range<PhysicalAddress>,
     fdt_phys: Range<PhysicalAddress>,
     hart_mask: usize,
     rng_seed: [u8; 32],
@@ -41,6 +42,7 @@ pub fn prepare_boot_info(
         fdt_phys,
         loader_phys,
         kernel_phys.clone(),
+        kernel_debuginfo_phys.clone(),
     );
 
     let mut boot_info = BootInfo::new(memory_regions);
@@ -49,6 +51,7 @@ pub fn prepare_boot_info(
     boot_info.tls_template = maybe_tls_template;
     boot_info.kernel_virt = kernel_virt;
     boot_info.kernel_phys = kernel_phys;
+    boot_info.kernel_debuginfo_phys = kernel_debuginfo_phys;
     boot_info.cpu_mask = hart_mask;
     boot_info.rng_seed = rng_seed;
 
@@ -69,6 +72,7 @@ fn init_boot_info_memory_regions(
     fdt_phys: Range<PhysicalAddress>,
     loader_phys: Range<PhysicalAddress>,
     kernel_phys: Range<PhysicalAddress>,
+    kernel_debuginfo_phys: Range<PhysicalAddress>,
 ) -> MemoryRegions {
     // Safety: we just allocated a whole frame for the boot info
     let regions: &mut [MaybeUninit<MemoryRegion>] = unsafe {
@@ -105,18 +109,36 @@ fn init_boot_info_memory_regions(
         });
     }
 
-    // Most of the memory occupied by the loader is not needed once the kernel is running,
-    // but the kernel itself lies somewhere in the loader memory.
-    //
-    // We can still mark the range before and after the kernel as usable.
-    push_region(MemoryRegion {
-        range: loader_phys.start..kernel_phys.start,
-        kind: MemoryRegionKind::Usable,
-    });
-    push_region(MemoryRegion {
-        range: kernel_phys.end..loader_phys.end,
-        kind: MemoryRegionKind::Usable,
-    });
+    // go over the embedded kernel and kernel debuginfo that are
+    // directly mapped and mark every around them as usable memory
+    {
+        let mut holes = [kernel_phys, kernel_debuginfo_phys];
+        holes.sort_unstable_by_key(|r| r.start);
+
+        let start = loader_phys.start..holes[0].start;
+        if !start.is_empty() {
+            push_region(MemoryRegion {
+                range: start,
+                kind: MemoryRegionKind::Usable,
+            });
+        }
+
+        let mid = holes[0].end..holes[1].start;
+        if !mid.is_empty() {
+            push_region(MemoryRegion {
+                range: mid,
+                kind: MemoryRegionKind::Usable,
+            });
+        }
+
+        let end = holes[1].end..loader_phys.end;
+        if !end.is_empty() {
+            push_region(MemoryRegion {
+                range: end,
+                kind: MemoryRegionKind::Usable,
+            });
+        }
+    }
 
     // Report the flattened device tree as a separate region.
     push_region(MemoryRegion {

--- a/sys/loader/src/kernel.rs
+++ b/sys/loader/src/kernel.rs
@@ -21,6 +21,18 @@ static INLINED_KERNEL_BYTES: KernelBytes = KernelBytes(*include_bytes!(env!("KER
 #[repr(C, align(4096))]
 struct KernelBytes(pub [u8; include_bytes!(env!("KERNEL")).len()]);
 
+/// The inlined kernel debuginfo.
+///
+/// Contains the `.symtab` and `.debug_*` sections stripped from the kernel binary.
+/// The loader hands a pointer to this blob to the kernel via [`BootInfo::kernel_debuginfo_phys`]
+/// so the backtrace subsystem can resolve symbols.
+///
+/// [`BootInfo::kernel_debuginfo_phys`]: loader_api::BootInfo::kernel_debuginfo_phys
+static INLINED_KERNEL_DEBUGINFO_BYTES: KernelDebuginfoBytes =
+    KernelDebuginfoBytes(*include_bytes!(env!("KERNEL_DEBUGINFO")));
+#[repr(C, align(4096))]
+struct KernelDebuginfoBytes(pub [u8; include_bytes!(env!("KERNEL_DEBUGINFO")).len()]);
+
 /// The decompressed and parsed kernel ELF plus the embedded loader configuration data
 pub struct Kernel<'a> {
     pub elf_file: xmas_elf::ElfFile<'a>,
@@ -64,6 +76,14 @@ impl Kernel<'_> {
         Range::from_start_len(
             PhysicalAddress::from_ptr(INLINED_KERNEL_BYTES.0.as_ptr()),
             INLINED_KERNEL_BYTES.0.len(),
+        )
+    }
+
+    /// Physical range of the embedded kernel debuginfo (`.debug` artifact).
+    pub fn debuginfo_phys_range(&self) -> Range<PhysicalAddress> {
+        Range::from_start_len(
+            PhysicalAddress::from_ptr(INLINED_KERNEL_DEBUGINFO_BYTES.0.as_ptr()),
+            INLINED_KERNEL_DEBUGINFO_BYTES.0.len(),
         )
     }
 

--- a/sys/loader/src/main.rs
+++ b/sys/loader/src/main.rs
@@ -186,6 +186,7 @@ fn do_global_init(hartid: usize, opaque: *const c_void) -> GlobalInitResult {
         maybe_tls_alloc.as_ref().map(|alloc| alloc.template.clone()),
         self_regions.executable.start..self_regions.read_write.end,
         kernel.phys_range(),
+        kernel.debuginfo_phys_range(),
         fdt_phys,
         minfo.hart_mask,
         rng_seed,


### PR DESCRIPTION
This change splits the kernel from one big debuginfo-containing ELF binary into a small, stripped ELF binary and a big debuginfo ELF.

While not much is changed right now, we can use this later to demand-load the debug symbols only when a kernel panic happened. this dramatically reduces memory usage (and mapping effort, etc) in the happy path. These optimizations are left for a follow-up though, this just puts the infra in-place.