### PR TITLE
fix(kernel): stop swallowing early boot log messages

### DIFF
--- a/sys/kernel/src/tracing/mod.rs
+++ b/sys/kernel/src/tracing/mod.rs
@@ -54,6 +54,7 @@ pub fn init_early() {
         lateinit: OnceLock::new(),
     });
     ::log::set_logger(subscriber).unwrap();
+    ::log::set_max_level(::log::LevelFilter::Trace);
 }
 
 /// Fully initialize the subsystem, after this point tracing [`Span`]s will be processed as well.


### PR DESCRIPTION
During early kernel boot we can use `log` instead of `tracing` because the log subscriber doesn't need to allocate. Through some refactoring though we forgot to actually set a log level on that subscriber during init that would allow it to print messages. This PR fixes that