### PR TITLE
ci: give the review bot a clean scratch-file write path

### DIFF
--- a/.github/claude-review-settings.json
+++ b/.github/claude-review-settings.json
@@ -19,11 +19,11 @@
       "Bash(gh pr diff *)",
       "Bash(gh api *)",
       "Bash(jq *)",
-      "Bash(printenv PR_NUMBER)"
+      "Bash(printenv PR_NUMBER)",
+      "Write(//tmp/**)"
     ],
     "deny": [
       "Edit",
-      "Write",
       "NotebookEdit",
       "AskUserQuestion",
       "Bash(git commit *)",

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -115,31 +115,37 @@ jobs:
             7. Build the payload from FILES, not shell-quoted strings. Bash
                double-quoted strings keep `\n` as a literal two-character
                sequence; jq's `--arg` then JSON-escapes that to `\\n`, which
-               renders as backslash-n on GitHub instead of a line break. Write
-               the body and the comments array to disk first, then assemble
-               with `--rawfile` / `--slurpfile`:
+               renders as backslash-n on GitHub instead of a line break.
 
-                 cat > /tmp/review-body.md <<'EOF'
-                 **Verdict**: Needs Attention
-                 ... actual body content with real newlines ...
-                 EOF
-                 printf '%s' "$COMMENTS_JSON" > /tmp/comments.json
+               Create the scratch files with the **Write tool**, not the
+               shell. The bash sandbox is read-only and no file-writing
+               command (`cat <<EOF`, `tee`, `printf >`, redirection, `python3`)
+               is allow-listed, so every shell write is denied — do not
+               attempt them. Only the Write tool can create files, and it is
+               allow-listed for `/tmp/**`. Write two files:
+                 /tmp/review-body.md   — the review body, with real newlines
+                 /tmp/comments.json    — the comments array as JSON
+
+               Then assemble the payload with jq, which only READS those files
+               (reads are allowed under the sandbox), and pipe it straight into
+               `gh api` in step 8. Never redirect jq output to a file:
+
                  jq -n --arg sha "$SHA" \
                        --rawfile body /tmp/review-body.md \
                        --slurpfile comments /tmp/comments.json \
-                       '{commit_id:$sha, body:$body, comments:$comments[0]}' \
-                   > /tmp/review.json
-
-               Use a quoted heredoc (`<<'EOF'`) so backticks and `$` in the
-               body are not expanded.
+                       '{commit_id:$sha, body:$body, comments:$comments[0]}'
 
             8. Create the review as PENDING first (omit `event`), then verify
                the rendered body before submitting. A pending review is
                visible only to the bot, so this leaves no public artifact:
 
-                 REVIEW_ID=$(gh api -X POST \
-                   "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
-                   --input /tmp/review.json --jq '.id')
+                 REVIEW_ID=$(jq -n --arg sha "$SHA" \
+                       --rawfile body /tmp/review-body.md \
+                       --slurpfile comments /tmp/comments.json \
+                       '{commit_id:$sha, body:$body, comments:$comments[0]}' \
+                   | gh api -X POST \
+                       "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
+                       --input - --jq '.id')
 
                Read it back and confirm the body contains real line breaks:
 


### PR DESCRIPTION
The Claude Review workflow's prompt assembles the PR-review payload from
files on disk (/tmp/review-body.md, /tmp/comments.json) and POSTs via
`gh api`. The bot does produce a full inline-anchored review, but the
publish phase thrashes: every file write in the run's execution log
targets the read-only *workspace* path
(/home/runner/work/k23/k23/review-body.md) and is denied — the Write
tool is denied in claude-review-settings.json and no file-writing shell
command (tee/printf/cat/python3/redirection) is allow-listed. The agent
retried a dozen+ variants before recovering, wasting much of the ~40-min
step; the last logged action was yet another denied workspace write,
after the review had already been submitted.

Give it a sanctioned write path instead of relying on it to flail into
one: allow Write scoped to /tmp, and rewrite prompt step 7/8 to create
the scratch files with the Write tool (the workspace and shell writes
are read-only/denied) and pipe jq straight into `gh api --input -`
rather than redirecting to /tmp/review.json.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ceb1vD9HGFy4ZWhHYaHRQe