### PR TITLE
build/toolchains: restore workspace clippy lints

### DIFF
--- a/build/riscv-elf2efi/src/main.rs
+++ b/build/riscv-elf2efi/src/main.rs
@@ -20,6 +20,7 @@ use std::path::PathBuf;
 use anyhow::{Context, bail};
 use clap::Parser;
 use object::read::elf::{FileHeader, Rela, SectionHeader, SectionTable};
+use object::write::pe::SectionRange;
 use object::{Endianness, ReadRef, SectionIndex, elf, pe};
 
 #[derive(Parser, Debug)]
@@ -40,6 +41,9 @@ fn main() -> anyhow::Result<()> {
     let input = fs::File::open(&args.input)
         .with_context(|| format!("Failed to open file '{}'", args.input.display()))?;
 
+    // Safety: yes the file *could* be modified while we hold it, BUT: doing that is something
+    // the user has to deliberately do (stupid) and will at-worst result in a corrupted output.
+    // Re-running the build will fix this, so not a big deal.
     let in_data = unsafe {
         memmap2::Mmap::map(&input)
             .with_context(|| format!("Failed to map file '{}'", args.input.display()))?
@@ -64,7 +68,7 @@ fn main() -> anyhow::Result<()> {
 // UEFI requires PE section alignment of at least 4 KiB (the firmware uses it to
 // apply page-level protection). Individual ELF section sh_addralign values are
 // typically smaller, so we pin the PE section/file alignment to a page.
-const PE_ALIGNMENT: u64 = 0x1000;
+const PE_ALIGNMENT: u32 = 0x1000;
 
 struct SectionLayout {
     text_start: u32,
@@ -92,7 +96,7 @@ fn scan_layout<Elf: FileHeader<Endian = Endianness>>(
         if !is_alloc(in_section, endian) {
             continue;
         }
-        assert!(in_section.sh_addralign(endian).into() <= PE_ALIGNMENT);
+        assert!(in_section.sh_addralign(endian).into() <= u64::from(PE_ALIGNMENT));
         let start: u32 = in_section.sh_addr(endian).into().try_into()?;
         let size: u32 = in_section.sh_size(endian).into().try_into()?;
         let end: u32 = start
@@ -159,7 +163,7 @@ fn collect_relocations<Elf: FileHeader<Endian = Endianness>>(
         // Static rela sections have sh_info pointing at the target section.
         // Dynamic rela sections (.rela.dyn, .rela.plt) are SHF_ALLOC and
         // target virtual addresses across the whole image.
-        let dynamic = (in_section.sh_flags(endian).into() as u32) & elf::SHF_ALLOC != 0;
+        let dynamic = in_section.sh_flags(endian).into() & u64::from(elf::SHF_ALLOC) != 0;
         let (info_addr, info_data): (u64, &[u8]) = if dynamic {
             (0, &[])
         } else {
@@ -207,7 +211,13 @@ fn collect_relocations<Elf: FileHeader<Endian = Endianness>>(
                             .context("R_RISCV_PCREL_LO12_I: instruction read out of bounds")?
                             .get(endian);
                         assert_eq!(instruction & 0x707f, 0x3003);
-                        addr = addr.wrapping_add(((instruction & 0xfff0_0000) as i32 >> 20) as u32);
+                        #[expect(
+                            clippy::cast_sign_loss,
+                            clippy::cast_possible_wrap,
+                            reason = "sign-extending RISC-V 12-bit immediate; bit pattern preserved"
+                        )]
+                        let imm = ((instruction & 0xfff0_0000_u32) as i32 >> 20_i32) as u32;
+                        addr = addr.wrapping_add(imm);
                         got_addresses.push(addr);
                     }
                 }
@@ -272,8 +282,8 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(in_data: &[u8]) -> anyhow::Re
     let mut out_data = Vec::new();
     let mut writer = object::write::pe::Writer::new(
         in_elf.is_type_64(),
-        PE_ALIGNMENT as u32,
-        PE_ALIGNMENT as u32,
+        PE_ALIGNMENT,
+        PE_ALIGNMENT,
         &mut out_data,
     );
 
@@ -295,7 +305,7 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(in_data: &[u8]) -> anyhow::Re
     writer.reserve_virtual_until(layout.text_start);
     let text_range = writer.reserve_text_section(layout.text_end - layout.text_start);
     assert_eq!(text_range.virtual_address, layout.text_start);
-    let mut data_range = Default::default();
+    let mut data_range = SectionRange::default();
     if layout.have_data {
         writer.reserve_virtual_until(layout.data_start);
         data_range = writer.reserve_data_section(
@@ -331,7 +341,12 @@ fn copy_file<Elf: FileHeader<Endian = Endianness>>(in_data: &[u8]) -> anyhow::Re
                 if slot + 8 > bytes.len() {
                     continue;
                 }
-                bytes[slot..slot + 8].copy_from_slice(&(addend as u64).to_le_bytes());
+                #[expect(
+                    clippy::cast_sign_loss,
+                    reason = "writing the 64-bit bit-pattern of the signed addend"
+                )]
+                let addend_bits = addend as u64;
+                bytes[slot..slot + 8].copy_from_slice(&addend_bits.to_le_bytes());
             } else {
                 if slot + 4 > bytes.len() {
                     continue;
@@ -427,21 +442,21 @@ fn is_runtime_section<S: SectionHeader>(s: &S, endian: S::Endian) -> bool {
 }
 
 fn is_text<S: SectionHeader>(s: &S, endian: S::Endian) -> bool {
-    let flags = s.sh_flags(endian).into() as u32;
+    let flags = s.sh_flags(endian).into();
     is_runtime_section(s, endian)
-        && flags & elf::SHF_ALLOC != 0
-        && (flags & elf::SHF_EXECINSTR != 0 || flags & elf::SHF_WRITE == 0)
+        && flags & u64::from(elf::SHF_ALLOC) != 0
+        && (flags & u64::from(elf::SHF_EXECINSTR) != 0 || flags & u64::from(elf::SHF_WRITE) == 0)
 }
 
 fn is_data<S: SectionHeader>(s: &S, endian: S::Endian) -> bool {
-    let flags = s.sh_flags(endian).into() as u32;
+    let flags = s.sh_flags(endian).into();
     is_runtime_section(s, endian)
-        && flags & elf::SHF_ALLOC != 0
-        && flags & elf::SHF_EXECINSTR == 0
-        && flags & elf::SHF_WRITE != 0
+        && flags & u64::from(elf::SHF_ALLOC) != 0
+        && flags & u64::from(elf::SHF_EXECINSTR) == 0
+        && flags & u64::from(elf::SHF_WRITE) != 0
 }
 
 fn is_alloc<S: SectionHeader>(s: &S, endian: S::Endian) -> bool {
-    let flags = s.sh_flags(endian).into() as u32;
-    is_runtime_section(s, endian) && flags & elf::SHF_ALLOC != 0
+    let flags = s.sh_flags(endian).into();
+    is_runtime_section(s, endian) && flags & u64::from(elf::SHF_ALLOC) != 0
 }

--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -3,6 +3,7 @@ load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:remote_test_execution.bzl", "remote_test_execution_toolchain")
 load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
 load(":flake.bzl", "flake")
+load(":lints.bzl", "ALLOW", "DENY")
 load(":rust.bzl", "rust_toolchain")
 load(":cxx.bzl", "clang_toolchain")
 load(":qemu.bzl", "qemu_toolchain")
@@ -164,6 +165,8 @@ rust_toolchain(
         "DEFAULT": None
     }),
     rust_target_path = "@root//build:targets",
+    deny_lints = DENY,
+    allow_lints = ALLOW,
     rustc_flags = [
         "-Zunstable-options",
     ] + select({

--- a/build/toolchains/lints.bzl
+++ b/build/toolchains/lints.bzl
@@ -1,0 +1,64 @@
+# Workspace clippy lint policy. Mirrors the [workspace.lints.clippy] table that
+# lived in the root Cargo.toml before the buck2 migration. Wired into the rust
+# toolchain via deny_lints / allow_lints in build/toolchains/BUCK.
+
+DENY = [
+    # numeric safety
+    "clippy::cast_possible_truncation",
+    "clippy::cast_possible_wrap",
+    "clippy::cast_precision_loss",
+    "clippy::cast_sign_loss",
+    "clippy::cast_lossless",
+    "clippy::default_numeric_fallback",
+    "clippy::checked_conversions",
+    "clippy::float_arithmetic",
+    "clippy::float_cmp",
+
+    # pointer safety
+    "clippy::cast_ptr_alignment",
+    "clippy::ptr_as_ptr",
+    "clippy::ptr_cast_constness",
+    "clippy::ref_as_ptr",
+    "clippy::transmute_ptr_to_ptr",
+
+    # stack overflow prevention
+    "clippy::large_futures",
+    "clippy::large_stack_arrays",
+    "clippy::large_stack_frames",
+    "clippy::large_types_passed_by_value",
+    "clippy::recursive_format_impl",
+
+    # style
+    "clippy::undocumented_unsafe_blocks",
+    "clippy::as_underscore",
+    "clippy::alloc_instead_of_core",
+    "clippy::allow_attributes_without_reason",
+    "clippy::default_trait_access",
+    "clippy::cloned_instead_of_copied",
+    "clippy::fn_params_excessive_bools",
+    "clippy::struct_excessive_bools",
+    "clippy::filter_map_next",
+    "clippy::explicit_iter_loop",
+    "clippy::flat_map_option",
+    "clippy::iter_filter_is_ok",
+    "clippy::iter_filter_is_some",
+    "clippy::manual_assert",
+    "clippy::manual_is_power_of_two",
+    "clippy::manual_is_variant_and",
+    "clippy::manual_let_else",
+    "clippy::manual_ok_or",
+    "clippy::match_bool",
+    "clippy::missing_fields_in_debug",
+    "clippy::semicolon_if_nothing_returned",
+    "clippy::trivially_copy_pass_by_ref",
+    "clippy::unnecessary_wraps",
+    "clippy::unnested_or_patterns",
+
+    # docs
+    "clippy::missing_panics_doc",
+    "clippy::missing_errors_doc",
+]
+
+ALLOW = [
+    "clippy::too_many_arguments",
+]

--- a/flake.nix
+++ b/flake.nix
@@ -227,6 +227,7 @@
             just
             cargo-deny
             typos
+            jq
           ];
 
           # Extra tooling for jobs that exercise the kernel on-target.

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ _supertd := require("supertd")
 _reindeer := require("reindeer")
 _rust_project := require("rust-project")
 _cargo_deny := require("cargo-deny")
+_jq := require("jq")
 
 _docstring := "
 justfile for k23
@@ -25,9 +26,14 @@ _default:
 run target buck2_args="" *qemu_args="":
     {{ _buck2 }} run {{target}} {{buck2_args}} {{qemu_args}}
 
-# quick check for development
-@check targets="" *buck2_args:
-    {{ _buck2 }} build {{append("[check]", _uquery(_q_buildables(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}}
+# quick check for development.
+# The prelude's [diag.json] action is infallible by design; gate on the
+# rendered diagnostics ourselves.
+check targets="" *buck2_args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    out=$({{ _buck2 }} build {{append("[diag.json]", _uquery(_q_buildables(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}} --show-simple-output | xargs {{ _jq }} -r 'select(.level=="error") | .rendered')
+    [ -z "$out" ] || { printf '%s' "$out" >&2; exit 1; }
 
 # One CI lane locally. Default is the host lane. With `platform=X` it's the
 # X lane: lint and check at X; unittests/miri/loom are host-only and get
@@ -43,8 +49,13 @@ lint targets="" *buck2_args: (clippy targets buck2_args) (check-fmt targets buck
 # ===== linting =====
 
 # run clippy on a crate or the entire workspace.
-@clippy targets="" *buck2_args:
-    {{ _buck2 }} build {{append("[clippy.txt]", _uquery(_q_buildables(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}}
+# The prelude's [clippy.json] action is infallible by design; gate on the
+# rendered diagnostics ourselves.
+clippy targets="" *buck2_args:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    out=$({{ _buck2 }} build {{append("[clippy.json]", _uquery(_q_buildables(_targets_query(targets))))}} {{_platform_args}} {{buck2_args}} --show-simple-output | xargs {{ _jq }} -r 'select(.level=="error") | .rendered')
+    [ -z "$out" ] || { printf '%s' "$out" >&2; exit 1; }
 
 # check the workspace for typos
 @typos:

--- a/lib/addr2line/src/frame.rs
+++ b/lib/addr2line/src/frame.rs
@@ -112,20 +112,17 @@ where
         };
 
         let loc = frames.next.take();
-        let func = match frames.inlined_functions.next() {
-            Some(func) => func,
-            None => {
-                let frame = Frame {
-                    dw_die_offset: Some(frames.function.dw_die_offset),
-                    function: frames.function.name.clone().map(|name| FunctionName {
-                        name,
-                        language: frames.unit.lang,
-                    }),
-                    location: loc,
-                };
-                self.0 = FrameIterState::Empty;
-                return Ok(Some(frame));
-            }
+        let Some(func) = frames.inlined_functions.next() else {
+            let frame = Frame {
+                dw_die_offset: Some(frames.function.dw_die_offset),
+                function: frames.function.name.clone().map(|name| FunctionName {
+                    name,
+                    language: frames.unit.lang,
+                }),
+                location: loc,
+            };
+            self.0 = FrameIterState::Empty;
+            return Ok(Some(frame));
         };
 
         let mut next = Location {

--- a/lib/addr2line/src/function.rs
+++ b/lib/addr2line/src/function.rs
@@ -114,7 +114,7 @@ impl<R: gimli::Reader> Functions<R> {
                                 match attr.name() {
                                     gimli::DW_AT_low_pc => match attr.value() {
                                         gimli::AttributeValue::Addr(val) => {
-                                            ranges.low_pc = Some(val)
+                                            ranges.low_pc = Some(val);
                                         }
                                         gimli::AttributeValue::DebugAddrIndex(index) => {
                                             ranges.low_pc = Some(unit.address(index)?);
@@ -123,13 +123,13 @@ impl<R: gimli::Reader> Functions<R> {
                                     },
                                     gimli::DW_AT_high_pc => match attr.value() {
                                         gimli::AttributeValue::Addr(val) => {
-                                            ranges.high_pc = Some(val)
+                                            ranges.high_pc = Some(val);
                                         }
                                         gimli::AttributeValue::DebugAddrIndex(index) => {
                                             ranges.high_pc = Some(unit.address(index)?);
                                         }
                                         gimli::AttributeValue::Udata(val) => {
-                                            ranges.size = Some(val)
+                                            ranges.size = Some(val);
                                         }
                                         _ => {}
                                     },
@@ -426,10 +426,20 @@ impl<R: gimli::Reader> InlinedFunction<R> {
                         }
                     }
                     gimli::DW_AT_call_line => {
-                        call_line = attr.udata_value().unwrap_or(0) as u32;
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "intentional, packing line number into u32 to save memory"
+                        )]
+                        let v = attr.udata_value().unwrap_or(0) as u32;
+                        call_line = v;
                     }
                     gimli::DW_AT_call_column => {
-                        call_column = attr.udata_value().unwrap_or(0) as u32;
+                        #[expect(
+                            clippy::cast_possible_truncation,
+                            reason = "intentional, packing column number into u32 to save memory"
+                        )]
+                        let v = attr.udata_value().unwrap_or(0) as u32;
+                        call_column = v;
                     }
                     _ => {}
                 },
@@ -519,9 +529,7 @@ where
     R: gimli::Reader,
 {
     let mut entries = unit.entries_raw(Some(offset))?;
-    let abbrev = if let Some(abbrev) = entries.read_abbreviation()? {
-        abbrev
-    } else {
+    let Some(abbrev) = entries.read_abbreviation()? else {
         return Err(gimli::Error::NoEntryAtGivenOffset(offset.0.into_u64()));
     };
 

--- a/lib/addr2line/src/lib.rs
+++ b/lib/addr2line/src/lib.rs
@@ -22,7 +22,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![deny(missing_docs)]
-#[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
 
@@ -80,7 +79,11 @@ impl<R: gimli::Reader> Context<R> {
     /// Construct a new `Context` from DWARF sections.
     ///
     /// This method does not support using a supplementary object file.
-    #[expect(clippy::too_many_arguments)]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
+    #[expect(clippy::too_many_arguments, reason = "a builder would be worse")]
     pub fn from_sections(
         debug_abbrev: gimli::DebugAbbrev<R>,
         debug_addr: gimli::DebugAddr<R>,
@@ -122,12 +125,20 @@ impl<R: gimli::Reader> Context<R> {
     }
 
     /// Construct a new `Context` from an existing [`gimli::Dwarf`] object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     #[inline]
     pub fn from_dwarf(sections: gimli::Dwarf<R>) -> Result<Context<R>, Error> {
         Self::from_arc_dwarf(Arc::new(sections))
     }
 
     /// Construct a new `Context` from an existing [`gimli::Dwarf`] object.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     #[inline]
     pub fn from_arc_dwarf(sections: Arc<gimli::Dwarf<R>>) -> Result<Context<R>, Error> {
         let units = ResUnits::parse(&sections)?;
@@ -146,6 +157,10 @@ impl<R: gimli::Reader> Context<R> {
 
 impl<R: gimli::Reader> Context<R> {
     /// Find the source file and line corresponding to the given virtual memory address.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     pub fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, Error> {
         for unit in self.units.find(probe) {
             if let Some(location) = unit.find_location(probe, &self.sections)? {
@@ -157,13 +172,18 @@ impl<R: gimli::Reader> Context<R> {
 
     /// Return source file and lines for a range of addresses. For each location it also
     /// returns the address and size of the range of the underlying instructions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     pub fn find_location_range(
         &self,
         probe_low: u64,
         probe_high: u64,
     ) -> Result<LocationRangeIter<'_, R>, Error> {
-        self.units
-            .find_location_range(probe_low, probe_high, &self.sections)
+        Ok(self
+            .units
+            .find_location_range(probe_low, probe_high, &self.sections))
     }
 
     /// Return an iterator for the function frames corresponding to the given virtual
@@ -260,7 +280,7 @@ impl<R: gimli::Reader> RangeAttributes<R> {
         let mut add_range = |range: gimli::Range| {
             if range.begin < range.end {
                 f(range);
-                added_any = true
+                added_any = true;
             }
         };
         if let Some(ranges_offset) = self.ranges_offset {

--- a/lib/addr2line/src/line.rs
+++ b/lib/addr2line/src/line.rs
@@ -79,9 +79,17 @@ impl Lines {
             // Convert line and column to u32 to save a little memory.
             // We'll handle the special case of line 0 later,
             // and return left edge as column 0 in the public API.
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "intentional, packing line number into u32 to save memory"
+            )]
             let line = row.line().map(NonZeroU64::get).unwrap_or(0) as u32;
             let column = match row.column() {
                 gimli::ColumnType::LeftEdge => 0,
+                #[expect(
+                    clippy::cast_possible_truncation,
+                    reason = "intentional, packing column number into u32 to save memory"
+                )]
                 gimli::ColumnType::Column(x) => x.get() as u32,
             };
 
@@ -122,7 +130,8 @@ impl Lines {
     }
 
     pub(crate) fn file(&self, index: u64) -> Option<&str> {
-        self.files.get(index as usize).map(String::as_str)
+        let index = usize::try_from(index).ok()?;
+        self.files.get(index).map(String::as_str)
     }
 
     pub(crate) fn ranges(&self) -> impl Iterator<Item = gimli::Range> + '_ {
@@ -133,7 +142,10 @@ impl Lines {
     }
 
     fn row_location(&self, row: &LineRow) -> Location<'_> {
-        let file = self.files.get(row.file_index as usize).map(String::as_str);
+        let file = usize::try_from(row.file_index)
+            .ok()
+            .and_then(|i| self.files.get(i))
+            .map(String::as_str);
         Location {
             file,
             line: if row.line != 0 { Some(row.line) } else { None },
@@ -146,7 +158,7 @@ impl Lines {
         }
     }
 
-    pub(crate) fn find_location(&self, probe: u64) -> Result<Option<Location<'_>>, Error> {
+    pub(crate) fn find_location(&self, probe: u64) -> Option<Location<'_>> {
         let seq_idx = self.sequences.binary_search_by(|sequence| {
             if probe < sequence.start {
                 Ordering::Greater
@@ -156,10 +168,7 @@ impl Lines {
                 Ordering::Equal
             }
         });
-        let seq_idx = match seq_idx {
-            Ok(x) => x,
-            Err(_) => return Ok(None),
-        };
+        let Ok(seq_idx) = seq_idx else { return None };
         let sequence = &self.sequences[seq_idx];
 
         let idx = sequence
@@ -167,17 +176,17 @@ impl Lines {
             .binary_search_by(|row| row.address.cmp(&probe));
         let idx = match idx {
             Ok(x) => x,
-            Err(0) => return Ok(None),
+            Err(0) => return None,
             Err(x) => x - 1,
         };
-        Ok(Some(self.row_location(&sequence.rows[idx])))
+        Some(self.row_location(&sequence.rows[idx]))
     }
 
     pub(crate) fn find_location_range(
         &self,
         probe_low: u64,
         probe_high: u64,
-    ) -> Result<LineLocationRangeIter<'_>, Error> {
+    ) -> LineLocationRangeIter<'_> {
         // Find index for probe_low.
         let seq_idx = self.sequences.binary_search_by(|sequence| {
             if probe_low < sequence.start {
@@ -204,12 +213,12 @@ impl Lines {
             0
         };
 
-        Ok(LineLocationRangeIter {
+        LineLocationRangeIter {
             lines: self,
             seq_idx,
             row_idx,
             probe_high,
-        })
+        }
     }
 }
 

--- a/lib/addr2line/src/unit.rs
+++ b/lib/addr2line/src/unit.rs
@@ -44,7 +44,7 @@ impl<R: gimli::Reader> ResUnit<R> {
     /// Returns the DWARF sections and the unit.
     ///
     /// Loads the DWO unit if necessary.
-    #[expect(clippy::type_complexity)]
+    #[expect(clippy::type_complexity, reason = "its fiinne, we're all adults here")]
     pub(crate) fn dwarf_and_unit<'unit, 'ctx: 'unit>(
         &'unit self,
         ctx: &'ctx Context<R>,
@@ -66,11 +66,8 @@ impl<R: gimli::Reader> ResUnit<R> {
             return complete(dwo);
         }
 
-        let dwo_id = match self.dw_unit.dwo_id {
-            None => {
-                return complete(self.dwo.get_or_init(|| Ok(None)));
-            }
-            Some(dwo_id) => dwo_id,
+        let Some(dwo_id) = self.dw_unit.dwo_id else {
+            return complete(self.dwo.get_or_init(|| Ok(None)));
         };
 
         let comp_dir = self.dw_unit.comp_dir.clone();
@@ -91,14 +88,12 @@ impl<R: gimli::Reader> ResUnit<R> {
         };
 
         let process_dwo = move |dwo_dwarf: Option<Arc<gimli::Dwarf<R>>>| {
-            let dwo_dwarf = match dwo_dwarf {
-                None => return Ok(None),
-                Some(dwo_dwarf) => dwo_dwarf,
+            let Some(dwo_dwarf) = dwo_dwarf else {
+                return Ok(None);
             };
             let mut dwo_units = dwo_dwarf.units();
-            let dwo_header = match dwo_units.next()? {
-                Some(dwo_header) => dwo_header,
-                None => return Ok(None),
+            let Some(dwo_header) = dwo_units.next()? else {
+                return Ok(None);
             };
 
             let mut dwo_unit = dwo_dwarf.unit(dwo_header)?;
@@ -120,16 +115,21 @@ impl<R: gimli::Reader> ResUnit<R> {
         )
     }
 
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     pub(crate) fn parse_lines(&self, sections: &gimli::Dwarf<R>) -> Result<Option<&Lines>, Error> {
         // NB: line information is always stored in the main debug file so this does not need
         // to handle DWOs.
-        let ilnp = match self.dw_unit.line_program {
-            Some(ref ilnp) => ilnp,
-            None => return Ok(None),
+        let Some(ref ilnp) = self.dw_unit.line_program else {
+            return Ok(None);
         };
         self.lines.borrow(self.unit_ref(sections), ilnp).map(Some)
     }
 
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     pub(crate) fn find_location(
         &self,
         probe: u64,
@@ -138,9 +138,12 @@ impl<R: gimli::Reader> ResUnit<R> {
         let Some(lines) = self.parse_lines(sections)? else {
             return Ok(None);
         };
-        lines.find_location(probe)
+        Ok(lines.find_location(probe))
     }
 
+    /// # Errors
+    ///
+    /// Returns an error when parsing the DWARF info fails.
     #[inline]
     pub(crate) fn find_location_range(
         &self,
@@ -151,10 +154,10 @@ impl<R: gimli::Reader> ResUnit<R> {
         let Some(lines) = self.parse_lines(sections)? else {
             return Ok(None);
         };
-        lines.find_location_range(probe_low, probe_high).map(Some)
+        Ok(Some(lines.find_location_range(probe_low, probe_high)))
     }
 
-    #[expect(clippy::type_complexity)]
+    #[expect(clippy::type_complexity, reason = "its fiinne, we're all adults here")]
     pub(crate) fn find_function_or_location<'unit, 'ctx: 'unit>(
         &'unit self,
         probe: u64,
@@ -204,9 +207,8 @@ impl<R: gimli::Reader> ResUnits<R> {
         let mut units = sections.units();
         while let Some(header) = units.next()? {
             let unit_id = res_units.len();
-            let offset = match header.offset().to_debug_info_offset(&header) {
-                Some(offset) => offset,
-                None => continue,
+            let Some(offset) = header.offset().to_debug_info_offset(&header) else {
+                continue;
             };
             // We mainly want compile units, but we may need to follow references to entries
             // within other units for function names.  We don't need anything from type units.
@@ -219,9 +221,8 @@ impl<R: gimli::Reader> ResUnits<R> {
                 }
                 _ => true,
             };
-            let dw_unit = match sections.unit(header) {
-                Ok(dw_unit) => dw_unit,
-                Err(_) => continue,
+            let Ok(dw_unit) = sections.unit(header) else {
+                continue;
             };
             let dw_unit_ref = gimli::UnitRef::new(sections, &dw_unit);
 
@@ -229,9 +230,8 @@ impl<R: gimli::Reader> ResUnits<R> {
             if need_unit_range {
                 let mut entries = dw_unit_ref.entries_raw(None)?;
 
-                let abbrev = match entries.read_abbreviation()? {
-                    Some(abbrev) => abbrev,
-                    None => continue,
+                let Some(abbrev) = entries.read_abbreviation()? else {
+                    continue;
                 };
 
                 let mut ranges = RangeAttributes::default();
@@ -325,7 +325,7 @@ impl<R: gimli::Reader> ResUnits<R> {
                             range,
                             unit_id,
                             min_begin: 0,
-                        })
+                        });
                     }
                 }
             }
@@ -434,15 +434,15 @@ impl<R: gimli::Reader> ResUnits<R> {
         probe_low: u64,
         probe_high: u64,
         sections: &'a gimli::Dwarf<R>,
-    ) -> Result<LocationRangeIter<'a, R>, Error> {
+    ) -> LocationRangeIter<'a, R> {
         let unit_iter = Box::new(self.find_range(probe_low, probe_high));
-        Ok(LocationRangeIter {
+        LocationRangeIter {
             unit_iter,
             iter: None,
             probe_low,
             probe_high,
             sections,
-        })
+        }
     }
 }
 
@@ -480,13 +480,11 @@ impl<R: gimli::Reader> SupUnits<R> {
         let mut sup_units = Vec::new();
         let mut units = sections.units();
         while let Some(header) = units.next()? {
-            let offset = match header.offset().to_debug_info_offset(&header) {
-                Some(offset) => offset,
-                None => continue,
+            let Some(offset) = header.offset().to_debug_info_offset(&header) else {
+                continue;
             };
-            let dw_unit = match sections.unit(header) {
-                Ok(dw_unit) => dw_unit,
-                Err(_) => continue,
+            let Ok(dw_unit) = sections.unit(header) else {
+                continue;
             };
             sup_units.push(SupUnit { dw_unit, offset });
         }

--- a/lib/ecma-119/src/build/directory.rs
+++ b/lib/ecma-119/src/build/directory.rs
@@ -9,8 +9,8 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeMap, btree_map};
+use std::fs;
 use std::path::Path;
-use std::{fs, io};
 
 use crate::validate::{validate_dir_identifier, validate_file_identifier};
 
@@ -28,30 +28,46 @@ pub struct File<'a> {
 #[derive(Debug)]
 pub enum FileSource<'a> {
     /// Data already in memory.
-    InMemory(Cow<'a, [u8]>),
+    InMemory { len: u32, bytes: Cow<'a, [u8]> },
     /// Read from an external source at build time.
-    OnDisk { len: u64, reader: fs::File },
+    OnDisk { len: u32, reader: fs::File },
 }
 
 impl<'a> FileSource<'a> {
-    pub fn len(&self) -> usize {
+    pub fn len(&self) -> u32 {
         match self {
-            FileSource::InMemory(items) => items.len(),
-            FileSource::OnDisk { len, .. } => *len as usize,
+            FileSource::InMemory { len, .. } => *len,
+            FileSource::OnDisk { len, .. } => *len,
         }
     }
 }
 
 impl<'a> File<'a> {
-    pub fn from_bytes(bytes: impl Into<Cow<'a, [u8]>>) -> Self {
-        Self {
-            source: FileSource::InMemory(bytes.into()),
-        }
+    /// Create a `File` from a in-memory bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the file sie exceeds `u32::MAX` (ECMA-119 single-extent files are limited to 4 GiB - 1)
+    pub fn from_bytes(bytes: impl Into<Cow<'a, [u8]>>) -> anyhow::Result<Self> {
+        let bytes = bytes.into();
+        let len = u32::try_from(bytes.len())?;
+
+        Ok(Self {
+            source: FileSource::InMemory { len, bytes },
+        })
     }
 
-    pub fn from_path(path: impl AsRef<Path>) -> io::Result<Self> {
+    /// Create a `File` from a file on-disk.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the file cannot be opened
+    /// - when the file sie exceeds `u32::MAX` (ECMA-119 single-extent files are limited to 4 GiB - 1)
+    pub fn from_path(path: impl AsRef<Path>) -> anyhow::Result<Self> {
         let file = fs::File::open(path)?;
-        let len = file.metadata()?.len();
+        let len = u32::try_from(file.metadata()?.len())?;
 
         Ok(Self {
             source: FileSource::OnDisk { len, reader: file },
@@ -69,6 +85,13 @@ impl<'a> Directory<'a> {
         Self::default()
     }
 
+    /// Add a file to this directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when:
+    /// - the file name is malformed
+    /// - a directory or file with the name already exists in this directory
     pub fn add_file(
         &mut self,
         name: impl Into<Cow<'a, str>>,
@@ -76,14 +99,6 @@ impl<'a> Directory<'a> {
     ) -> anyhow::Result<&mut Self> {
         let name = name.into();
         validate_file_identifier(name.as_bytes())?;
-        // ECMA-119 single-extent files are limited to 4 GiB - 1 (the data_length
-        // field is 32-bit).
-        anyhow::ensure!(
-            file.source.len() <= u32::MAX as usize,
-            "file {name}: {} bytes exceeds ECMA-119 single-extent limit ({} bytes)",
-            file.source.len(),
-            u32::MAX,
-        );
 
         match self.entries.entry(name) {
             btree_map::Entry::Occupied(o) => {
@@ -96,6 +111,13 @@ impl<'a> Directory<'a> {
         }
     }
 
+    /// Add a subdirectory to this directory.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the directory name is malformed
+    /// - a directory or file with the name already exists in this directory
     pub fn add_subdir(
         &mut self,
         name: impl Into<Cow<'a, str>>,

--- a/lib/ecma-119/src/build/layout.rs
+++ b/lib/ecma-119/src/build/layout.rs
@@ -123,7 +123,7 @@ impl<'a> Layout<'a> {
             lba += 1; // Boot Record VD
 
             self.boot_catalog_lba = Some(lba);
-            lba += sectors_for(boot_config.required_size() as u32);
+            lba += sectors_for(u32::try_from(boot_config.required_size()).unwrap());
         }
 
         // account for both the L and M path tables
@@ -142,13 +142,13 @@ impl<'a> Layout<'a> {
 
         // every file's data, back to back. Zero-byte files get LBA 0
         // (libisofs convention) and consume no sectors.
-        for file in self.files.iter_mut() {
+        for file in &mut self.files {
             if file.len == 0 {
                 file.lba = 0;
                 continue;
             }
             file.lba = lba;
-            lba += sectors_for(file.len as u32);
+            lba += sectors_for(u32::try_from(file.len).unwrap());
         }
 
         self.total_sectors = lba;
@@ -210,7 +210,7 @@ impl<'a> Layout<'a> {
         let mut root_record = RootDirectoryRecord::new_zeroed();
         root_record.header = build_dir_record_header(root.extent_lba, root.extent_len, true, 1);
 
-        pvd.logical_block_size = BothEndianU16::new(SECTOR_SIZE as u16);
+        pvd.logical_block_size = BothEndianU16::new(u16::try_from(SECTOR_SIZE).unwrap());
         pvd.volume_set_size = BothEndianU16::new(1);
         pvd.volume_sequence_number = BothEndianU16::new(1);
         pvd.file_structure_version = 1;
@@ -232,6 +232,10 @@ impl<'a> Layout<'a> {
         //   ...             every file's data, in BFS order
 
         // system area: sectors 0–15 are skipped (left zeroed by the writer)
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "2048 * 16 trivially fits into i64"
+        )]
         w.seek_relative(16 * SECTOR_SIZE as i64)?;
 
         // sector 16: Primary Volume Descriptor
@@ -250,7 +254,7 @@ impl<'a> Layout<'a> {
 
             // Boot catalog
             w.seek(SeekFrom::Start(
-                boot_catalog_lba as u64 * SECTOR_SIZE as u64,
+                u64::from(boot_catalog_lba) * SECTOR_SIZE as u64,
             ))?;
             write_boot_catalog(&mut w, boot_config)?;
         } else {
@@ -259,14 +263,14 @@ impl<'a> Layout<'a> {
 
         // Path Table L (little-endian)
         w.seek(SeekFrom::Start(
-            self.path_table_l_lba as u64 * SECTOR_SIZE as u64,
+            u64::from(self.path_table_l_lba) * SECTOR_SIZE as u64,
         ))?;
         write_path_table::<LittleEndian>(&mut w, &self.dirs)?;
         pad_to_sector(&mut w)?;
 
         // Path Table M (big-endian)
         w.seek(SeekFrom::Start(
-            self.path_table_m_lba as u64 * SECTOR_SIZE as u64,
+            u64::from(self.path_table_m_lba) * SECTOR_SIZE as u64,
         ))?;
         write_path_table::<BigEndian>(&mut w, &self.dirs)?;
         pad_to_sector(&mut w)?;
@@ -281,9 +285,9 @@ impl<'a> Layout<'a> {
             if file.len == 0 {
                 continue; // zero-byte files occupy no sectors (LBA stays 0)
             }
-            w.seek(SeekFrom::Start(file.lba as u64 * SECTOR_SIZE as u64))?;
+            w.seek(SeekFrom::Start(u64::from(file.lba) * SECTOR_SIZE as u64))?;
             match file.source {
-                FileSource::InMemory(bytes) => w.write_all(bytes.as_bytes())?,
+                FileSource::InMemory { bytes, .. } => w.write_all(bytes.as_bytes())?,
                 FileSource::OnDisk { mut reader, .. } => {
                     io::copy(&mut reader, &mut w)?;
                 }
@@ -365,7 +369,7 @@ enum DirNodeEntry {
 #[derive(Debug)]
 pub(super) struct FileNode<'a> {
     pub(super) lba: u32, // 0 until LBA pass
-    pub(super) len: usize,
+    pub(super) len: u32,
     pub(super) identifier: Cow<'a, str>,
     pub(super) source: FileSource<'a>,
 }
@@ -403,8 +407,9 @@ impl<'a> DirNode<'a> {
     }
 
     fn required_path_table_record_size(&self) -> u32 {
-        let header_size = const { size_of::<raw::PathTableRecordHeader<LittleEndian>>() as u32 };
-        let id_len = self.identifier.len() as u32;
+        let header_size =
+            u32::try_from(size_of::<raw::PathTableRecordHeader<LittleEndian>>()).unwrap();
+        let id_len = u32::try_from(self.identifier.len()).unwrap();
 
         // round up so the size is always even
         header_size + id_len + (id_len & 1)
@@ -438,17 +443,18 @@ impl<'a> DirNode<'a> {
         let mut total = 0;
 
         let mut add_record = |id: &str| {
-            let record_size = dir_record_size(id.len() as u8);
+            let record_size = dir_record_size(u8::try_from(id.len()).unwrap());
 
             // no record may straddle a logical block boundary.
             // so we pad out to the end of the sector and continue
             if offset_in_sector as usize + record_size as usize > SECTOR_SIZE {
-                total += SECTOR_SIZE as u32 - offset_in_sector; // pad rest of sector
+                total += u32::try_from(SECTOR_SIZE).unwrap() - offset_in_sector; // pad rest of sector
                 offset_in_sector = 0;
             }
 
-            total += record_size as u32;
-            offset_in_sector = (offset_in_sector + record_size as u32) % SECTOR_SIZE as u32;
+            total += u32::from(record_size);
+            offset_in_sector =
+                (offset_in_sector + u32::from(record_size)) % u32::try_from(SECTOR_SIZE).unwrap();
         };
 
         // account for the `.` and `..`  special directories
@@ -461,7 +467,7 @@ impl<'a> DirNode<'a> {
             add_record(id);
         }
 
-        total.next_multiple_of(SECTOR_SIZE as u32)
+        total.next_multiple_of(u32::try_from(SECTOR_SIZE).unwrap())
     }
 }
 
@@ -474,7 +480,7 @@ static ZEROS: [u8; SECTOR_SIZE] = [0u8; SECTOR_SIZE];
 /// Converts a byte count to the number of whole sectors needed to hold it.
 #[inline]
 fn sectors_for(bytes: u32) -> u32 {
-    bytes.div_ceil(SECTOR_SIZE as u32)
+    bytes.div_ceil(u32::try_from(SECTOR_SIZE).unwrap())
 }
 
 /// Writes the three-field `VolumeDescriptorHeader` (type + "CD001" + version).
@@ -508,7 +514,7 @@ fn write_vd_terminator(w: &mut impl io::Write) -> io::Result<()> {
 
 /// Zero-fills the writer up to the next sector boundary.
 fn pad_to_sector(w: &mut (impl io::Write + io::Seek)) -> io::Result<()> {
-    let pos = w.stream_position()? as usize;
+    let pos = usize::try_from(w.stream_position()?).unwrap();
     let rem = pos % SECTOR_SIZE;
     if rem != 0 {
         w.write_all(&ZEROS[..SECTOR_SIZE - rem])?;
@@ -521,7 +527,7 @@ fn dir_record_size(id_len: u8) -> u8 {
     // DirectoryRecordHeader is 33 bytes (odd). A 1-byte pad is added when
     // id_len is even so the total record length is always even.
     let pad: u8 = 1 - (id_len & 1);
-    size_of::<DirectoryRecordHeader>() as u8 + id_len + pad
+    u8::try_from(size_of::<DirectoryRecordHeader>()).unwrap() + id_len + pad
 }
 
 /// Builds a `DirectoryRecordHeader` for a file or subdirectory record.
@@ -574,7 +580,7 @@ where
 {
     for dir in dirs {
         let id_bytes = dir.identifier.as_bytes();
-        let id_len = id_bytes.len() as u8;
+        let id_len = u8::try_from(id_bytes.len()).unwrap();
 
         // ECMA-119 1-based parent index: our in-memory indices are 0-based,
         // so root's parent wire value becomes 0 + 1 = 1 (pointing at itself).
@@ -606,13 +612,14 @@ fn write_dir_record(
     data_length: u32,
     is_dir: bool,
 ) -> io::Result<()> {
-    let id_len = id.len() as u8;
-    let record_size = dir_record_size(id_len) as u32;
+    let id_len = u8::try_from(id.len()).unwrap();
+    let record_size = u32::from(dir_record_size(id_len));
     let pad = 1 - (id_len & 1);
 
     // ECMA-119 §9.1: no directory record may straddle a sector boundary.
-    if *offset_in_sector + record_size > SECTOR_SIZE as u32 {
-        let pad_len = (SECTOR_SIZE as u32 - *offset_in_sector) as usize;
+    let sector_size_u32 = u32::try_from(SECTOR_SIZE).unwrap();
+    if *offset_in_sector + record_size > sector_size_u32 {
+        let pad_len = usize::try_from(sector_size_u32 - *offset_in_sector).unwrap();
         w.write_all(&ZEROS[..pad_len])?;
         *offset_in_sector = 0;
     }
@@ -623,7 +630,7 @@ fn write_dir_record(
     if pad > 0 {
         w.write_all(&[0u8])?;
     }
-    *offset_in_sector = (*offset_in_sector + record_size) % SECTOR_SIZE as u32;
+    *offset_in_sector = (*offset_in_sector + record_size) % sector_size_u32;
     Ok(())
 }
 
@@ -642,7 +649,9 @@ fn serialize_dir_extent(
     dirs: &[DirNode<'_>],
     files: &[FileNode<'_>],
 ) -> io::Result<()> {
-    w.seek(SeekFrom::Start(dir.extent_lba as u64 * SECTOR_SIZE as u64))?;
+    w.seek(SeekFrom::Start(
+        u64::from(dir.extent_lba) * SECTOR_SIZE as u64,
+    ))?;
 
     let mut offset: u32 = 0;
 
@@ -690,7 +699,7 @@ fn serialize_dir_extent(
                     &mut offset,
                     file.identifier.as_bytes(),
                     file.lba,
-                    file.len as u32,
+                    u32::try_from(file.len).unwrap(),
                     false,
                 )?;
             }
@@ -736,7 +745,7 @@ fn write_boot_catalog(w: &mut impl io::Write, boot_config: &BootConfig) -> io::R
         // 0x91 = last section header; 0x90 = more sections follow
         header.header_indicator = if is_last { 0x91 } else { 0x90 };
         header.platform_id = u8::from(section.platform);
-        header.entries = U16::new(section.entries.len() as u16);
+        header.entries = U16::new(u16::try_from(section.entries.len()).unwrap());
         header.id = section.id;
         header.write_to_io(&mut *w)?;
 

--- a/lib/ecma-119/src/build/mod.rs
+++ b/lib/ecma-119/src/build/mod.rs
@@ -29,6 +29,7 @@ pub struct ImageBuilder<'a> {
 }
 
 impl<'a> ImageBuilder<'a> {
+    #[expect(clippy::missing_panics_doc, reason = "internal assertion")]
     pub fn new() -> Self {
         Self {
             pvd: {
@@ -46,31 +47,67 @@ impl<'a> ImageBuilder<'a> {
         }
     }
 
+    /// Sets this image's "System Identifier".
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the identifier is malformed
     pub fn system_id(&mut self, s: &str) -> anyhow::Result<&mut Self> {
         self.pvd.system_id = AStr::from_str(s)?;
         Ok(self)
     }
 
+    /// Sets this image's "Volume Identifier".
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the identifier is malformed
     pub fn volume_id(&mut self, s: &str) -> anyhow::Result<&mut Self> {
         self.pvd.volume_id = DStr::from_str(s)?;
         Ok(self)
     }
 
+    /// Sets this image's "Volume Set Identifier".
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the identifier is malformed
     pub fn volume_set_id(&mut self, s: &str) -> anyhow::Result<&mut Self> {
         self.pvd.volume_set_id = DStr::from_str(s)?;
         Ok(self)
     }
 
+    /// Sets this image's "Publisher Identifier".
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the identifier is malformed
     pub fn publisher_id(&mut self, s: &str) -> anyhow::Result<&mut Self> {
         self.pvd.publisher_id = AStr::from_str(s)?;
         Ok(self)
     }
 
+    /// Sets this image's "Data Preparer Identifier".
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the identifier is malformed
     pub fn data_preparer_id(&mut self, s: &str) -> anyhow::Result<&mut Self> {
         self.pvd.data_preparer_id = AStr::from_str(s)?;
         Ok(self)
     }
 
+    /// Sets this image's "Application Identifier".
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - the identifier is malformed
     pub fn application_id(&mut self, s: &str) -> anyhow::Result<&mut Self> {
         self.pvd.application_id = AStr::from_str(s)?;
         Ok(self)
@@ -90,6 +127,13 @@ impl<'a> ImageBuilder<'a> {
         self
     }
 
+    /// Finish building the image and emit it to the provided writer.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` when
+    /// - building the image fails
+    /// - writing the image to disk fails
     pub fn finish(self, writer: impl io::Write + io::Seek) -> io::Result<()> {
         let mut layout = Layout::flatten(self.root);
         let mut boot = self.boot;

--- a/lib/ecma-119/src/eltorito/parse.rs
+++ b/lib/ecma-119/src/eltorito/parse.rs
@@ -7,6 +7,7 @@
 
 use core::cmp;
 
+use anyhow::Context;
 use fallible_iterator::FallibleIterator;
 use zerocopy::IntoBytes;
 
@@ -45,7 +46,7 @@ impl BootRecord {
             )
         })?;
         let len = u32::try_from(cmp::min(remaining, 6 * SECTOR_SIZE))
-            .expect("len bounded above by 6 * SECTOR_SIZE");
+            .context("len bounded above by 6 * SECTOR_SIZE")?;
 
         let parser = Parser::from_lba_and_len(img.data, lba, len, img.strict)?;
 

--- a/lib/ecma-119/src/raw/mod.rs
+++ b/lib/ecma-119/src/raw/mod.rs
@@ -19,4 +19,4 @@ pub use volume::*;
 
 pub const SECTOR_SIZE: usize = 2048;
 /// El Torito uses 512-byte "virtual" sectors for boot image sector counts.
-pub const VIRTUAL_SECTOR_SIZE: usize = 512;
+pub const VIRTUAL_SECTOR_SIZE: u32 = 512;

--- a/lib/ecma-119/tests/roundtrip.rs
+++ b/lib/ecma-119/tests/roundtrip.rs
@@ -31,13 +31,13 @@ const BOOT_CATALOG_LBA: usize = 19;
 
 fn build_image(with_boot: bool) -> Vec<u8> {
     let mut root = DirBuilder::new();
-    root.add_file("HELLO.TXT;1", FileBuilder::from_bytes(HELLO))
+    root.add_file("HELLO.TXT;1", FileBuilder::from_bytes(HELLO).unwrap())
         .unwrap();
-    root.add_file("EMPTY.BIN;1", FileBuilder::from_bytes(&[][..]))
+    root.add_file("EMPTY.BIN;1", FileBuilder::from_bytes(&[][..]).unwrap())
         .unwrap();
 
     let mut sub = DirBuilder::new();
-    sub.add_file("DEEP.TXT;1", FileBuilder::from_bytes(DEEP))
+    sub.add_file("DEEP.TXT;1", FileBuilder::from_bytes(DEEP).unwrap())
         .unwrap();
     root.add_subdir("SUB", sub).unwrap();
 
@@ -45,7 +45,7 @@ fn build_image(with_boot: bool) -> Vec<u8> {
         let mut efi_dir = DirBuilder::new();
         let mut boot_dir = DirBuilder::new();
         boot_dir
-            .add_file("BOOTAA64.EFI;1", FileBuilder::from_bytes(EFI_STUB))
+            .add_file("BOOTAA64.EFI;1", FileBuilder::from_bytes(EFI_STUB).unwrap())
             .unwrap();
         efi_dir.add_subdir("BOOT", boot_dir).unwrap();
         root.add_subdir("EFI", efi_dir).unwrap();
@@ -162,8 +162,11 @@ fn explicit_load_size_overrides_auto() {
     let mut root = DirBuilder::new();
     let mut efi = DirBuilder::new();
     let mut boot = DirBuilder::new();
-    boot.add_file("BOOTAA64.EFI;1", FileBuilder::from_bytes(&b"x"[..]))
-        .unwrap();
+    boot.add_file(
+        "BOOTAA64.EFI;1",
+        FileBuilder::from_bytes(&b"x"[..]).unwrap(),
+    )
+    .unwrap();
     efi.add_subdir("BOOT", boot).unwrap();
     root.add_subdir("EFI", efi).unwrap();
 

--- a/lib/range-tree/benches/comparisons.rs
+++ b/lib/range-tree/benches/comparisons.rs
@@ -1,6 +1,9 @@
 #![feature(allocator_api)]
 #![feature(new_range_api)]
-
+#![expect(
+    clippy::undocumented_unsafe_blocks,
+    reason = "benchmarks are not that important"
+)]
 use std::collections::{BTreeMap, Bound};
 use std::hint::black_box;
 use std::mem::offset_of;
@@ -113,7 +116,7 @@ fn bench_insertions(c: &mut Criterion) {
     let mut group = c.benchmark_group("Insertions");
     for num_entries in (10..1000).step_by(100) {
         let mut ranges = (1..num_entries * 2 * MIB)
-            .step_by(2 * MIB as usize)
+            .step_by(usize::try_from(2 * MIB).unwrap())
             .map(|base| base..base + rng.sample(Uniform::new(0, 2 * MIB).unwrap()))
             .collect::<Vec<_>>();
 
@@ -188,7 +191,7 @@ fn bench_lookups_hits(c: &mut Criterion) {
     let mut group = c.benchmark_group("Lookups Hits");
     for num_entries in (10..1000).step_by(100) {
         let mut ranges = (1..num_entries * 2 * MIB)
-            .step_by(2 * MIB as usize)
+            .step_by(usize::try_from(2 * MIB).unwrap())
             .map(|base| base..base + rng.sample(Uniform::new(1, 2 * MIB).unwrap()))
             .collect::<Vec<_>>();
 
@@ -196,7 +199,7 @@ fn bench_lookups_hits(c: &mut Criterion) {
 
         let mut lookups = vec![];
         for range in &ranges {
-            for _ in 0..1_000 {
+            for _ in 0..1_000_usize {
                 let lookup = rng.sample(Uniform::new(range.start, range.end).unwrap());
                 lookups.push(lookup);
             }
@@ -273,7 +276,7 @@ fn bench_lookups_hits(c: &mut Criterion) {
 //     let mut group = c.benchmark_group("Lookups Misses");
 //     for num_entries in (10..10_000).step_by(1000) {
 //         let mut ranges = (0..num_entries * 2 * MIB)
-//             .step_by(2 * MIB as usize)
+//             .step_by(usize::try_from(2 * MIB).unwrap())
 //             .map(|base| base..base + rng.sample(Uniform::new(0, 2 * MIB).unwrap()))
 //             .collect::<Vec<_>>();
 //

--- a/lib/range-tree/fuzz/range_tree.rs
+++ b/lib/range-tree/fuzz/range_tree.rs
@@ -121,9 +121,8 @@ enum ValueType {
 fn bounds_reversed<T: Ord>(start: Bound<T>, end: Bound<T>) -> bool {
     match (start, end) {
         (Bound::Unbounded, _) | (_, Bound::Unbounded) => false,
-        (Bound::Included(s), Bound::Included(e))
-        | (Bound::Included(s), Bound::Excluded(e))
-        | (Bound::Excluded(s), Bound::Included(e)) => s > e,
+        (Bound::Included(s) | Bound::Excluded(s), Bound::Included(e))
+        | (Bound::Included(s), Bound::Excluded(e)) => s > e,
         (Bound::Excluded(s), Bound::Excluded(e)) => s >= e,
     }
 }
@@ -228,7 +227,7 @@ fn run<
                         expected_gaps.push((Bound::Included(end), Bound::Unbounded));
                     }
                 } else {
-                    expected_gaps.push((Bound::Unbounded, Bound::Unbounded))
+                    expected_gaps.push((Bound::Unbounded, Bound::Unbounded));
                 }
 
                 // filter out all empty ranges
@@ -347,7 +346,7 @@ fn run<
                     assert_eq!(entries, vec[index..]);
                     assert_eq!(
                         cursor.entry().map(|(k, &v)| (k, v)),
-                        vec.get(index).cloned()
+                        vec.get(index).copied()
                     );
                     assert_eq!(cursor.is_end(), index == vec.len());
                 }

--- a/lib/range-tree/src/simd/avx2.rs
+++ b/lib/range-tree/src/simd/avx2.rs
@@ -1,3 +1,17 @@
+#![allow(
+    clippy::cast_ptr_alignment,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    reason = "AVX2 intrinsics: `_mm256_load_si256` requires 32-byte \
+              alignment, which callers uphold via the aligned `pivots` \
+              buffer; `_mm256_movemask_epi8` returns a full-width i32 \
+              bitmask reinterpreted as u32 via `count_ones`; \
+              signed/unsigned bitcasts on integer lanes are required by \
+              the signed-compare intrinsics and by the `i*::MIN`-based \
+              BIAS constants."
+)]
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]

--- a/lib/range-tree/src/simd/avx512.rs
+++ b/lib/range-tree/src/simd/avx512.rs
@@ -1,3 +1,16 @@
+#![allow(
+    clippy::cast_ptr_alignment,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    reason = "AVX-512 intrinsics: `_mm512_load_si512` requires 64-byte \
+              alignment, which callers uphold via the aligned `pivots` \
+              buffer; k-mask register results from `_mm512_kunpack*` are \
+              reinterpreted into u64/u32/u16 of the same bit width; \
+              signed/unsigned bitcasts on integer lanes are required by \
+              the signed-compare intrinsics."
+)]
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]

--- a/lib/range-tree/src/simd/sse2.rs
+++ b/lib/range-tree/src/simd/sse2.rs
@@ -1,3 +1,16 @@
+#![allow(
+    clippy::cast_ptr_alignment,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    reason = "SSE2 intrinsics: `_mm_load_si128` requires 16-byte alignment, \
+              which callers uphold via the aligned `pivots` buffer; \
+              `_mm_movemask_epi8` returns an i32 with only the low 16 bits \
+              set, so `as u16` is an exact trim; signed/unsigned bitcasts \
+              on integer lanes are required by the signed-compare \
+              intrinsics and by the `i*::MIN`-based BIAS constants."
+)]
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]

--- a/lib/range-tree/src/simd/sse2_popcnt.rs
+++ b/lib/range-tree/src/simd/sse2_popcnt.rs
@@ -1,3 +1,16 @@
+#![allow(
+    clippy::cast_ptr_alignment,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    reason = "SSE2 intrinsics: `_mm_load_si128` requires 16-byte alignment, \
+              which callers uphold via the aligned `pivots` buffer; \
+              `_mm_movemask_epi8` returns an i32 with only the low 16 bits \
+              set, so `as u16` is an exact trim; signed/unsigned bitcasts \
+              on integer lanes are required by the signed-compare \
+              intrinsics and by the `i*::MIN`-based BIAS constants."
+)]
+
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]

--- a/lib/riscv/src/lib.rs
+++ b/lib/riscv/src/lib.rs
@@ -9,10 +9,10 @@
 
 #![cfg_attr(not(test), no_std)]
 #![allow(edition_2024_expr_fragment_specifier, reason = "vetted usage")]
-#![cfg_attr(
-    not(any(target_arch = "riscv32", target_arch = "riscv64")),
-    allow(unused)
-)]
+// #![cfg_attr(
+//     not(any(target_arch = "riscv32", target_arch = "riscv64")),
+//     allow(unused)
+// )]
 
 mod error;
 pub mod extensions;

--- a/lib/spin/src/rw_lock.rs
+++ b/lib/spin/src/rw_lock.rs
@@ -106,17 +106,31 @@ pub struct RwLockUpgradableGuard<'a, T: 'a + ?Sized> {
     inner: &'a RwLock<T>,
 }
 
-// Same unsafe impls as `std::sync::RwLock`
+// Safety: spinlocks can be unlocked from any thread, therefore `RwLock` is `Send` as long as `T` is `Send`.
 unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
+// Safety: `RwLock` (by design) can be read from multiple threads which requires `T: Sync`.
+// It also (again by design) hands out `&mut T` so other threads _could_ `mem::take` the value.
+// This means `T` must be safe to move to a different thread, hence `T: Send`.
 unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
 
-unsafe impl<T: ?Sized + Send + Sync> Send for RwLockWriteGuard<'_, T> {}
+// Safety: sending an `RwLockWriteGuard` to another thread gives that thread `&mut T`, requiring `T: Send`.
+unsafe impl<T: ?Sized + Send> Send for RwLockWriteGuard<'_, T> {}
+// Safety: `&RwLockWriteGuard` derefs to `&T`, requiring `T: Sync`. The extra `T: Send` matches
+// `RwLock`'s `Sync` bound for consistency and isn't strictly required by the `Sync` impl alone.
 unsafe impl<T: ?Sized + Send + Sync> Sync for RwLockWriteGuard<'_, T> {}
 
+// Safety: `RwLockReadGuard` only ever hands out `&T`, so it is `Send` iff `T: Sync`
+// (other threads only ever observe `&T`, never own or mutate it).
 unsafe impl<T: ?Sized + Sync> Send for RwLockReadGuard<'_, T> {}
+// Safety: `&RwLockReadGuard` derefs to `&T`, so it is `Sync` iff `T: Sync`.
 unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
 
+// Safety: sending an `RwLockUpgradableGuard` to another thread gives that thread `&T` directly
+// (`T: Sync`) and the ability to upgrade to `&mut T` (`T: Send`). Both bounds are load-bearing here,
+// unlike `RwLockWriteGuard` where `Sync` is only required for symmetry.
 unsafe impl<T: ?Sized + Send + Sync> Send for RwLockUpgradableGuard<'_, T> {}
+// Safety: `&RwLockUpgradableGuard` derefs to `&T` (`T: Sync`), and because the guard can be upgraded
+// into a `RwLockWriteGuard` it inherits the upgrade requirement of `T: Send`.
 unsafe impl<T: ?Sized + Send + Sync> Sync for RwLockUpgradableGuard<'_, T> {}
 
 impl<T> RwLock<T> {
@@ -532,6 +546,11 @@ impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
     ///     Err(upgradeable) => /* upgrade unsuccessful */ (),
     /// };
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)`, with the upgradable guard returned unchanged, if any other readers
+    /// are currently holding the lock.
     #[inline]
     pub fn try_upgrade(self) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
         self.try_upgrade_internal(true)
@@ -541,6 +560,14 @@ impl<'rwlock, T: ?Sized> RwLockUpgradableGuard<'rwlock, T> {
     ///
     /// Unlike [`RwLockUpgradableGuard::try_upgrade`], this function is allowed to spuriously fail even when upgrading
     /// would otherwise succeed, which can result in more efficient code on some platforms.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)`, with the upgradable guard returned unchanged, if either:
+    /// - other readers are currently holding the lock, or
+    /// - the underlying compare-exchange spuriously failed (allowed by this variant — see above).
+    ///
+    /// For the non-spurious variant, see [`Self::try_upgrade`].
     #[inline]
     pub fn try_upgrade_weak(self) -> Result<RwLockWriteGuard<'rwlock, T>, Self> {
         self.try_upgrade_internal(false)

--- a/lib/test/macros/src/lib.rs
+++ b/lib/test/macros/src/lib.rs
@@ -11,6 +11,7 @@ use quote::{format_ident, quote};
 use syn::{Attribute, Error, ItemFn, Path, parse_macro_input, parse_quote};
 
 #[proc_macro_attribute]
+#[expect(clippy::missing_panics_doc, reason = "internal assertion")]
 pub fn test(_args: TokenStream, item: TokenStream) -> TokenStream {
     let mut func = parse_macro_input!(item as ItemFn);
 

--- a/lib/unwind/src/arch/aarch64.rs
+++ b/lib/unwind/src/arch/aarch64.rs
@@ -224,7 +224,7 @@ macro_rules! restore {
 /// **without** performing any sort of validation. The caller must ensure at least:
 /// 1. `SP` `regs.sp` is a valid, correctly-aligned, writable stack address.
 pub unsafe fn restore_context(ctx: &Registers) -> ! {
-    // Safety: inline assembly
+    // Safety: ensured by caller
     unsafe {
         cfg_if! {
             if #[cfg(target_feature = "neon")] {

--- a/lib/unwind/src/arch/riscv64.rs
+++ b/lib/unwind/src/arch/riscv64.rs
@@ -265,7 +265,7 @@ macro_rules! restore {
 /// **without** performing any sort of validation. The caller must ensure at least:
 /// 1. `SP` `regs.gp[2]` is a valid, correctly-aligned, writable stack address.
 pub unsafe fn restore_context(ctx: &Registers) -> ! {
-    // Safety: inline assembly
+    // Safety: ensured by caller
     unsafe {
         cfg_if! {
             if #[cfg(target_feature = "d")] {

--- a/lib/unwind/src/arch/x86_64.rs
+++ b/lib/unwind/src/arch/x86_64.rs
@@ -127,6 +127,7 @@ pub extern "C-unwind" fn save_context(f: extern "C" fn(&mut Registers, *mut ()),
 /// 1. `RSP` `regs.gp[7]` is a valid, correctly-aligned, writable stack address.
 /// 2. `RA` `regs.ra` is a valid, correctly-aligned, code pointer.
 pub unsafe fn restore_context(regs: &Registers) -> ! {
+    // Safety: ensured by caller
     unsafe {
         core::arch::asm!(
             "

--- a/sys/async/benches/spawn.rs
+++ b/sys/async/benches/spawn.rs
@@ -30,7 +30,7 @@ fn single_threaded_spawn(c: &mut Criterion) {
                 let h = EXEC.try_spawn(work()).unwrap();
                 assert_eq!(h.await.unwrap(), 2);
             }))
-        })
+        });
     });
 }
 
@@ -44,7 +44,7 @@ fn single_threaded_spawn10(c: &mut Criterion) {
         b.iter(|| {
             kasync::test_util::block_on(worker.run(async {
                 let mut handles = Vec::with_capacity(10);
-                for _ in 0..10 {
+                for _ in 0..10_usize {
                     let h = EXEC.build_task().try_spawn(work()).unwrap();
                     handles.push(h);
                 }
@@ -54,7 +54,7 @@ fn single_threaded_spawn10(c: &mut Criterion) {
                 }
             }))
             .unwrap();
-        })
+        });
     });
 }
 

--- a/sys/async/src/block_on.rs
+++ b/sys/async/src/block_on.rs
@@ -38,10 +38,20 @@ pub trait Park {
     /// Block the current thread until [`unpark`](Self::unpark) is called, or
     /// until a previously-issued `unpark` token is consumed. Spurious
     /// returns are permitted; [`block_on`] re-checks state before re-parking.
+    ///
+    /// # Errors
+    ///
+    /// Return `Self::Error` when parking the thread fails.
+    /// The returned error should contain more information about the reason.
     fn park(&self) -> Result<(), Self::Error>;
 
     /// Wake the thread that owns this `Park`, even if it is not currently
     /// parked. Calls that precede a matching `park` must be remembered.
+    ///
+    /// # Errors
+    ///
+    /// Return `Self::Error` when unparking the target thread fails.
+    /// The returned error should contain more information about the reason.
     fn unpark(&self) -> Result<(), Self::Error>;
 }
 
@@ -153,6 +163,11 @@ impl<P: Park + Sync + 'static> Notify<P> {
 ///
 /// Caller must not nest `block_on` calls on the same `notify`: the inner
 /// `drain()` would swallow the outer's pending wake.
+///
+/// # Errors
+///
+/// Returns `P::Error` when blocking the current thread fails.
+/// The returned error contains more information about the reason.
 // NB: we require the static lifetime here so we can safely turn this into a ptr in `waker_ref`.
 // instead of forcing callers into an `Arc` allocation they can now simply use `cpu_local!`
 pub fn block_on<P: Park + Sync + 'static, F: Future>(

--- a/sys/async/src/test_util.rs
+++ b/sys/async/src/test_util.rs
@@ -52,5 +52,8 @@ crate::loom::thread_local! {
 }
 
 pub fn block_on<F: Future>(f: F) -> F::Output {
-    NOTIFY.with(|notify| crate::block_on::block_on(*notify, f).unwrap())
+    NOTIFY.with(|notify| {
+        // Safety: `StdPark::Error` is infallible
+        unsafe { crate::block_on::block_on(*notify, f).unwrap_unchecked() }
+    })
 }

--- a/sys/kernel/src/arch/riscv64/trap_handler.rs
+++ b/sys/kernel/src/arch/riscv64/trap_handler.rs
@@ -514,7 +514,7 @@ mod tests {
     #[test::test]
     async fn repeated_wasm_traps() {
         let mut ctx = WastContext::new_default().unwrap();
-        for i in 0..5 {
+        for i in 0..5_usize {
             ctx.run(
                 "repeated_wasm_traps",
                 include_str!("../../../wast/tests/trap.wast"),

--- a/sys/kernel/src/mem/frame_alloc/frame.rs
+++ b/sys/kernel/src/mem/frame_alloc/frame.rs
@@ -249,7 +249,7 @@ impl FrameInfo {
     /// Private accessor used in `frame_alloc/arena.rs` to mark the frame
     /// that was previously "wired" as free before we push it into the buddy allocator freelist
     pub(crate) fn mark_as_free_for_freelist(&self) {
-        self.refcount.store(0, Ordering::Release)
+        self.refcount.store(0, Ordering::Release);
     }
 
     /// The physical address of this frame.

--- a/sys/kernel/src/tests/args.rs
+++ b/sys/kernel/src/tests/args.rs
@@ -22,6 +22,7 @@ pub const FILTER: Flag =
     Flag::new_string("--filter").with_help("substring filter applied to test idents");
 
 #[derive(Default, Debug)]
+#[expect(clippy::struct_excessive_bools, reason = "its fiiiine")]
 pub struct Arguments<'a> {
     pub test_name: Option<&'a str>,
     pub list: bool,

--- a/sys/kernel/src/tests/mod.rs
+++ b/sys/kernel/src/tests/mod.rs
@@ -158,9 +158,15 @@ pub fn all_tests() -> &'static [Test] {
     static mut LINKME_PLEASE: [Test; 0] = [];
 
     unsafe extern "C" {
-        #[allow(improper_ctypes)]
+        #[expect(
+            improper_ctypes,
+            reason = "These are linker-defined markers, not real C externs. We only take their addresses."
+        )]
         static __start_k23_tests: Test;
-        #[allow(improper_ctypes)]
+        #[expect(
+            improper_ctypes,
+            reason = "These are linker-defined markers, not real C externs. We only take their addresses."
+        )]
         static __stop_k23_tests: Test;
     }
 
@@ -169,12 +175,15 @@ pub fn all_tests() -> &'static [Test] {
 
     let stride = size_of::<Test>();
     let byte_offset = stop as usize - start as usize;
-    let len = match byte_offset.checked_div(stride) {
-        Some(len) => len,
-        // The #[distributed_slice] call checks `size_of::<T>() > 0` before
-        // using the unsafe `private_new`.
-        None => unsafe { hint::unreachable_unchecked() },
+
+    let Some(len) = byte_offset.checked_div(stride) else {
+        // Safety: `byte_offset.checked_div(stride)` returns `None` only when `stride == 0`,
+        // i.e. `size_of::<Test>() == 0`. The `#[distributed_slice]` macro asserts `size_of::<T>() > 0`
+        // so this branch is unreachable.
+        unsafe { hint::unreachable_unchecked() }
     };
 
+    // Safety: the linker populates `k23_tests` with properly aligned, initialized `Test` entries
+    // (registered by `#[ktest::test]`).
     unsafe { slice::from_raw_parts(start, len) }
 }

--- a/sys/kernel/src/tests/printer.rs
+++ b/sys/kernel/src/tests/printer.rs
@@ -46,7 +46,7 @@ impl Printer {
                 // `print_single_outcome` prints one character.
             }
             FormatSetting::Json => {
-                tracing::info!(r#"{{ "type": "test", "event": "started", "name": "{ident}" }}"#,)
+                tracing::info!(r#"{{ "type": "test", "event": "started", "name": "{ident}" }}"#,);
             }
         }
     }
@@ -139,7 +139,7 @@ impl Printer {
                     conclusion.num_ignored.load(Ordering::Acquire),
                     conclusion.num_measured.load(Ordering::Acquire),
                     conclusion.num_filtered_out.load(Ordering::Acquire),
-                )
+                );
             }
         }
     }

--- a/sys/kernel/src/tests/wast.rs
+++ b/sys/kernel/src/tests/wast.rs
@@ -79,16 +79,16 @@ impl WastContext {
 
         linker.func_wrap("spectest", "print", || {})?;
         linker.func_wrap("spectest", "print_i32", move |val: i32| {
-            tracing::debug!("{val}: i32")
+            tracing::debug!("{val}: i32");
         })?;
         linker.func_wrap("spectest", "print_i64", move |val: i64| {
-            tracing::debug!("{val}: i64")
+            tracing::debug!("{val}: i64");
         })?;
         linker.func_wrap("spectest", "print_f32", move |val: f32| {
-            tracing::debug!("{val}: f32")
+            tracing::debug!("{val}: f32");
         })?;
         linker.func_wrap("spectest", "print_f64", move |val: f64| {
-            tracing::debug!("{val}: f64")
+            tracing::debug!("{val}: f64");
         })?;
         linker.func_wrap("spectest", "print_i32_f32", move |i: i32, f: f32| {
             tracing::debug!("{i}: i32");
@@ -396,14 +396,7 @@ impl WastContext {
             bail!("expected {} results found {}", results.len(), values.len());
         }
         for (v, e) in values.iter().zip(results) {
-            let e = match e {
-                WastRet::Core(core) => core,
-                // WastRet::Component(_) => {
-                //     bail!("expected component value found core value")
-                // }
-                _ => unreachable!(),
-            };
-
+            let WastRet::Core(e) = e else { unreachable!() };
             let inner = self.inner_mut();
             match_val(&mut inner.store, v, e)?;
         }
@@ -512,7 +505,7 @@ pub fn match_val(store: &Store<()>, actual: &Val, expected: &WastRetCore) -> any
 
         // Note that these float comparisons are comparing bits, not float
         // values, so we're testing for bit-for-bit equivalence
-        (Val::F32(a), WastRetCore::F32(b)) => match_f32(*a, b),
+        (Val::F32(a), WastRetCore::F32(b)) => match_f32(*a, *b),
         (Val::F64(a), WastRetCore::F64(b)) => match_f64(*a, b),
         (Val::V128(a), WastRetCore::V128(b)) => match_v128(*a, b),
 
@@ -587,7 +580,7 @@ where
     }
 }
 
-pub fn match_f32(actual: u32, expected: &NanPattern<F32>) -> anyhow::Result<()> {
+pub fn match_f32(actual: u32, expected: NanPattern<F32>) -> anyhow::Result<()> {
     match expected {
         // Check if an f32 (as u32 bits to avoid possible quieting when moving values in registers, e.g.
         // https://developer.arm.com/documentation/ddi0344/i/neon-and-vfp-programmers-model/modes-of-operation/default-nan-mode?lang=en)
@@ -814,13 +807,21 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> anyhow::Result<()> {
         }
         V128Pattern::F32x4(expected) => {
             for (i, expected) in expected.iter().enumerate() {
+                #[expect(
+                    clippy::cast_sign_loss,
+                    reason = "reinterpreting f32 bit pattern via the signed lane accessor"
+                )]
                 let a = extract_lane_as_i32(actual, i) as u32;
-                match_f32(a, expected).with_context(|| format!("difference in lane {i}"))?;
+                match_f32(a, *expected).with_context(|| format!("difference in lane {i}"))?;
             }
             Ok(())
         }
         V128Pattern::F64x2(expected) => {
             for (i, expected) in expected.iter().enumerate() {
+                #[expect(
+                    clippy::cast_sign_loss,
+                    reason = "reinterpreting f64 bit pattern via the signed lane accessor"
+                )]
                 let a = extract_lane_as_i64(actual, i) as u64;
                 match_f64(a, expected).with_context(|| format!("difference in lane {i}"))?;
             }
@@ -829,18 +830,34 @@ fn match_v128(actual: u128, expected: &V128Pattern) -> anyhow::Result<()> {
     }
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "extracting low bits of a v128 lane"
+)]
 fn extract_lane_as_i8(bytes: u128, lane: usize) -> i8 {
     (bytes >> (lane * 8)) as i8
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "extracting low bits of a v128 lane"
+)]
 fn extract_lane_as_i16(bytes: u128, lane: usize) -> i16 {
     (bytes >> (lane * 16)) as i16
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "extracting low bits of a v128 lane"
+)]
 fn extract_lane_as_i32(bytes: u128, lane: usize) -> i32 {
     (bytes >> (lane * 32)) as i32
 }
 
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "extracting low bits of a v128 lane"
+)]
 fn extract_lane_as_i64(bytes: u128, lane: usize) -> i64 {
     (bytes >> (lane * 64)) as i64
 }

--- a/sys/loader/api/src/info.rs
+++ b/sys/loader/api/src/info.rs
@@ -47,7 +47,11 @@ pub struct BootInfo {
 
     pub rng_seed: [u8; 32],
 }
+// Safety: `BootInfo` is handed off from the loader to the kernel, which then has exclusive
+// ownership. Pointers inside `MemoryRegions` are not aliased when the loader is gone.
 unsafe impl Send for BootInfo {}
+// Safety: `BootInfo` is handed off from the loader to the kernel, which then has exclusive
+// ownership. Pointers inside `MemoryRegions` are not aliased when the loader is gone.
 unsafe impl Sync for BootInfo {}
 
 impl BootInfo {
@@ -58,12 +62,12 @@ impl BootInfo {
         Self {
             memory_regions,
             cpu_mask: 0,
-            physical_address_offset: Default::default(),
-            physical_memory_map: Default::default(),
+            physical_address_offset: VirtualAddress::default(),
+            physical_memory_map: Range::default(),
             tls_template: None,
-            kernel_virt: Default::default(),
-            kernel_phys: Default::default(),
-            kernel_debuginfo_phys: Default::default(),
+            kernel_virt: Range::default(),
+            kernel_phys: Range::default(),
+            kernel_debuginfo_phys: Range::default(),
             rng_seed: [0; 32],
         }
     }
@@ -74,7 +78,8 @@ impl BootInfo {
 ///
 /// This type implements the [`Deref`][core::ops::Deref] and [`DerefMut`][core::ops::DerefMut]
 /// traits, so it can be used like a `&mut [MemoryRegion]` slice. It also implements [`From`]
-/// and [`Into`] for easy conversions from and to `&'static mut [MemoryRegion]`.
+/// and [`Into`] for easy conversions from and to `&'static mut [MemoryRegion]`. This is the
+/// ONLY way to construct it: `(ptr, len)` must always describe a valid `&'static mut [MemoryRegion]`.
 #[derive(Debug)]
 #[repr(C)]
 pub struct MemoryRegions {
@@ -86,12 +91,14 @@ impl Deref for MemoryRegions {
     type Target = [MemoryRegion];
 
     fn deref(&self) -> &Self::Target {
+        // Safety: see invariant on `MemoryRegions`.
         unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 }
 
 impl DerefMut for MemoryRegions {
     fn deref_mut(&mut self) -> &mut Self::Target {
+        // Safety: see invariant on `MemoryRegions`.
         unsafe { slice::from_raw_parts_mut(self.ptr, self.len) }
     }
 }
@@ -107,6 +114,8 @@ impl From<&'static mut [MemoryRegion]> for MemoryRegions {
 
 impl From<MemoryRegions> for &'static mut [MemoryRegion] {
     fn from(regions: MemoryRegions) -> &'static mut [MemoryRegion] {
+        // Safety: `MemoryRegions` is created from `&'static mut [MemoryRegion]`
+        // we can therefore always reconstitute the original type from its parts.
         unsafe { slice::from_raw_parts_mut(regions.ptr, regions.len) }
     }
 }

--- a/sys/loader/api/src/lib.rs
+++ b/sys/loader/api/src/lib.rs
@@ -6,7 +6,11 @@
 // copied, modified, or distributed except according to those terms.
 
 #![no_std]
-#![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
+#![allow(
+    clippy::doc_markdown,
+    clippy::module_name_repetitions,
+    reason = "stylistic noise"
+)]
 
 mod config;
 mod info;


### PR DESCRIPTION
Reintroduces the deny/allow set from the pre-buck2 [workspace.lints.clippy] table, applied via the rust toolchain's deny_lints/allow_lints. Same treatment for tests, fuzz, loom, and production builds.

Also applies fixes so the now enabled lint actually passes.