### PR TITLE
fix(mem-core): use proper DFS table walking for correct sequential mapping

### DIFF
--- a/lib/mem-core/proptest-regressions/address_space.txt
+++ b/lib/mem-core/proptest-regressions/address_space.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 055d7f972a03f6b0c2270f9f2cc8914e5b61fb12c18330160ba44ec4849e5570 # shrinks to pages_before = 1, pages_after = 1, boundary_idx = 1
+cc 6e8ac0546d9a1e25ff2fcc585206e3cbe04d49df1173c3630f19f851744e3db6 # shrinks to pages_before = 1, pages_after = 1, boundary_idx = 1
+cc 0b8f93a076c1df902b35252c612b81cfb65594d496dbef00ed158e3e91f19a6f # shrinks to pages_before = 1, pages_after = 1, boundary_idx = 1

--- a/lib/mem-core/src/address.rs
+++ b/lib/mem-core/src/address.rs
@@ -336,6 +336,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn lower_half_is_canonical(addr in 0x0usize..0x3fffffffff) {
             let addr = VirtualAddress::new(addr);
             prop_assert!(addr.is_canonical::<crate::arch::riscv64::Riscv64Sv39>());
@@ -343,6 +344,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn upper_half_is_canonical(addr in 0xffffffc000000000usize..0xffffffffffffffff) {
             let addr = VirtualAddress::new(addr);
             prop_assert!(addr.is_canonical::<crate::arch::riscv64::Riscv64Sv39>());
@@ -350,6 +352,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn non_canonical_hole(addr in 0x4000000000usize..0xffffffbfffffffff) {
             let addr = VirtualAddress::new(addr);
             prop_assert_ne!(addr.canonicalize::<crate::arch::riscv64::Riscv64Sv39>(), addr);

--- a/lib/mem-core/src/address_range.rs
+++ b/lib/mem-core/src/address_range.rs
@@ -108,6 +108,7 @@ mod test {
 
     proptest::proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn len(len: usize) {
             let r: Range<VirtualAddress> = Range::from_start_len(VirtualAddress::new(0), len);
 

--- a/lib/mem-core/src/address_space.rs
+++ b/lib/mem-core/src/address_space.rs
@@ -392,9 +392,15 @@ impl<A: Arch, Phase> HardwareAddressSpace<A, Phase> {
             "address range span be at least one page"
         );
         debug_assert!(
-            virt.start.is_aligned_to(A::GRANULE_SIZE,),
+            virt.start.is_aligned_to(A::GRANULE_SIZE),
             "virtual address {} must be aligned to at least page size {}",
             virt.start,
+            A::GRANULE_SIZE,
+        );
+        debug_assert!(
+            virt.end.is_aligned_to(A::GRANULE_SIZE),
+            "virtual address {} must be aligned to at least page size {}",
+            virt.end,
             A::GRANULE_SIZE,
         );
         debug_assert!(
@@ -407,8 +413,12 @@ impl<A: Arch, Phase> HardwareAddressSpace<A, Phase> {
                               range: Range<VirtualAddress>,
                               level: &'static PageTableLevel|
          -> Result<(), AllocError> {
+            // If the entry is a table, just keep walking
+            if entry.is_table() {
+                return Ok(());
+            }
+
             debug_assert!(entry.is_vacant());
-            debug_assert!(!entry.is_leaf() && !entry.is_table());
 
             if level.can_map(range.start, phys, range.len()) {
                 *entry = <A as Arch>::PageTableEntry::new_leaf(phys, attributes);
@@ -886,6 +896,99 @@ mod tests {
             assert_eq!(attrs.allows_write(), false);
             assert_eq!(attrs.allows_execution(), true);
             assert_eq!(lvl.page_size(), 4096);
+        }
+    });
+}
+
+#[cfg(test)]
+mod proptests {
+    use core::alloc::Layout;
+    use core::range::Range;
+
+    use proptest::prelude::*;
+
+    use crate::arch::Arch;
+    use crate::flush::Flush;
+    use crate::frame_allocator::FrameAllocator;
+    use crate::test_utils::{Machine, MachineBuilder};
+    use crate::{MemoryAttributes, VirtualAddress, for_arch};
+
+    for_arch!(A in [
+        Riscv64Sv39,
+        #[cfg(not(miri))]
+        Riscv64Sv48,
+        #[cfg(not(miri))]
+        Riscv64Sv57,
+    ] {
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(if cfg!(miri) { 10 } else { 250 }))]
+
+            /// Regression test for `map_contiguous` across a higher-level page-table
+            /// boundary (review Blocker).
+            ///
+            /// A contiguous physical block mapped to a contiguous virtual range that
+            /// straddles a leaf-table boundary must map every virtual page to the
+            /// matching physical page, in order. This currently fails for two
+            /// compounding reasons:
+            ///  - `PageTableEntries::next` (utils.rs) overshoots the per-entry sub-range
+            ///    when the range start is not aligned to the level's page size.
+            ///  - `visit_mut` (table.rs) descends sibling subtables LIFO.
+            #[test]
+            fn map_contiguous_across_table_boundary(
+                pages_before in 1usize..=8,
+                pages_after in 1usize..=8,
+                boundary_idx in 1usize..256,
+            ) {
+                let machine: Machine<A> = MachineBuilder::new()
+                    .with_memory_regions([
+                        Layout::from_size_align(0x40000, A::GRANULE_SIZE).unwrap()
+                    ])
+                    .finish();
+
+                let (mut address_space, frame_allocator, physmap) =
+                    machine.bootstrap_address_space(A::DEFAULT_PHYSMAP_BASE);
+
+                let granule = A::GRANULE_SIZE;
+                let total_pages = pages_before + pages_after;
+
+                // A single contiguous physical block backing the whole mapping.
+                let phys = frame_allocator
+                    .allocate_contiguous(
+                        Layout::from_size_align(total_pages * granule, granule).unwrap(),
+                    )
+                    .unwrap();
+
+                // A contiguous virtual range straddling a leaf-table boundary: the
+                // page size of the level whose entries point at leaf tables is the
+                // span of one leaf table, and thus the gap between two of them.
+                let leaf_table_span = A::LEVELS[A::LEVELS.len() - 2].page_size();
+                let boundary = VirtualAddress::new(boundary_idx * leaf_table_span);
+                let virt = Range::from(boundary.sub(pages_before * granule)
+                    ..boundary.add(pages_after * granule));
+
+                let mut flush = Flush::new();
+                unsafe {
+                    address_space
+                        .map_contiguous(
+                            virt,
+                            phys,
+                            MemoryAttributes::new().with(MemoryAttributes::READ, true),
+                            frame_allocator.by_ref(),
+                            &physmap,
+                            &mut flush,
+                        )
+                        .unwrap();
+                }
+                flush.flush(address_space.arch());
+
+                // Every page must be mapped, to the matching physical page, in order.
+                for i in 0..total_pages {
+                    let page = virt.start.add(i * granule);
+                    let mapped = address_space.lookup(page, &physmap);
+                    prop_assert!(mapped.is_some(), "page {} is not mapped", page);
+                    prop_assert_eq!(mapped.unwrap().0, phys.add(i * granule));
+                }
+            }
         }
     });
 }

--- a/lib/mem-core/src/arch/riscv64.rs
+++ b/lib/mem-core/src/arch/riscv64.rs
@@ -341,6 +341,7 @@ mod tests {
 
     proptest! {
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn pte_new_leaf(address in aligned_phys(phys(0..1 << PHYSICAL_ADDRESS_BITS), 4*KIB)) {
             let pte = <super::PageTableEntry as PageTableEntry>::new_leaf(address, MemoryAttributes::new());
 

--- a/lib/mem-core/src/physmap.rs
+++ b/lib/mem-core/src/physmap.rs
@@ -181,6 +181,8 @@ mod tests {
     };
 
     proptest! {
+        #![proptest_config(ProptestConfig::with_cases(if cfg!(miri) { 25 } else { 250 }))]
+
         #[test]
         fn single_region(base in aligned_virt(any::<VirtualAddress>(), 1*GIB), region_start in aligned_phys(any::<PhysicalAddress>(), 4*KIB), region_size in 0..256*GIB) {
             let map = PhysMap::new(

--- a/lib/mem-core/src/table.rs
+++ b/lib/mem-core/src/table.rs
@@ -182,34 +182,51 @@ impl<A: Arch> Table<A, marker::Mut<'_>> {
             entries_iter: PageTableEntries<A>,
         }
 
+        // NB: we use a fixed size stack here to help with loop unrolling and
+        // enforce a known upper bound on the runtime-complexity of this function
+        // (5 level deep max). 5 is chosen because it is the deepest page table depth
+        // across all our supported target architectures.
         let mut stack: ArrayVec<Level<'_, _>, 5> = ArrayVec::from_iter([Level {
             table: self,
             entries_iter: page_table_entries_for(range, &A::LEVELS[0]),
         }]);
 
-        while let Some(mut frame) = stack.pop() {
-            for (entry_index, range) in frame.entries_iter {
-                // Safety: `page_table_entries_for` yields only in-bound indices
-                let mut entry = unsafe { frame.table.get(entry_index, physmap, arch) };
+        // Depth-first, in-order walk of the page tables.
+        while let Some(frame) = stack.last_mut() {
+            let Some((entry_index, range)) = frame.entries_iter.next() else {
+                // This table is fully visited; backtrack to its parent.
+                stack.pop();
+                continue;
+            };
 
-                visit_entry(&mut entry, range, frame.table.level())?;
+            // Safety: `page_table_entries_for` yields only in-bound indices
+            let mut entry = unsafe { frame.table.get(entry_index, physmap, arch) };
 
-                // Safety: `page_table_entries_for` yields only in-bound indices
-                unsafe {
-                    frame.table.set(entry_index, entry, physmap, arch);
-                }
+            visit_entry(&mut entry, range, frame.table.level())?;
 
-                if entry.is_table() {
-                    // Safety: We checked the entry is a table above (1.) know the depth is correct (2.).
-                    let subtable: Table<_, marker::Mut<'_>> =
-                        unsafe { Table::from_raw_parts(entry.address(), frame.table.depth() + 1) };
+            // Safety: `page_table_entries_for` yields only in-bound indices
+            unsafe {
+                frame.table.set(entry_index, entry, physmap, arch);
+            }
 
-                    // Push new frame for subtable
-                    stack.push(Level {
-                        entries_iter: page_table_entries_for(range, subtable.level()),
-                        table: subtable,
-                    });
-                }
+            if entry.is_table() {
+                debug_assert!((frame.table.depth() as usize + 1) < A::LEVELS.len());
+
+                // Safety: We checked the entry is a table above (1.) know the depth is correct (2.)
+                // and inherit the mutable access from self.
+                let subtable: Table<_, marker::Mut<'_>> = unsafe {
+                    Table::from_raw_parts(
+                        entry.address(),
+                        frame.table.depth().checked_add(1).unwrap(),
+                    )
+                };
+
+                // Descend at once, before advancing to the next sibling, so entries
+                // are visited in ascending address order.
+                stack.push(Level {
+                    entries_iter: page_table_entries_for(range, subtable.level()),
+                    table: subtable,
+                });
             }
         }
 

--- a/lib/mem-core/src/utils.rs
+++ b/lib/mem-core/src/utils.rs
@@ -16,10 +16,15 @@ use crate::arch::{Arch, PageTableLevel};
 /// `range` must lie within a single table at `level`: a `PageTableEntries`
 /// indexes one table, and each caller consumes it against one `Table`. A
 /// cross-table range cannot be represented and panics in debug builds.
+///
+/// # Panics
+///
+/// Panics in debug builds if the range crosses tables at the chosen level.
 pub fn page_table_entries_for<A: Arch>(
     range: Range<VirtualAddress>,
     level: &PageTableLevel,
 ) -> PageTableEntries<A> {
+    debug_assert!(range.start.is_canonical::<A>() && range.end.is_canonical::<A>());
     debug_assert!(
         {
             // `range` stays within one table at this level iff its first and last
@@ -164,6 +169,7 @@ mod tests {
         /// table, so it must panic rather than silently truncate.
         #[test]
         #[should_panic = "crosses a page-table boundary"]
+        #[cfg_attr(not(debug_assertions), ignore)]
         fn rejects_a_range_crossing_a_table_boundary() {
             let level = &A::LEVELS[A::LEVELS.len() - 1];
             let table_span = level.entries() as usize * level.page_size();


### PR DESCRIPTION
The previous `Table::visit_mut` implementation was traversing subtables in the reverse order: since we pushed after descending into the sub table we would visit subtables in the reverse order. This of caused caused horribly malformed mappings