### PR TITLE
test(mem-core): make test Memory Miri-compatible

### DIFF
--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -18,7 +18,7 @@ flake.package(
 flake.package(
     name = "rust_toolchain",
     package = "rustToolchain",
-    binaries = ["rustc", "rustdoc", "clippy-driver", "miri-driver", "rustfmt"],
+    binaries = ["rustc", "cargo", "cargo-miri", "rustdoc", "clippy-driver", "miri", "rustfmt"],
     path = "root//:flake",
 )
 
@@ -133,13 +133,31 @@ filegroup(
   srcs = [":rust_toolchain"],
 )
 
+# Miri can only interpret crates whose std/core/alloc carry full MIR
+# (`-Zalways-encode-mir`). `cargo miri setup` rebuilds the standard library
+# from the toolchain's bundled `rust-src` into a Miri-compatible sysroot.
+#
+# `cargo miri setup` shells out to cargo-miri, miri and rustc, so the flake
+# toolchain's bin dir goes on PATH. buck hands genrules repo-relative paths
+# and those subprocesses change directory, so $PWD absolutizes them.
+genrule(
+    name = "miri_sysroot",
+    out = "sysroot",
+    cmd = " && ".join([
+        'export CARGO_HOME="$TMP/cargo"',
+        'export PATH="$PWD/$(location :rust_toolchain)/bin:$PATH"',
+        'export MIRI_SYSROOT="$PWD/$OUT"',
+        '$(exe :rust_toolchain[cargo]) miri setup',
+    ]),
+)
+
 rust_toolchain(
     name = "rust",
     rustc = ":rust_toolchain[rustc]",
     clippy = ":rust_toolchain[clippy-driver]",
     rustdoc = ":rust_toolchain[rustdoc]",
-    miri_driver = ":rust_toolchain[miri-driver]",
-    miri_sysroot_path = ":rust_toolchain",
+    miri_driver = ":rust_toolchain[miri]",
+    miri_sysroot_path = ":miri_sysroot",
     default_edition = "2024",
     nightly_features = select({
         "constraints//:rust-std[bootstrap]": True,

--- a/lib/mem-core/src/test_utils/memory.rs
+++ b/lib/mem-core/src/test_utils/memory.rs
@@ -121,7 +121,8 @@ impl fmt::Debug for Memory {
 // Use mmap with MAP_NORESERVE on Unix so the kernel doesn't count test memory against
 // overcommit limits. Without this, proptests that allocate hundreds of GiB of virtual
 // address space fail on Linux systems with limited RAM and no swap.
-#[cfg(unix)]
+// Miri can't call `mmap`, so under `cfg(miri)` it uses the `System` branch below.
+#[cfg(all(unix, not(miri)))]
 fn host_alloc(layout: Layout) -> NonNull<[u8]> {
     let ptr = unsafe {
         libc::mmap(
@@ -141,19 +142,19 @@ fn host_alloc(layout: Layout) -> NonNull<[u8]> {
     .unwrap()
 }
 
-#[cfg(unix)]
+#[cfg(all(unix, not(miri)))]
 unsafe fn host_dealloc(region: NonNull<[u8]>, _layout: Layout) {
     let ret = unsafe { libc::munmap(region.as_ptr() as *mut libc::c_void, region.len()) };
     assert_eq!(ret, 0, "munmap failed");
 }
 
-#[cfg(not(unix))]
+#[cfg(any(not(unix), miri))]
 fn host_alloc(layout: Layout) -> NonNull<[u8]> {
     use std::alloc::Allocator;
     std::alloc::System.allocate(layout).unwrap()
 }
 
-#[cfg(not(unix))]
+#[cfg(any(not(unix), miri))]
 unsafe fn host_dealloc(region: NonNull<[u8]>, layout: Layout) {
     use std::alloc::Allocator;
     unsafe { std::alloc::System.deallocate(region.cast(), layout) }


### PR DESCRIPTION
`Memory::host_alloc` backs test physical memory with `libc::mmap` (MAP_NORESERVE) on Unix. Miri cannot call the foreign `mmap`/`munmap` functions, so any test constructing a `Machine` is uninterpretable under Miri — that is the entire L7/L8 unsafe table-walking suite, the riskiest code in the crate.

Select the existing `System`-allocator branch of host_alloc/host_dealloc under `cfg(miri)` so that code becomes visible to Miri. Implements tool 1 of lib/mem-core/TESTPLAN.md.