### PR TITLE
refactor(mem-core): overhaul PhysMap implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,9 +57,9 @@ After adding/removing a crate, run `just rust-project` so rust-analyzer picks up
 
 ## Unsafe discipline
 
-1. **Every `unsafe { }` block carries a `// SAFETY:` comment** stating the invariant relied on. One terse line — accuracy over verbosity.
+1. **Every `unsafe { }` block carries a `// Safety:` comment** stating the invariant relied on. One terse line — accuracy over verbosity.
 2. **Every `unsafe fn` has a `# Safety` doc section** listing caller obligations.
-3. **A `SAFETY` comment relying on a critical invariant below cites it by number** — e.g. `// SAFETY: per invariant 4 (trap frame layout)`.
+3. **A `Safety` comment relying on a critical invariant below cites it by number** — e.g. `// Safety: per invariant 4 (trap frame layout)`.
 4. Inside `unsafe fn`, wrap unsafe ops in explicit inner `unsafe { }` blocks (Rust 2024).
 5. Manual `Send` / `Sync` impls justify themselves against interior state (raw ptrs, `Cell`, MMIO).
 6. `slice::from_raw_parts`, `get_unchecked`, raw-ptr deref: only after explicit length/alignment validation. Never on user-controlled sizes without a bound check.

--- a/build/mkdisk-img/src/main.rs
+++ b/build/mkdisk-img/src/main.rs
@@ -81,10 +81,13 @@ fn main() -> Result<()> {
     if let Some(vid) = args.volume_id.as_deref() {
         img.volume_id(vid)?;
     }
-    img.set_boot_catalog(BootConfig::new(
-        BootPlatform::Efi,
-        BootEntry::new(EmulationType::NoEmulation, "BOOT/EFI.IMG"),
-    ));
+    // UEFI §13.3.2.1: an EFI no-emulation entry with `sector_count` < 2 tells
+    // firmware the boot partition extends to end-of-CD. The ecma-119 layout
+    // pass places boot images last, so this is always safe — and it's the
+    // only way to express an ESP whose virtual sector count exceeds u16::MAX.
+    let mut entry = BootEntry::new(EmulationType::NoEmulation, "BOOT/EFI.IMG");
+    entry.set_load_size(0);
+    img.set_boot_catalog(BootConfig::new(BootPlatform::Efi, entry));
 
     let out = File::create(&args.output)
         .with_context(|| format!("creating output {}", args.output.display()))?;

--- a/lib/ecma-119/src/build/boot.rs
+++ b/lib/ecma-119/src/build/boot.rs
@@ -7,8 +7,6 @@
 
 //! Builders for configuring the El Torito bootable disk image properties
 
-use std::num::NonZeroU16;
-
 use crate::eltorito::{self, BootPlatform, EmulationType};
 
 #[derive(Debug)]
@@ -83,14 +81,16 @@ pub struct BootEntry<'a> {
     pub(super) bootable: bool,
     pub(super) emulation: EmulationType,
     /// Explicit override for the catalog `sector_count` field (in 512-byte
-    /// virtual sectors). If `None`, the layout pass auto-computes the size from the boot image.
-    pub(super) load_size: Option<NonZeroU16>,
+    /// virtual sectors). 0 is meaningful: per UEFI §13.3.2.1, an EFI
+    /// no-emulation entry with `sector_count` < 2 is read as extending to
+    /// end-of-CD. If `None`, the layout pass auto-computes from the image.
+    pub(super) load_size: Option<u16>,
     // must be a `/`-separated path to a file that has been added to the directory tree.
     pub(super) boot_image_path: &'a str,
     /// LBA of the boot image file; 0 until LBA assignment.
     pub(super) boot_image_lba: u32,
-    /// Sector count (512-byte virtual sectors) covering the resolved boot
-    /// image; 0 until LBA assignment. Only used when `load_size` is None.
+    /// Auto-computed sector count covering the resolved boot image; only
+    /// used when `load_size` is `None`. Set during LBA assignment.
     pub(super) boot_image_sector_count: u16,
 }
 
@@ -109,9 +109,7 @@ impl<'a> BootEntry<'a> {
     /// Resolved catalog `sector_count` value: caller-supplied `load_size` if
     /// set, otherwise the auto-computed sector count covering the whole image.
     pub(super) fn resolved_sector_count(&self) -> u16 {
-        self.load_size
-            .map(NonZeroU16::get)
-            .unwrap_or(self.boot_image_sector_count)
+        self.load_size.unwrap_or(self.boot_image_sector_count)
     }
 
     pub fn set_bootable(&mut self, bootable: bool) -> &mut Self {
@@ -124,7 +122,7 @@ impl<'a> BootEntry<'a> {
         self
     }
 
-    pub fn set_load_size(&mut self, load_size: NonZeroU16) -> &mut Self {
+    pub fn set_load_size(&mut self, load_size: u16) -> &mut Self {
         self.load_size = Some(load_size);
         self
     }

--- a/lib/ecma-119/src/build/layout.rs
+++ b/lib/ecma-119/src/build/layout.rs
@@ -140,9 +140,32 @@ impl<'a> Layout<'a> {
             lba += sectors_for(extent_len);
         }
 
-        // every file's data, back to back. Zero-byte files get LBA 0
+        // Boot images go last in the file area, in catalog order. UEFI
+        // §13.3.2.1 reads an EFI no-emulation entry with `sector_count` < 2
+        // as "extends to end of CD", so the boot image must physically end
+        // the volume; we make that invariant unconditional.
+        let boot_image_indices = match boot_config.as_deref() {
+            Some(bc) => self.collect_boot_image_indices(bc)?,
+            None => Vec::new(),
+        };
+
+        // Non-boot files first, back to back. Zero-byte files get LBA 0
         // (libisofs convention) and consume no sectors.
-        for file in &mut self.files {
+        for (i, file) in self.files.iter_mut().enumerate() {
+            if boot_image_indices.contains(&i) {
+                continue;
+            }
+            if file.len == 0 {
+                file.lba = 0;
+                continue;
+            }
+            file.lba = lba;
+            lba += sectors_for(file.len as u32);
+        }
+
+        // Boot images last, in the order they were collected.
+        for &i in &boot_image_indices {
+            let file = &mut self.files[i];
             if file.len == 0 {
                 file.lba = 0;
                 continue;
@@ -157,7 +180,7 @@ impl<'a> Layout<'a> {
         // to the LBA + virtual-sector size of the corresponding file.
         if let Some(boot_config) = boot_config {
             let resolve = |entry: &mut BootEntry<'_>| -> io::Result<()> {
-                let boot_image = self.find_file(entry.boot_image_path).ok_or_else(|| {
+                let idx = self.find_file_index(entry.boot_image_path).ok_or_else(|| {
                     io::Error::new(
                         io::ErrorKind::InvalidInput,
                         format!(
@@ -166,10 +189,15 @@ impl<'a> Layout<'a> {
                         ),
                     )
                 })?;
+                let boot_image = &self.files[idx];
 
                 entry.boot_image_lba = boot_image.lba;
 
                 // Auto-compute sector_count (in 512-byte virtual sectors).
+                // Callers whose image exceeds u16::MAX can opt into the
+                // UEFI §13.3.2.1 "extends to end-of-CD" rule by passing
+                // `set_load_size(0)` — boot images are placed last in the
+                // file area precisely so that's safe.
                 if entry.load_size.is_none() {
                     let virtual_sectors = boot_image.len.div_ceil(VIRTUAL_SECTOR_SIZE);
                     entry.boot_image_sector_count =
@@ -196,6 +224,32 @@ impl<'a> Layout<'a> {
         }
 
         Ok(())
+    }
+
+    /// Resolve every boot entry's path to a file index in `self.files`,
+    /// preserving catalog order (default entry first, then sections in
+    /// declaration order). Duplicate paths collapse so the file is only
+    /// placed once.
+    fn collect_boot_image_indices(&self, bc: &BootConfig<'_>) -> io::Result<Vec<usize>> {
+        let paths = std::iter::once(bc.default_entry.boot_image_path).chain(
+            bc.sections
+                .iter()
+                .flat_map(|s| s.entries.iter().map(|e| e.boot_image_path)),
+        );
+
+        let mut indices = Vec::new();
+        for path in paths {
+            let idx = self.find_file_index(path).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("boot image path {path:?} not found in directory tree"),
+                )
+            })?;
+            if !indices.contains(&idx) {
+                indices.push(idx);
+            }
+        }
+        Ok(indices)
     }
 
     pub(crate) fn serialize(
@@ -299,10 +353,10 @@ impl<'a> Layout<'a> {
     }
 
     /// Walk the directory tree to find a file by its `/`-separated path and
-    /// return its assigned LBA. Returns `None` if the path does not exist.
-    /// A leading `/` is accepted and ignored (both `"EFI/BOOT/FILE"` and
-    /// `"/EFI/BOOT/FILE"` resolve identically).
-    fn find_file(&self, path: &str) -> Option<&FileNode<'a>> {
+    /// return its index into `self.files`. Returns `None` if the path does
+    /// not exist. A leading `/` is accepted and ignored (both `"EFI/BOOT/FILE"`
+    /// and `"/EFI/BOOT/FILE"` resolve identically).
+    fn find_file_index(&self, path: &str) -> Option<usize> {
         let mut parts = path.trim_start_matches('/').split('/').peekable();
         let mut dir_idx = 0usize; // start at root
 
@@ -321,7 +375,7 @@ impl<'a> Layout<'a> {
                     return None; // path component exists but is a directory, not a file
                 };
 
-                return self.files.get(*file_idx as usize);
+                return Some(*file_idx as usize);
             }
 
             // directory component — binary-search sorted_entry_ids and descend

--- a/lib/ecma-119/tests/roundtrip.rs
+++ b/lib/ecma-119/tests/roundtrip.rs
@@ -10,7 +10,6 @@
 //! all survive the trip.
 
 use std::io::Cursor;
-use std::num::NonZeroU16;
 
 use ecma_119::build::{
     BootConfig, BootEntry, Directory as DirBuilder, File as FileBuilder, ImageBuilder,
@@ -171,7 +170,7 @@ fn explicit_load_size_overrides_auto() {
     root.add_subdir("EFI", efi).unwrap();
 
     let mut entry = BootEntry::new(EmulationType::NoEmulation, "EFI/BOOT/BOOTAA64.EFI;1");
-    entry.set_load_size(NonZeroU16::new(42).unwrap());
+    entry.set_load_size(42);
 
     let mut builder = ImageBuilder::new();
     builder.volume_id("OVERRIDE").unwrap();

--- a/lib/human-bytes/BUCK
+++ b/lib/human-bytes/BUCK
@@ -1,0 +1,15 @@
+load("@prelude//platforms:defs.bzl", "host_configuration")
+
+rust_library(
+    name = "human-bytes",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+    tests = [":human-bytes_unittests"],
+)
+
+rust_test(
+    name = "human-bytes_unittests",
+    srcs = glob(["src/**/*.rs"]),
+    target_compatible_with = [host_configuration.os, host_configuration.cpu],
+    visibility = ["PUBLIC"],
+)

--- a/lib/human-bytes/src/lib.rs
+++ b/lib/human-bytes/src/lib.rs
@@ -1,0 +1,102 @@
+// Copyright 2025 Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+#![no_std]
+
+use core::fmt::{self, Display};
+
+/// One kibibyte (2^10 bytes).
+pub const KIB: usize = 1024;
+/// One mebibyte (2^20 bytes).
+pub const MIB: usize = KIB * 1024;
+/// One gibibyte (2^30 bytes).
+pub const GIB: usize = MIB * 1024;
+/// One tebibyte (2^40 bytes).
+#[cfg(target_pointer_width = "64")]
+pub const TIB: usize = GIB * 1024;
+
+/// Binary byte units
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Unit {
+    B = 0,
+    KiB = 1,
+    MiB = 2,
+    GiB = 3,
+    TiB = 4,
+    PiB = 5,
+    EiB = 6,
+}
+
+impl Display for Unit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Unit::B => f.write_str("B"),
+            Unit::KiB => f.write_str("KiB"),
+            Unit::MiB => f.write_str("MiB"),
+            Unit::GiB => f.write_str("GiB"),
+            Unit::TiB => f.write_str("TiB"),
+            Unit::PiB => f.write_str("PiB"),
+            Unit::EiB => f.write_str("EiB"),
+        }
+    }
+}
+
+/// Formats a byte count in a human-readable way (e.g. `1.50 MiB`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HumanBytes {
+    pub whole: usize,
+    pub frac: u8,
+    pub unit: Unit,
+}
+
+impl HumanBytes {
+    /// Create a human-readable representation from the given `bytes`.
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "truncations are on purpose"
+    )]
+    pub fn from(bytes: usize) -> Self {
+        if bytes == 0 {
+            return Self {
+                whole: 0,
+                frac: 0,
+                unit: Unit::B,
+            };
+        }
+
+        let unit = (bytes.ilog2() / 10) as u8;
+
+        let shift = 10 * unit;
+        let whole = bytes >> shift;
+        let frac = (((bytes & ((1usize << shift) - 1)).saturating_mul(100)) >> shift) as u8;
+
+        Self {
+            whole,
+            frac,
+            unit: match unit {
+                0 => Unit::B,
+                1 => Unit::KiB,
+                2 => Unit::MiB,
+                3 => Unit::GiB,
+                4 => Unit::TiB,
+                5 => Unit::PiB,
+                6 => Unit::EiB,
+                _ => unreachable!(),
+            },
+        }
+    }
+}
+
+impl fmt::Display for HumanBytes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.unit {
+            Unit::B => write!(f, "{} B", self.whole),
+            _ => write!(f, "{}.{:02} {}", self.whole, self.frac, self.unit),
+        }
+    }
+}

--- a/lib/mem-core/BUCK
+++ b/lib/mem-core/BUCK
@@ -5,6 +5,7 @@ rust_library(
     srcs = glob(["src/**/*.rs"]),
     deps = [
         "//lib/arrayvec:arrayvec",
+        "//lib/human-bytes:human-bytes",
         "//lib/riscv:riscv",
         "//third-party:mycelium-bitfield",
         "//third-party:log",
@@ -19,6 +20,7 @@ rust_test(
     srcs = glob(["**/*.rs"]),
     deps = [
         "//lib/arrayvec:arrayvec",
+        "//lib/human-bytes:human-bytes",
         "//lib/riscv:riscv",
         "//third-party:mycelium-bitfield",
         "//third-party:log",

--- a/lib/mem-core/src/arch/riscv64.rs
+++ b/lib/mem-core/src/arch/riscv64.rs
@@ -7,14 +7,12 @@
 
 use core::range::Range;
 
+use human_bytes::{GIB, KIB, MIB, TIB};
 use riscv::satp;
 use riscv::sbi::rfence::{sfence_vma, sfence_vma_asid};
 
 use crate::arch::PageTableLevel;
-use crate::{
-    AddressRangeExt, GIB, KIB, MIB, MemoryAttributes, PhysicalAddress, TIB, VirtualAddress,
-    WriteOrExecute,
-};
+use crate::{AddressRangeExt, MemoryAttributes, PhysicalAddress, VirtualAddress, WriteOrExecute};
 
 /// The number of usable bits in a `PhysicalAddress`. This may be used for address canonicalization.
 #[cfg_attr(not(test), expect(unused, reason = "only used by tests"))]
@@ -329,12 +327,13 @@ fn fence_all() {
 
 #[cfg(test)]
 mod tests {
+    use human_bytes::KIB;
     use proptest::{prop_assert_eq, proptest};
 
     use super::*;
+    use crate::MemoryAttributes;
     use crate::arch::PageTableEntry;
     use crate::test_utils::proptest::{aligned_phys, phys};
-    use crate::{KIB, MemoryAttributes};
 
     proptest! {
         #[test]

--- a/lib/mem-core/src/frame_allocator/bump.rs
+++ b/lib/mem-core/src/frame_allocator/bump.rs
@@ -576,9 +576,8 @@ mod tests {
             let frame_allocator: BumpAllocator<parking_lot::RawMutex> =
                 BumpAllocator::new::<A>(machine.memory_regions().collect());
 
+            let physmap = PhysMap::new_identity(machine.memory_regions());
             let arch = EmulateArch::new(machine);
-
-            let physmap = PhysMap::ABSENT;
 
             // Based on the memory of the machine we set up above, we expect the allocator to
             // yield 3 pages.
@@ -646,7 +645,7 @@ mod tests {
 
             let arch = EmulateArch::new(machine.clone());
 
-            let physmap = PhysMap::ABSENT;
+            let physmap = PhysMap::new_identity(machine.memory_regions());
 
             let frame_allocator: BumpAllocator<parking_lot::RawMutex> =
                 BumpAllocator::new::<A>(machine.memory_regions().collect());

--- a/lib/mem-core/src/frame_allocator/bump.rs
+++ b/lib/mem-core/src/frame_allocator/bump.rs
@@ -508,12 +508,14 @@ impl<const MAX: usize> ExactSizeIterator for Blocks<MAX> {}
 mod tests {
     use core::alloc::Layout;
 
+    use human_bytes::GIB;
+
     use super::*;
     use crate::address_range::AddressRangeExt;
     use crate::arch::Arch;
     use crate::frame_allocator::FrameAllocator;
     use crate::test_utils::{EmulateArch, Machine, MachineBuilder};
-    use crate::{GIB, PhysMap, PhysicalAddress, archtest};
+    use crate::{PhysMap, PhysicalAddress, archtest};
 
     fn assert_zeroed(frame: PhysicalAddress, bytes: usize, physmap: &PhysMap, arch: &impl Arch) {
         let frame = unsafe { arch.read_bytes(physmap.phys_to_virt(frame), bytes) };
@@ -768,14 +770,15 @@ mod tests {
 mod proptests {
     use core::alloc::Layout;
 
+    use human_bytes::{GIB, KIB};
     use proptest::prelude::*;
 
     use crate::address_range::AddressRangeExt;
     use crate::arch::Arch;
+    use crate::for_every_arch;
     use crate::frame_allocator::{BumpAllocator, DEFAULT_MAX_REGIONS, FrameAllocator};
     use crate::test_utils::proptest::region_layouts;
     use crate::test_utils::{Machine, MachineBuilder};
-    use crate::{GIB, KIB, for_every_arch};
 
     for_every_arch!(A => {
         proptest! {

--- a/lib/mem-core/src/lib.rs
+++ b/lib/mem-core/src/lib.rs
@@ -26,15 +26,9 @@ mod utils;
 
 pub use address::{PhysicalAddress, VirtualAddress};
 pub use address_range::AddressRangeExt;
-pub use address_space::HardwareAddressSpace;
+pub use address_space::{Active, Bootstrapping, HardwareAddressSpace};
 pub use arch::Arch;
 pub use flush::Flush;
 pub use frame_allocator::{AllocError, BumpAllocator, DEFAULT_MAX_REGIONS, FrameAllocator};
 pub use memory_attributes::{MemoryAttributes, WriteOrExecute};
 pub use physmap::PhysMap;
-
-pub const KIB: usize = 1024;
-pub const MIB: usize = KIB * 1024;
-pub const GIB: usize = MIB * 1024;
-#[cfg(target_pointer_width = "64")]
-pub const TIB: usize = GIB * 1024;

--- a/lib/mem-core/src/physmap.rs
+++ b/lib/mem-core/src/physmap.rs
@@ -103,6 +103,7 @@ impl PhysMap {
 
 #[cfg(test)]
 mod tests {
+    use human_bytes::{GIB, KIB};
     use proptest::prelude::*;
 
     use super::*;
@@ -110,7 +111,6 @@ mod tests {
     use crate::test_utils::proptest::{
         aligned_phys, aligned_virt, pick_address_in_regions, regions_phys,
     };
-    use crate::{GIB, KIB};
 
     proptest! {
         #[test]

--- a/lib/mem-core/src/physmap.rs
+++ b/lib/mem-core/src/physmap.rs
@@ -6,7 +6,6 @@
 // copied, modified, or distributed except according to those terms.
 
 use core::cmp;
-use core::num::NonZeroIsize;
 use core::range::Range;
 
 use crate::{PhysicalAddress, VirtualAddress};
@@ -16,20 +15,14 @@ use crate::{PhysicalAddress, VirtualAddress};
 /// zeroing frames of memory in the frame allocator).
 ///
 /// This region must be mapped so it is only accessible by the kernel.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PhysMap {
-    translation_offset: Option<NonZeroIsize>,
-    #[cfg(debug_assertions)]
-    range: Option<Range<u128>>,
+    translation_offset: isize,
+    range_phys: Range<PhysicalAddress>,
+    range_virt: Range<VirtualAddress>,
 }
 
 impl PhysMap {
-    pub const ABSENT: Self = Self {
-        translation_offset: None,
-        #[cfg(debug_assertions)]
-        range: None,
-    };
-
     /// Construct a new `PhysMap` from a chosen base address and the machines physical memory regions.
     /// The iterator over the memory regions must not be empty.
     ///
@@ -37,67 +30,142 @@ impl PhysMap {
     ///
     /// Panics if the iterator is empty.
     pub fn new(
-        physmap_start: VirtualAddress,
+        physmap_base: VirtualAddress,
         regions: impl IntoIterator<Item = Range<PhysicalAddress>>,
     ) -> Self {
-        let mut min_addr = PhysicalAddress::MAX;
-        let mut max_addr = PhysicalAddress::MIN;
+        let mut range_phys = Range::from(PhysicalAddress::MAX..PhysicalAddress::MIN);
 
         for region in regions {
-            min_addr = cmp::min(min_addr, region.start);
-            max_addr = cmp::max(max_addr, region.end);
+            range_phys.start = cmp::min(range_phys.start, region.start);
+            range_phys.end = cmp::max(range_phys.end, region.end);
         }
 
-        assert!(min_addr <= max_addr, "regions must not be empty");
+        assert!(!range_phys.is_empty(), "regions must not be empty");
 
         #[expect(
             clippy::cast_possible_wrap,
             reason = "this is expected to wrap when the physmap_start is lower than the lowest physical address (e.g. when it is in upper half of memory)"
         )]
-        let translation_offset =
-            NonZeroIsize::new(physmap_start.get().wrapping_sub(min_addr.get()) as isize)
-                .expect("identity-mapped physmap is not allowed");
+        let translation_offset = physmap_base.get().wrapping_sub(range_phys.start.get()) as isize;
 
-        #[cfg(debug_assertions)]
-        let range = {
-            let start = physmap_start.get() as u128;
-            let end = start + max_addr.offset_from_unsigned(min_addr) as u128;
+        let range_virt = {
+            let start =
+                VirtualAddress::new(range_phys.start.wrapping_offset(translation_offset).get());
+            let end = VirtualAddress::new(range_phys.end.wrapping_offset(translation_offset).get());
 
             Range::from(start..end)
         };
 
         Self {
-            translation_offset: Some(translation_offset),
-            #[cfg(debug_assertions)]
-            range: Some(range),
+            translation_offset,
+            range_phys,
+            range_virt,
+        }
+    }
+
+    /// Construct a new `PhysMap` that **identity maps** physical memory addresses to virtual addresses.
+    ///
+    /// The iterator over the memory regions must not be empty.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the iterator is empty.
+    pub fn new_identity(regions: impl IntoIterator<Item = Range<PhysicalAddress>>) -> Self {
+        let mut range_phys = Range::from(PhysicalAddress::MAX..PhysicalAddress::MIN);
+
+        for region in regions {
+            range_phys.start = cmp::min(range_phys.start, region.start);
+            range_phys.end = cmp::max(range_phys.end, region.end);
+        }
+
+        assert!(!range_phys.is_empty(), "regions must not be empty");
+
+        let range_virt = {
+            let start = VirtualAddress::new(range_phys.start.get());
+            let end = VirtualAddress::new(range_phys.end.get());
+
+            Range::from(start..end)
+        };
+
+        Self {
+            translation_offset: 0,
+            range_phys,
+            range_virt,
         }
     }
 
     /// Translates a `PhysicalAddress` to a `VirtualAddress` through this `PhysMap`.
-    #[expect(clippy::missing_panics_doc, reason = "internal assert")]
+    ///
+    /// # Panics
+    ///
+    /// Panics if `phys` is _outside_ the physical memory regions this physmap was created with.
     #[inline]
     pub fn phys_to_virt(&self, phys: PhysicalAddress) -> VirtualAddress {
-        let translation_offset = self.translation_offset.map_or(0, NonZeroIsize::get);
+        debug_assert!(
+            self.range_phys.contains(&phys),
+            "invalid physical address. this is a bug! physmap={self:#x?},phys={phys:?}"
+        );
 
-        let virt = VirtualAddress::new(phys.wrapping_offset(translation_offset).get());
+        // Safety: we have checked the address to be within the physical range above
+        let virt = unsafe { self.phys_to_virt_internal(phys) };
 
-        #[cfg(debug_assertions)]
-        if let Some(range) = &self.range {
-            assert!(
-                range.start <= virt.get() as u128 && virt.get() as u128 <= range.end,
-                "physical address is not mapped in physical memory mapping. this is a bug! physmap={self:#x?},phys={phys:?},virt={virt}"
-            );
-        }
+        debug_assert!(
+            self.range_virt.contains(&virt),
+            "physical address is not mapped in physical memory mapping. this is a bug! physmap={self:#x?},phys={phys:?},virt={virt}"
+        );
 
         virt
     }
 
+    /// Translates a `Range<PhysicalAddress>` through this `PhysMap`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any address in `phys` range is _outside_ the physical memory regions this physmap was created with.
     #[inline]
     pub fn phys_to_virt_range(&self, phys: Range<PhysicalAddress>) -> Range<VirtualAddress> {
-        let start = self.phys_to_virt(phys.start);
-        let end = self.phys_to_virt(phys.end);
+        debug_assert!(
+            phys.start >= self.range_phys.start && phys.end <= self.range_phys.end,
+            "physical range out of bounds. this is a bug! physmap={self:#x?},phys={phys:?}"
+        );
 
-        Range::from(start..end)
+        let virt = {
+            // Safety: we checked the range bound to be within the physical range above
+            let start = unsafe { self.phys_to_virt_internal(phys.start) };
+            // Safety: we checked the range bound to be within the physical range above
+            let end = unsafe { self.phys_to_virt_internal(phys.end) };
+
+            Range::from(start..end)
+        };
+
+        debug_assert!(
+            virt.start >= self.range_virt.start && virt.end <= self.range_virt.end,
+            "physical address range not mapped in physical memory mapping. this is a bug! physmap={self:#x?},phys={phys:?},virt={virt:?}"
+        );
+
+        virt
+    }
+
+    /// Translates a `PhysicalAddress` to a `VirtualAddress` through this `PhysMap` _without_
+    /// doing bounds checking of the address.
+    ///
+    /// # Safety
+    ///
+    /// 1. The physical address must be contained within one of the physical memory regions this physmap was created with.
+    ///    Violating this yields a `VirtualAddress` not backed by any mapping; dereferencing it is undefined behavior.
+    #[inline]
+    unsafe fn phys_to_virt_internal(&self, phys: PhysicalAddress) -> VirtualAddress {
+        VirtualAddress::new(phys.wrapping_offset(self.translation_offset).get())
+    }
+
+    /// The virtual address range covered by this physmap.
+    pub fn range_virt(&self) -> Range<VirtualAddress> {
+        self.range_virt
+    }
+
+    /// The physical address range covered by this physmap.
+    pub fn range_phys(&self) -> Range<PhysicalAddress> {
+        self.range_phys
     }
 }
 
@@ -120,11 +188,11 @@ mod tests {
                 [Range::from_start_len(region_start, region_size)],
             );
 
-            prop_assert_eq!(map.translation_offset.unwrap().get(), base.get().wrapping_sub(region_start.get()) as isize);
+            prop_assert_eq!(map.translation_offset, base.get().wrapping_sub(region_start.get()) as isize);
             #[cfg(debug_assertions)]
             prop_assert_eq!(
-                map.range,
-                Some(Range::from(base.get() as u128..base.add(region_size).get() as u128))
+                map.range_virt(),
+                Range::from_start_len(base, region_size)
             )
         }
 
@@ -137,7 +205,7 @@ mod tests {
                 regions
             );
 
-            prop_assert_eq!(map.translation_offset.unwrap().get(), base.get().wrapping_sub(regions_start.get()) as isize);
+            prop_assert_eq!(map.translation_offset, base.get().wrapping_sub(regions_start.get()) as isize);
         }
 
         #[test]

--- a/lib/mem-core/src/test_utils/machine.rs
+++ b/lib/mem-core/src/test_utils/machine.rs
@@ -73,7 +73,7 @@ impl<A: Arch> Machine<A> {
 
         let memory_regions: ArrayVec<_, _> = arch.machine().memory_regions().collect();
 
-        let active_physmap = PhysMap::ABSENT;
+        let active_physmap = PhysMap::new_identity(memory_regions.clone());
         let chosen_physmap = PhysMap::new(physmap_start, memory_regions.clone());
 
         let frame_allocator = BumpAllocator::new::<A>(memory_regions.clone());

--- a/sys/kernel/src/mem/mod.rs
+++ b/sys/kernel/src/mem/mod.rs
@@ -39,10 +39,6 @@ use xmas_elf::program::Type;
 use crate::arch;
 use crate::mem::frame_alloc::FrameAllocator;
 
-pub const KIB: usize = 1024;
-pub const MIB: usize = KIB * 1024;
-pub const GIB: usize = MIB * 1024;
-
 static KERNEL_ASPACE: OnceLock<Arc<Mutex<AddressSpace>>> = OnceLock::new();
 
 pub fn with_kernel_aspace<F, R>(f: F) -> R


### PR DESCRIPTION
Fixes a number of things with the pretty shoddy `PhysMap` implementation, but in particular this type now can be _the_ central phys-to-virt type of the kernel: it stores the physical memory hull (transitive hull of all possibly discontiguous memory regions) and the mapped virtual memory map.

In debug mode we check all address translations before (and after) against these maps.