### PR TITLE
build: add LTO constraint, enable ThinLTO for release builds

### DIFF
--- a/.direnv/flake-profile
+++ b/.direnv/flake-profile
@@ -1,1 +1,0 @@
-flake-profile-2-link

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ target
 .DS_Store
 .local
 /qemu-monitor-socket
-.direnv
+.direnv/
 
 # buck2-change-detector files
 /base.jsonl

--- a/PACKAGE
+++ b/PACKAGE
@@ -12,12 +12,14 @@ set_cfg_constructor(
         debug = [
             "constraints//:opt-level[0]",
             "constraints//:debuginfo[full]",
-            "constraints//:strip[none]"
+            "constraints//:strip[none]",
+            "constraints//:lto[off]"
         ],
         release = [
             "constraints//:opt-level[3]",
             "constraints//:debuginfo[line-tables-only]",
-            "constraints//:strip[debuginfo]"
+            "constraints//:strip[debuginfo]",
+            "constraints//:lto[thin]"
         ],
     ),
     extra_data = struct(),

--- a/build/constraints/BUCK
+++ b/build/constraints/BUCK
@@ -77,3 +77,13 @@ constraint(
     default = "none",
     visibility = ["PUBLIC"],
 )
+
+constraint(
+    name = "lto",
+    values = [
+        "off",
+        "thin",
+    ],
+    default = "off",
+    visibility = ["PUBLIC"],
+)

--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -207,6 +207,9 @@ rust_toolchain(
         "constraints//:strip[debuginfo]": ["-Cstrip=debuginfo"],
         "constraints//:strip[symbols]": ["-Cstrip=symbols"],
     }) + select({
+        "constraints//:lto[off]": [],
+        "constraints//:lto[thin]": ["-Clto=thin"],
+    }) + select({
         "constraints//:sanitizer[address]": [
             "-Zsanitizer=address",
             "-Cpasses=sancov-module",

--- a/build/transitions.bzl
+++ b/build/transitions.bzl
@@ -8,6 +8,7 @@ _NAMED_SETTINGS = [
     "constraints//:rust-std",
     "constraints//:sanitizer",
     "constraints//:opt-level",
+    "constraints//:lto",
 ]
 
 def _cfg_name(cfg: ConfigurationInfo) -> str:


### PR DESCRIPTION
From my testing this cuts down the kernel release build from 2,82MiB to 1,19MiB so quite a sizable improvement!