### PR TITLE
fix(mem-core/test-util): back test memory with MAP_NORESERVE mmap instead of regular allocation

### DIFF
--- a/lib/mem-core/BUCK
+++ b/lib/mem-core/BUCK
@@ -23,6 +23,7 @@ rust_test(
         "//third-party:lock_api",
         "//lib/cpu-local:cpu-local",
         "//lib/spin:spin",
+        "//third-party:libc",
         "//third-party:proptest",
         "//third-party:proptest-derive",
         "//third-party:parking_lot",

--- a/lib/mem-core/proptest-regressions/frame_allocator/bump.txt
+++ b/lib/mem-core/proptest-regressions/frame_allocator/bump.txt
@@ -1,0 +1,12 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 537ed2b2aa7832fa7c8ff74771777b44a28e548e5f67903c5b6547182ff1ceb1 # shrinks to region_layouts = [Layout { size: 16106127360, align: 1073741824 (1 << 30) }]
+cc 8f3434a3ce6aa17f4146c3d9a8a21e828aa79bab39b5648cf2b374a7c92f7833 # shrinks to region_layouts = [Layout { size: 16437112832, align: 4096 (1 << 12) }]
+cc 2bcda22e5ee7cd97b52cfdeaecedd6e452d4970ce4b20891c7cd8a5c7c1ee926 # shrinks to region_layouts = [Layout { size: 16106127360, align: 1073741824 (1 << 30) }], alignment_pot = 1
+cc 6a4342aa2d5cffdcc0bd31c1319378144e6d33b9a296db2459c762629d18abb8 # shrinks to region_layouts = [Layout { size: 16106127360, align: 1073741824 (1 << 30) }], alignment_pot = 1
+cc 10ca1c271098d01c256166957b5999f0fd6561a6d5393b49f619c23cb29ab34a # shrinks to region_layouts = [Layout { size: 16437112832, align: 4096 (1 << 12) }]
+cc bd5d0de834d9a837150f8830977d2dd3373d5392d732e931143d7faa4a595ad4 # shrinks to region_layouts = [Layout { size: 16106127360, align: 1073741824 (1 << 30) }], alignment_pot = 1

--- a/lib/mem-core/src/test_utils/memory.rs
+++ b/lib/mem-core/src/test_utils/memory.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use std::alloc::{Allocator, Layout};
+use std::alloc::Layout;
 use std::collections::BTreeMap;
 use std::ops::Range;
 use std::ptr::NonNull;
@@ -23,7 +23,7 @@ impl Drop for Memory {
         let regions = mem::take(&mut self.regions);
 
         for (_end, (_start, region, layout)) in regions {
-            unsafe { std::alloc::System.deallocate(region.cast(), layout) }
+            unsafe { host_dealloc(region, layout) }
         }
     }
 }
@@ -33,7 +33,7 @@ impl Memory {
         let regions = region_sizes
             .into_iter()
             .map(|layout| {
-                let region = std::alloc::System.allocate(layout).unwrap();
+                let region = host_alloc(layout);
 
                 // Safety: we just allocated the ptr, we know it is valid
                 let Range { start, end } = unsafe { region.as_ref() }.as_ptr_range();
@@ -116,4 +116,45 @@ impl fmt::Debug for Memory {
             })
             .finish()
     }
+}
+
+// Use mmap with MAP_NORESERVE on Unix so the kernel doesn't count test memory against
+// overcommit limits. Without this, proptests that allocate hundreds of GiB of virtual
+// address space fail on Linux systems with limited RAM and no swap.
+#[cfg(unix)]
+fn host_alloc(layout: Layout) -> NonNull<[u8]> {
+    let ptr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            layout.size(),
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE,
+            -1,
+            0,
+        )
+    };
+    assert_ne!(ptr, libc::MAP_FAILED, "mmap failed for {layout:?}");
+    NonNull::new(std::ptr::slice_from_raw_parts_mut(
+        ptr as *mut u8,
+        layout.size(),
+    ))
+    .unwrap()
+}
+
+#[cfg(unix)]
+unsafe fn host_dealloc(region: NonNull<[u8]>, _layout: Layout) {
+    let ret = unsafe { libc::munmap(region.as_ptr() as *mut libc::c_void, region.len()) };
+    assert_eq!(ret, 0, "munmap failed");
+}
+
+#[cfg(not(unix))]
+fn host_alloc(layout: Layout) -> NonNull<[u8]> {
+    use std::alloc::Allocator;
+    std::alloc::System.allocate(layout).unwrap()
+}
+
+#[cfg(not(unix))]
+unsafe fn host_dealloc(region: NonNull<[u8]>, layout: Layout) {
+    use std::alloc::Allocator;
+    unsafe { std::alloc::System.deallocate(region.cast(), layout) }
 }


### PR DESCRIPTION
previously we used the regular rust global-allocator to obtain an allocation backing a test physmem.  But just like real physmem we rarely write to _all_ pages so this was always wasteful. Additionally, systems with kernels that are not as willing to overcommit memory would error on the allocation.

This change fixes both by backing the test physmem with an MMAP that has MAP_NORESERVE set.

At the same time this makes the tests pass ~4x faster, nice.