### PR TITLE
fix(toolchains): bake libstdc++ rpath via flake-provided gcc lib

### DIFF
--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -45,6 +45,13 @@ flake.package(
 )
 
 flake.package(
+    name = "cxx_runtime_lib",
+    package = "cxxRuntimeLib",
+    output = "lib",
+    path = "root//:flake",
+)
+
+flake.package(
     name = "mdbook",
     binary = "mdbook",
     package = "mdbook",
@@ -204,6 +211,10 @@ clang_toolchain(
     linker_dispatch = select({
         "prelude//os:none": "direct",
         "DEFAULT": "driver",
+    }),
+    cxx_runtime_lib = select({
+        "prelude//os:none": None,
+        "DEFAULT": ":cxx_runtime_lib",
     }),
     c_flags = select({
         "constraints//:opt-level[0]": ["-O0"],

--- a/build/toolchains/cxx.bzl
+++ b/build/toolchains/cxx.bzl
@@ -49,6 +49,13 @@ def _clang_toolchain(ctx: AnalysisContext) -> list[Provider]:
         additional_linker_flags = [
             cmd_args(ctx.attrs.linker[RunInfo].args, format = "--ld-path={}"),
         ]
+
+        # --ld-path bypasses clang's bintools-wrapper, so bake an rpath to
+        # the C++ runtime ourselves.
+        if ctx.attrs.cxx_runtime_lib:
+            additional_linker_flags.append(
+                cmd_args(ctx.attrs.cxx_runtime_lib[DefaultInfo].default_outputs[0], format = "-Wl,-rpath,{}/lib"),
+            )
     else:
         # Invoke the linker directly. Use this for freestanding targets whose
         # rustc target spec sets linker-flavor=gnu-lld (raw lld flags only).
@@ -146,6 +153,7 @@ clang_toolchain = rule(
         "clang": attrs.exec_dep(),
         "linker": attrs.exec_dep(),
         "linker_dispatch": attrs.enum(["direct", "driver"]),
+        "cxx_runtime_lib": attrs.option(attrs.dep(), default = None),
         "_target_os_type": buck.target_os_type_arg(),
     },
     doc = """

--- a/flake.nix
+++ b/flake.nix
@@ -42,9 +42,14 @@
         pkgs:
         let
           rustToolchain = with pkgs; rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+          # libstdc++ (linux) / libc++ (darwin) shared by stdenv's cc.
+          # The cxx toolchain bakes its lib dir into binaries as -rpath
+          # so they can find it at runtime.
+          cxxRuntimeLib = pkgs.stdenv.cc.cc.lib;
         in
         {
-          inherit rustToolchain;
+          inherit rustToolchain cxxRuntimeLib;
           inherit (pkgs)
             bash
             python3


### PR DESCRIPTION
Commit 6cceafd6 made the cxx toolchain link via clang with `--ld-path=<lld_20>/bin/ld.lld`, pinning the linker hermetically. But clang's driver -- when used with `-stdlib=libstdc++` -- emits `-lstdc++` resolved through nix's `--gcc-toolchain`, with no `-rpath` for the runtime location of nix's `libstdc++.so.6`. Before that change clang dispatched to the host's ld via PATH search, so the host's libstdc++ on `/usr/lib` satisfied the binary's NEEDED entry by accident.

Expose `pkgs.stdenv.cc.cc.lib` as a flake package, plumb it through `clang_toolchain` as a new `cxx_runtime_lib` attr, and -- on linux only -- inject `-Wl,-rpath,<gcc-lib>/lib` into the link flags so the produced binary can resolve nix's libstdc++ at runtime.