### PR TITLE
fix(panic): replace tracing with log for early-boot panic handling

### DIFF
--- a/lib/panic-unwind/BUCK
+++ b/lib/panic-unwind/BUCK
@@ -6,7 +6,7 @@ rust_library(
         "//lib/spin:spin",
         "//lib/cpu-local:cpu-local",
         "//lib/abort:abort",
-        "//third-party:tracing",
+        "//third-party:log",
     ],
     visibility = ["PUBLIC"],
 )

--- a/lib/panic-unwind/src/hook.rs
+++ b/lib/panic-unwind/src/hook.rs
@@ -222,5 +222,5 @@ pub fn take_hook() -> fn(&PanicHookInfo<'_>) {
 
 /// The default panic handler.
 pub(crate) fn default_hook(info: &PanicHookInfo<'_>) {
-    tracing::error!("{info}");
+    log::error!("{info}");
 }

--- a/lib/panic-unwind/src/lib.rs
+++ b/lib/panic-unwind/src/lib.rs
@@ -77,11 +77,11 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     if let Some(must_abort) = panic_count::increase(true) {
         match must_abort {
             MustAbort::PanicInHook => {
-                tracing::error!("{info}");
+                log::error!("{info}");
             }
         }
 
-        tracing::error!("cpu panicked while processing panic. aborting.");
+        log::error!("cpu panicked while processing panic. aborting.");
         abort();
     }
 
@@ -104,7 +104,7 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
         // If a thread panics while running destructors or tries to unwind
         // through a nounwind function (e.g. extern "C") then we cannot continue
         // unwinding and have to abort immediately.
-        tracing::error!("cpu caused non-unwinding panic. aborting.");
+        log::error!("cpu caused non-unwinding panic. aborting.");
         abort();
     }
 
@@ -119,13 +119,13 @@ fn rust_panic(payload: Box<dyn Any + Send>, regs: unwind::Registers, pc: usize) 
     // Safety: `begin_unwind` will either return an error or not return at all
     match unsafe { unwind::begin_unwind_with(payload, regs, pc).unwrap_err_unchecked() } {
         unwind::Error::EndOfStack => {
-            tracing::error!(
+            log::error!(
                 "unwinding completed without finding a `catch_unwind` make sure there is at least a root level catch unwind wrapping the main function. aborting."
             );
             abort();
         }
         err => {
-            tracing::error!("unwinding failed with error {}. aborting.", err);
+            log::error!("unwinding failed with error {}. aborting.", err);
             abort()
         }
     }

--- a/lib/unwind/BUCK
+++ b/lib/unwind/BUCK
@@ -7,7 +7,7 @@ rust_library(
         "//third-party:cfg-if",
         "//third-party:gimli",
         "//third-party:fallible-iterator",
-        "//third-party:tracing",
+        "//third-party:log",
     ],
     visibility = ["PUBLIC"],
 )

--- a/lib/unwind/src/exception.rs
+++ b/lib/unwind/src/exception.rs
@@ -59,7 +59,7 @@ impl Exception {
             // Safety: Caller ensures `exception` is a valid exception
             unsafe {
                 drop(Box::from_raw(exception.cast::<Exception>()));
-                tracing::error!("Rust panics must be rethrown");
+                log::error!("Rust panics must be rethrown");
                 abort();
             }
         }

--- a/lib/unwind/src/lang_items.rs
+++ b/lib/unwind/src/lang_items.rs
@@ -43,11 +43,11 @@ pub unsafe extern "C-unwind" fn _Unwind_Resume(exception: *mut Exception) -> ! {
         match raise_exception_phase2(frames, exception) {
             Ok(_) => {}
             Err(Error::EndOfStack) => {
-                tracing::error!("Uncaught exception");
+                log::error!("Uncaught exception");
                 abort();
             }
             Err(err) => {
-                tracing::error!("Failed to resume exception: {err:?}");
+                log::error!("Failed to resume exception: {err:?}");
                 abort()
             }
         }

--- a/lib/unwind/src/lib.rs
+++ b/lib/unwind/src/lib.rs
@@ -147,7 +147,7 @@ fn raise_exception_phase2(mut frames: FrameIter, exception: *mut Exception) -> R
         }
     }
 
-    tracing::trace!("reached end of stack without handler");
+    log::trace!("reached end of stack without handler");
     Err(Error::EndOfStack)
 }
 
@@ -207,7 +207,7 @@ where
         match unsafe { Exception::unwrap(exception.cast()) } {
             Ok(p) => data.p = ManuallyDrop::new(p),
             Err(err) => {
-                tracing::error!("Failed to catch exception: {err:?}");
+                log::error!("Failed to catch exception: {err:?}");
                 abort();
             }
         }
@@ -246,7 +246,7 @@ mod tests {
             .set_default();
 
         std::panic::set_hook(Box::new(|info| {
-            tracing::trace!("PANIC while unwinding {info}. Aborting...");
+            log::trace!("PANIC while unwinding {info}. Aborting...");
             std::process::exit(1);
         }));
 


### PR DESCRIPTION
During early boot (in particular, before the global allocator is set up) we do not have the full tracing machinery yet. Log messages emitted during early boot will therefore be silently ignored at the moment. To make the panic machinery itself early-boot "safe" we replace all uses of `tracing` with `log` which does work.