### PR TITLE
wip: heartbeat scheduler

### DIFF
--- a/build/bench.bzl
+++ b/build/bench.bzl
@@ -48,9 +48,15 @@ def rust_benchmark(name, modifiers = [], visibility = None, **kwargs):
         visibility = visibility,
         **kwargs
     )
+    # Buck2 applies a target's `modifiers` only when it is the *top-level* target
+    # being built. The runner is what `just benchmark` builds, so the modifiers
+    # must live here as well — as a mere dependency, the `_bin`'s own modifiers
+    # are ignored and it would inherit the runner's (default, opt-level=0)
+    # configuration, silently benchmarking unoptimized code.
     _rust_benchmark_runner(
         name = name,
         binary = ":" + bin_name,
         target_compatible_with = [host_configuration.os, host_configuration.cpu],
+        modifiers = _DEFAULT_MODIFIERS + modifiers,
         visibility = visibility,
     )

--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -197,6 +197,8 @@ rust_toolchain(
     allow_lints = ALLOW,
     rustc_flags = [
         "-Zunstable-options",
+        "-Cdebug-assertions=off",
+        "-Coverflow-checks=off"
     ] + select({
         "constraints//:env[loader]": [],
         "DEFAULT": ["-Cpanic=unwind"],

--- a/lib/heartbeat/BUCK
+++ b/lib/heartbeat/BUCK
@@ -61,3 +61,14 @@ rust_binary(
     target_compatible_with = [host_configuration.os, host_configuration.cpu],
     visibility = ["PUBLIC"],
 )
+
+# Adversarial benchmarks: idle-transition latency (`short`), skew (`skewed`),
+# and — via HEARTBEAT_SHORT_N=1000 — the tiny-scope case.
+rust_binary(
+    name = "heartbeat-adversarial",
+    srcs = ["examples/adversarial.rs"],
+    crate_root = "examples/adversarial.rs",
+    deps = [":heartbeat"],
+    target_compatible_with = [host_configuration.os, host_configuration.cpu],
+    visibility = ["PUBLIC"],
+)

--- a/lib/heartbeat/BUCK
+++ b/lib/heartbeat/BUCK
@@ -1,0 +1,63 @@
+load("@prelude//platforms:defs.bzl", "host_configuration")
+load("//build:bench.bzl", "rust_benchmark")
+load("//build:loom.bzl", "rust_loom_test")
+
+_DEPS = [
+    "//lib/util:util",
+    "//lib/spin:spin",
+
+    "//third-party:log",
+    "//third-party:cordyceps",
+    "//third-party:cfg-if",
+    "//third-party:mycelium-bitfield",
+    "//third-party:pin-project-lite",
+]
+
+rust_library(
+    name = "heartbeat",
+    srcs = glob(["src/**/*.rs"]),
+    visibility = ["PUBLIC"],
+    deps = _DEPS,
+    tests = [":heartbeat_unittests", ":heartbeat_loom_tests"],
+)
+
+rust_test(
+    name = "heartbeat_unittests",
+    srcs = glob(["src/**/*.rs"]),
+    deps = _DEPS,
+    target_compatible_with = [host_configuration.os, host_configuration.cpu],
+    visibility = ["PUBLIC"],
+)
+
+# Host-only criterion benchmark: the balanced-binary-tree sum from the Spice
+# example, sequential vs. the heartbeat scheduler at a range of hart counts.
+rust_benchmark(
+    name = "heartbeat_benchmarks",
+    srcs = ["benches/binary_tree.rs"],
+    crate_root = "benches/binary_tree.rs",
+    deps = [
+        ":heartbeat",
+        "//third-party:criterion",
+    ],
+    visibility = ["PUBLIC"],
+)
+
+# Model-checks the park/wake protocol and the idle-queue registration handshake.
+# See `src/loom_tests.rs` for why the scope stops there.
+rust_loom_test(
+    name = "heartbeat_loom_tests",
+    srcs = glob(["src/**/*.rs"]),
+    crate = "heartbeat",
+    deps = _DEPS + [
+        "//third-party:loom",
+    ],
+)
+
+rust_binary(
+    name = "heartbeat-example",
+    srcs = ["examples/binary_tree.rs"],
+    crate_root = "examples/binary_tree.rs",
+    deps = [":heartbeat"],
+    target_compatible_with = [host_configuration.os, host_configuration.cpu],
+    visibility = ["PUBLIC"],
+)

--- a/lib/heartbeat/benches/binary_tree.rs
+++ b/lib/heartbeat/benches/binary_tree.rs
@@ -144,7 +144,7 @@ fn bench_harts(group: &mut BenchmarkGroup<'_, WallTime>, root: &Node, harts: usi
                         .unwrap()
                         .push(&raw const *worker.heartbeat_flag() as usize);
 
-                    let _ = worker.main_loop();
+                    worker.main_loop();
                 })
             })
             .collect();

--- a/lib/heartbeat/benches/binary_tree.rs
+++ b/lib/heartbeat/benches/binary_tree.rs
@@ -1,0 +1,251 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Criterion port of Spice's `examples/zig-parallel-example`: build a perfectly
+//! balanced binary tree and time summing all its values, sequentially
+//! (baseline) and through the heartbeat scheduler at various hart counts.
+//!
+//! The scheduler is wired up the way it will be on real hardware: `harts - 1`
+//! workers sitting in `main_loop` waiting for work to be shared with them, the
+//! benchmark thread itself as the hart that asks for the sum, and one thread
+//! standing in for the per-hart timer interrupt that delivers the heartbeats.
+//! Reported times are per whole-tree sum; divide by the node count for ns/node.
+//!
+//! The 10M-node tree needs roughly 400 MB of RAM (upstream's 100M needs ~4 GB).
+//! Override the defaults with env vars, e.g.:
+//!
+//! ```sh
+//! HEARTBEAT_BENCH_SIZES=1000,100000000 HEARTBEAT_BENCH_HARTS=1,2,4 just benchmark //lib/heartbeat:heartbeat_benchmarks
+//! ```
+
+#![expect(clippy::undocumented_unsafe_blocks, reason = "its fine for benchmarks")]
+
+use std::hint::black_box;
+use std::mem::ManuallyDrop;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use criterion::measurement::WallTime;
+use criterion::{BenchmarkGroup, BenchmarkId, Criterion, criterion_group, criterion_main};
+use heartbeat::{Job, Park, ParkVTable, Scheduler, Scope, Worker};
+
+/// Interval at which each worker is handed a heartbeat.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_micros(100);
+
+pub struct Node {
+    value: i64,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
+}
+
+impl Node {
+    /// Perfectly balanced tree holding the values `from..=to`.
+    ///
+    /// Allocates the parent *before* its children (pre-order), exactly like the
+    /// Zig example's `balancedTree`. This matters: it lays the tree out nearly
+    /// sequentially in memory, and the walk order then matches the allocation
+    /// order. (Upstream's own Rust example builds children first, which costs it
+    /// roughly 2x on tree-walk speed on this author's box.)
+    pub fn make_balanced_tree(from: i64, to: i64) -> Box<Node> {
+        let value = from + (to - from) / 2;
+        let mut node = Box::new(Node {
+            value,
+            left: None,
+            right: None,
+        });
+        if value > from {
+            node.left = Some(Self::make_balanced_tree(from, value - 1));
+        }
+        if value < to {
+            node.right = Some(Self::make_balanced_tree(value + 1, to));
+        }
+        node
+    }
+
+    /// Sequential baseline.
+    pub fn sum(&self) -> i64 {
+        let mut res = self.value;
+        if let Some(child) = &self.left {
+            res += child.sum();
+        }
+        if let Some(child) = &self.right {
+            res += child.sum();
+        }
+        res
+    }
+}
+
+/// The parallel sum, structured exactly like `sum` in the Zig example: fork the
+/// right child, run the left inline, join (running the right inline if it was
+/// never stolen).
+fn sum(mut s: Scope<'_, '_>, node: &Node) -> i64 {
+    // Load the value *before* forking: written after the joins, LLVM sinks
+    // this load below both recursive calls, putting its latency on every
+    // frame's critical path — worth ~20% on this whole benchmark.
+    let value = node.value;
+    match (&node.left, &node.right) {
+        (Some(left), Some(right)) => {
+            let (l, r) = s.fork_join(|s| sum(s, left), |s| sum(s, right));
+            value + l + r
+        }
+        (Some(child), None) | (None, Some(child)) => value + sum(s, child),
+        (None, None) => value,
+    }
+}
+
+/// A [`Park`] backed by `std::thread::park`. The library itself is `no_std` and
+/// knows nothing about threads, so the host supplies this the same way the
+/// kernel will supply a WFI-based one.
+fn std_park() -> Park {
+    fn park(ptr: *const ()) {
+        let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+        debug_assert_eq!(me.id(), thread::current().id());
+
+        thread::park();
+    }
+    fn unpark(ptr: *const ()) {
+        let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+        me.unpark();
+    }
+    fn drop(ptr: *const ()) {
+        unsafe { Arc::decrement_strong_count(ptr.cast::<thread::Thread>()) };
+    }
+
+    static STD_PARK_VTABLE: ParkVTable = ParkVTable { park, unpark, drop };
+
+    let state = Arc::new(thread::current());
+    unsafe { Park::new(Arc::into_raw(state).cast::<()>(), &STD_PARK_VTABLE) }
+}
+
+/// Time the tree sum on `harts` harts: this thread plus `harts - 1` workers.
+fn bench_harts(group: &mut BenchmarkGroup<'_, WallTime>, root: &Node, harts: usize, expected: i64) {
+    let sched = Scheduler::new();
+
+    // On real hardware each hart's timer ISR sets its own CPU-local heartbeat
+    // flag. Here one thread plays the timer for every hart, so each worker has
+    // to publish the address of its flag first.
+    let flags: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+    thread::scope(|scope| {
+        // The idle harts, running whatever gets shared with them.
+        let idle: Vec<_> = (1..harts)
+            .map(|_| {
+                scope.spawn(|| {
+                    let stub = Job::stub();
+                    let mut worker = Worker::new(&sched, std_park(), &stub);
+                    flags
+                        .lock()
+                        .unwrap()
+                        .push(&raw const *worker.heartbeat_flag() as usize);
+
+                    let _ = worker.main_loop();
+                })
+            })
+            .collect();
+
+        // The "timer interrupt". Round-robin, one worker per tick, like the Zig
+        // reference's `heartbeatWorker`: every worker still sees a heartbeat
+        // each `HEARTBEAT_INTERVAL`, but *staggered* — setting every flag at
+        // once makes all workers promote simultaneously and stampede the
+        // scheduler lock.
+        let timer = scope.spawn(|| {
+            let mut i = 0;
+            while !sched.is_stopping() {
+                let mut to_sleep = HEARTBEAT_INTERVAL;
+                {
+                    let flags = flags.lock().unwrap();
+                    if !flags.is_empty() {
+                        i %= flags.len();
+                        // Safety: every worker outlives the joins below, and this
+                        // loop ends once the scheduler is stopping — which is also
+                        // the only way a worker returns.
+                        unsafe {
+                            (*(flags[i] as *const AtomicBool)).store(true, Ordering::Relaxed);
+                        };
+                        i += 1;
+                        to_sleep /= flags.len() as u32;
+                    }
+                }
+
+                thread::sleep(to_sleep);
+            }
+        });
+
+        // The hart asking for the tree sum. The others only get anything to do
+        // because this one's heartbeat shares its jobs.
+        let stub = Job::stub();
+        let mut worker = Worker::new(&sched, std_park(), &stub);
+        flags
+            .lock()
+            .unwrap()
+            .push(&raw const *worker.heartbeat_flag() as usize);
+
+        assert_eq!(worker.scope(|s| sum(s, root)), expected);
+
+        // `black_box` on the input: `sum` is a pure function of read-only
+        // memory, and LLVM will otherwise merge the repeated calls across
+        // iterations, reporting picoseconds.
+        group.bench_function(BenchmarkId::new("heartbeat", harts), |b| {
+            b.iter(|| worker.scope(|s| sum(s, black_box(root))));
+        });
+
+        sched.stop();
+
+        // A worker may not be dropped while another hart can still reach it: a
+        // thief unparks its owner *after* publishing the result. Join everyone
+        // before `worker` goes out of scope. See `Worker::new`.
+        for hart in idle {
+            hart.join().unwrap();
+        }
+        timer.join().unwrap();
+    });
+}
+
+fn env_list(name: &str, default: &[usize]) -> Vec<usize> {
+    match std::env::var(name) {
+        Ok(s) => s
+            .split(',')
+            .map(|v| {
+                v.trim()
+                    .parse()
+                    .unwrap_or_else(|_| panic!("bad {name}: {v:?}"))
+            })
+            .collect(),
+        Err(_) => default.to_vec(),
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let sizes = env_list("HEARTBEAT_BENCH_SIZES", &[1000, 10_000_000]);
+    let harts = env_list("HEARTBEAT_BENCH_HARTS", &[1, 2, 4, 8, 16, 32]);
+
+    for &n in &sizes {
+        let mut group = c.benchmark_group(format!("tree-sum-{n}"));
+        group.sample_size(50);
+
+        let root = Node::make_balanced_tree(1, n as i64);
+
+        // Correctness check outside the timed region: 1 + 2 + ... + n.
+        let expected = (n as i64) * (n as i64 + 1) / 2;
+        assert_eq!(root.sum(), expected);
+
+        group.bench_function(BenchmarkId::new("Baseline", 1), |b| {
+            b.iter(|| black_box(root.as_ref()).sum());
+        });
+
+        for &harts in &harts {
+            bench_harts(&mut group, &root, harts, expected);
+        }
+
+        group.finish();
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/lib/heartbeat/examples/adversarial.rs
+++ b/lib/heartbeat/examples/adversarial.rs
@@ -1,0 +1,265 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Adversarial benchmarks for the scheduler's known hard cases:
+//!
+//! 1. **Idle-transition latency** (`short`): repeated sums of a tree small
+//!    enough that stolen subtrees finish in well under a heartbeat interval,
+//!    so workers constantly finish, go idle, and need re-feeding. A steal only
+//!    becomes available when a victim's beat re-advertises, so refeed latency
+//!    is bounded by the (staggered) tick.
+//!
+//! 2. **Skew** (`skewed`): one sum of a heavily lopsided tree (90/10 split),
+//!    so the promotable jobs at any moment differ in size by orders of
+//!    magnitude and *which* job a thief gets matters as much as getting one.
+//!
+//! Sizing `short` down (`HEARTBEAT_SHORT_N=1000`) turns it into the tiny-scope
+//! case: scopes shorter than a tick, where promotion is pure overhead.
+//!
+//! ```sh
+//! buck2 run //lib/heartbeat:heartbeat-adversarial -m release -- [short|skewed|all] [threads...]
+//! HEARTBEAT_SHORT_N=300000 HEARTBEAT_SKEWED_N=10000000  # size overrides
+//! ```
+
+use std::hint::black_box;
+use std::mem::ManuallyDrop;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use heartbeat::{Job, Park, ParkVTable, Scheduler, Scope, Worker};
+
+/// Interval at which each worker is handed a heartbeat.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_micros(100);
+
+struct Node {
+    value: i64,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
+}
+
+impl Node {
+    /// Pre-order allocation with the pivot at `num/den` of the range: the left
+    /// subtree holds that fraction of the values. `1/2` is the balanced tree;
+    /// `9/10` makes the *forked* (right) subtrees hold ~10% of whatever
+    /// remains, so queued job sizes fall off geometrically along the spine.
+    fn lopsided(from: i64, to: i64, num: i64, den: i64) -> Box<Node> {
+        let value = from + (to - from) * num / den;
+        let mut node = Box::new(Node {
+            value,
+            left: None,
+            right: None,
+        });
+        if value > from {
+            node.left = Some(Self::lopsided(from, value - 1, num, den));
+        }
+        if value < to {
+            node.right = Some(Self::lopsided(value + 1, to, num, den));
+        }
+        node
+    }
+
+    fn sum(&self) -> i64 {
+        let mut res = self.value;
+        if let Some(child) = &self.left {
+            res += child.sum();
+        }
+        if let Some(child) = &self.right {
+            res += child.sum();
+        }
+        res
+    }
+}
+
+fn sum(mut s: Scope<'_, '_>, node: &Node) -> i64 {
+    // Loaded before the forks so the load's latency hides behind the subtree
+    // walk (P3); see `examples/binary_tree.rs`.
+    let value = node.value;
+    match (&node.left, &node.right) {
+        (Some(left), Some(right)) => {
+            let (l, r) = s.fork_join(|s| sum(s, left), |s| sum(s, right));
+            value + l + r
+        }
+        (Some(child), None) | (None, Some(child)) => value + sum(s, child),
+        (None, None) => value,
+    }
+}
+
+/// A [`Park`] backed by `std::thread::park`; same as the other examples.
+fn std_park() -> Park {
+    fn park(ptr: *const ()) {
+        let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+        debug_assert_eq!(me.id(), thread::current().id());
+
+        thread::park();
+    }
+    fn unpark(ptr: *const ()) {
+        let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+        me.unpark();
+    }
+    fn drop(ptr: *const ()) {
+        unsafe { Arc::decrement_strong_count(ptr.cast::<thread::Thread>()) };
+    }
+
+    static STD_PARK_VTABLE: ParkVTable = ParkVTable { park, unpark, drop };
+
+    let state = Arc::new(thread::current());
+    // Safety: `std::thread` park/unpark is a sticky permit, and the `Arc` keeps
+    // the handle alive until `drop` releases it.
+    unsafe { Park::new(Arc::into_raw(state).cast::<()>(), &STD_PARK_VTABLE) }
+}
+
+fn bench(name: &str, n: i64, expected: i64, mut f: impl FnMut() -> i64) {
+    let warmup = Duration::from_secs_f64(
+        std::env::var("SPICE_WARMUP_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3.0),
+    );
+    let n_samples: usize = std::env::var("SPICE_SAMPLES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+
+    assert_eq!(f(), expected);
+
+    let start = Instant::now();
+    while start.elapsed() < warmup {
+        std::hint::black_box(f());
+    }
+
+    let mut samples = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
+        let t0 = Instant::now();
+        let got = std::hint::black_box(f());
+        let elapsed = t0.elapsed().as_nanos() as f64;
+        assert_eq!(got, expected);
+        samples.push(elapsed / n as f64);
+    }
+
+    let min = samples.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = samples.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    println!("{name:>24}:  Min: {min:.4} ns  Mean: {mean:.4} ns  Max: {max:.4} ns");
+}
+
+/// Run `f` with the full scheduler wiring — `threads - 1` main-loop workers
+/// plus the staggered heartbeat timer — handing it the requesting worker.
+fn with_scheduler(threads: usize, f: impl FnOnce(&mut Worker<'_>)) {
+    let sched = Scheduler::new();
+    let flags: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+    thread::scope(|scope| {
+        let idle: Vec<_> = (1..threads)
+            .map(|_| {
+                scope.spawn(|| {
+                    let stub = Job::stub();
+                    let mut worker = Worker::new(&sched, std_park(), &stub);
+                    flags
+                        .lock()
+                        .unwrap()
+                        .push(&raw const *worker.heartbeat_flag() as usize);
+
+                    let _ = worker.main_loop();
+                })
+            })
+            .collect();
+
+        // Staggered round-robin timer, as in `examples/binary_tree.rs` (P14).
+        let timer = scope.spawn(|| {
+            let mut i = 0;
+            while !sched.is_stopping() {
+                let mut to_sleep = HEARTBEAT_INTERVAL;
+                {
+                    let flags = flags.lock().unwrap();
+                    if !flags.is_empty() {
+                        i %= flags.len();
+                        // Safety: every worker outlives the joins below, and this
+                        // loop ends once the scheduler is stopping — which is also
+                        // the only way a worker returns.
+                        unsafe {
+                            (*(flags[i] as *const AtomicBool)).store(true, Ordering::Relaxed);
+                        };
+                        i += 1;
+                        to_sleep /= flags.len() as u32;
+                    }
+                }
+
+                thread::sleep(to_sleep);
+            }
+        });
+
+        let stub = Job::stub();
+        let mut worker = Worker::new(&sched, std_park(), &stub);
+        flags
+            .lock()
+            .unwrap()
+            .push(&raw const *worker.heartbeat_flag() as usize);
+
+        f(&mut worker);
+
+        sched.stop();
+        for hart in idle {
+            hart.join().unwrap();
+        }
+        timer.join().unwrap();
+    });
+}
+
+fn env_size(name: &str, default: i64) -> i64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let which = args.next().unwrap_or_else(|| "all".to_string());
+    let threads: Vec<usize> = args.map(|a| a.parse().expect("bad thread count")).collect();
+    let threads = if threads.is_empty() {
+        vec![1, 2, 4, 8]
+    } else {
+        threads
+    };
+
+    if which == "short" || which == "all" {
+        // Small enough that a whole sum is only a few heartbeat intervals long:
+        // stolen subtrees are *short*, so workers cycle through idle constantly.
+        let n = env_size("HEARTBEAT_SHORT_N", 300_000);
+        let expected = n * (n + 1) / 2;
+        println!("== short: repeated sums of a balanced {n}-node tree");
+        let root = Node::lopsided(1, n, 1, 2);
+
+        for &t in &threads {
+            with_scheduler(t, |worker| {
+                bench(&format!("short {t} thr"), n, expected, || {
+                    worker.scope(|s| sum(s, black_box(&root)))
+                });
+            });
+        }
+    }
+
+    if which == "skewed" || which == "all" {
+        // 90/10 split: the forked jobs queued along the spine differ in size by
+        // orders of magnitude, so *which* promoted job a thief ends up with
+        // matters as much as getting one at all.
+        let n = env_size("HEARTBEAT_SKEWED_N", 10_000_000);
+        let expected = n * (n + 1) / 2;
+        println!("== skewed: one sum of a 90/10 lopsided {n}-node tree");
+        let root = Node::lopsided(1, n, 9, 10);
+
+        for &t in &threads {
+            with_scheduler(t, |worker| {
+                bench(&format!("skewed {t} thr"), n, expected, || {
+                    worker.scope(|s| sum(s, black_box(&root)))
+                });
+            });
+        }
+    }
+}

--- a/lib/heartbeat/examples/adversarial.rs
+++ b/lib/heartbeat/examples/adversarial.rs
@@ -165,7 +165,7 @@ fn with_scheduler(threads: usize, f: impl FnOnce(&mut Worker<'_>)) {
                         .unwrap()
                         .push(&raw const *worker.heartbeat_flag() as usize);
 
-                    let _ = worker.main_loop();
+                    worker.main_loop();
                 })
             })
             .collect();

--- a/lib/heartbeat/examples/binary_tree.rs
+++ b/lib/heartbeat/examples/binary_tree.rs
@@ -189,7 +189,7 @@ fn main() {
                             .unwrap()
                             .push(&raw const *worker.heartbeat_flag() as usize);
 
-                        let _ = worker.main_loop();
+                        worker.main_loop();
                     })
                 })
                 .collect();

--- a/lib/heartbeat/examples/binary_tree.rs
+++ b/lib/heartbeat/examples/binary_tree.rs
@@ -1,0 +1,251 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Criterion port of Spice's `examples/zig-parallel-example`: build a perfectly
+//! balanced binary tree and time summing all its values, sequentially
+//! (baseline) and through the heartbeat scheduler at various hart counts.
+//!
+//! The scheduler is wired up the way it will be on real hardware: `harts - 1`
+//! workers sitting in `main_loop` waiting for work to be shared with them, the
+//! benchmark thread itself as the hart that asks for the sum, and one thread
+//! standing in for the per-hart timer interrupt that delivers the heartbeats.
+//! Reported times are per whole-tree sum; divide by the node count for ns/node.
+//!
+//! The 10M-node tree needs roughly 400 MB of RAM (upstream's 100M needs ~4 GB).
+//! Override the defaults with env vars, e.g.:
+//!
+//! ```sh
+//! HEARTBEAT_BENCH_SIZES=1000,100000000 HEARTBEAT_BENCH_HARTS=1,2,4 just benchmark //lib/heartbeat:heartbeat_benchmarks
+//! ```
+
+#![expect(clippy::undocumented_unsafe_blocks, reason = "its fine for benchmarks")]
+
+use std::hint::black_box;
+use std::mem::ManuallyDrop;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use heartbeat::{Job, Park, ParkVTable, Scheduler, Scope, Worker};
+
+/// Interval at which each worker is handed a heartbeat.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_micros(100);
+
+struct Node {
+    value: i64,
+    left: Option<Box<Node>>,
+    right: Option<Box<Node>>,
+}
+
+impl Node {
+    /// Parent-first (pre-order) allocation, like the Zig example.
+    fn balanced(from: i64, to: i64) -> Box<Node> {
+        let value = from + (to - from) / 2;
+        let mut node = Box::new(Node {
+            value,
+            left: None,
+            right: None,
+        });
+        if value > from {
+            node.left = Some(Self::balanced(from, value - 1));
+        }
+        if value < to {
+            node.right = Some(Self::balanced(value + 1, to));
+        }
+        node
+    }
+
+    fn sum(&self) -> i64 {
+        let mut res = self.value;
+        if let Some(child) = &self.left {
+            res += child.sum();
+        }
+        if let Some(child) = &self.right {
+            res += child.sum();
+        }
+        res
+    }
+}
+
+/// The parallel sum, structured exactly like `sum` in the Zig example: fork the
+/// right child, run the left inline, join (running the right inline if it was
+/// never stolen).
+fn sum(mut s: Scope<'_, '_>, node: &Node) -> i64 {
+    // Load the value *before* forking: written after the joins, LLVM sinks
+    // this load below both recursive calls, putting its latency on every
+    // frame's critical path — worth ~20% on this whole benchmark. Loaded here,
+    // it waits out the subtree walk in a callee-saved register (this is where
+    // the Zig example gets its `ldp val, left` from).
+    let value = node.value;
+    match (&node.left, &node.right) {
+        (Some(left), Some(right)) => {
+            let (l, r) = s.fork_join(|s| sum(s, left), |s| sum(s, right));
+            value + l + r
+        }
+        (Some(child), None) | (None, Some(child)) => value + sum(s, child),
+        (None, None) => value,
+    }
+}
+
+/// A [`Park`] backed by `std::thread::park`. The library itself is `no_std` and
+/// knows nothing about threads, so the host supplies this the same way the
+/// kernel will supply a WFI-based one.
+fn std_park() -> Park {
+    fn park(ptr: *const ()) {
+        let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+        debug_assert_eq!(me.id(), thread::current().id());
+
+        thread::park();
+    }
+    fn unpark(ptr: *const ()) {
+        let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+        me.unpark();
+    }
+    fn drop(ptr: *const ()) {
+        unsafe { Arc::decrement_strong_count(ptr.cast::<thread::Thread>()) };
+    }
+
+    static STD_PARK_VTABLE: ParkVTable = ParkVTable { park, unpark, drop };
+
+    let state = Arc::new(thread::current());
+    unsafe { Park::new(Arc::into_raw(state).cast::<()>(), &STD_PARK_VTABLE) }
+}
+
+fn bench(name: &str, n: i64, mut f: impl FnMut() -> i64) {
+    let warmup = Duration::from_secs_f64(
+        std::env::var("SPICE_WARMUP_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(3.0),
+    );
+    let n_samples: usize = std::env::var("SPICE_SAMPLES")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50);
+
+    let expected = n * (n + 1) / 2;
+    assert_eq!(f(), expected);
+
+    let start = Instant::now();
+    while start.elapsed() < warmup {
+        std::hint::black_box(f());
+    }
+
+    let mut samples = Vec::with_capacity(n_samples);
+    for _ in 0..n_samples {
+        let t0 = Instant::now();
+        let got = std::hint::black_box(f());
+        let elapsed = t0.elapsed().as_nanos() as f64;
+        assert_eq!(got, expected);
+        samples.push(elapsed / n as f64);
+    }
+
+    let min = samples.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = samples.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    println!("{name:>16}:  Min: {min:.4} ns  Mean: {mean:.4} ns  Max: {max:.4} ns");
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let n: i64 = args
+        .next()
+        .and_then(|a| a.parse().ok())
+        .unwrap_or(10_000_000);
+    let threads: Vec<usize> = args.map(|a| a.parse().expect("bad thread count")).collect();
+    let threads = if threads.is_empty() {
+        vec![1, 2, 4, 8]
+    } else {
+        threads
+    };
+
+    println!("building balanced tree with {n} nodes...");
+    let root = Node::balanced(1, n);
+
+    bench("Baseline", n, || std::hint::black_box(&*root).sum());
+
+    for &num_threads in &threads {
+        let sched = Scheduler::new();
+
+        // On real hardware each hart's timer ISR sets its own CPU-local heartbeat
+        // flag. Here one thread plays the timer for every hart, so each worker has
+        // to publish the address of its flag first.
+        let flags: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+        thread::scope(|scope| {
+            // The idle harts, running whatever gets shared with them.
+            let idle: Vec<_> = (1..num_threads)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let stub = Job::stub();
+                        let mut worker = Worker::new(&sched, std_park(), &stub);
+                        flags
+                            .lock()
+                            .unwrap()
+                            .push(&raw const *worker.heartbeat_flag() as usize);
+
+                        let _ = worker.main_loop();
+                    })
+                })
+                .collect();
+
+            // The "timer interrupt". Round-robin, one worker per tick, like the
+            // Zig reference's `heartbeatWorker`: every worker still sees a
+            // heartbeat each `HEARTBEAT_INTERVAL`, but *staggered* — setting
+            // every flag at once makes all workers promote simultaneously and
+            // stampede the scheduler lock.
+            let timer = scope.spawn(|| {
+                let mut i = 0;
+                while !sched.is_stopping() {
+                    let mut to_sleep = HEARTBEAT_INTERVAL;
+                    {
+                        let flags = flags.lock().unwrap();
+                        if !flags.is_empty() {
+                            i %= flags.len();
+                            // Safety: every worker outlives the joins below, and this
+                            // loop ends once the scheduler is stopping — which is also
+                            // the only way a worker returns.
+                            unsafe {
+                                (*(flags[i] as *const AtomicBool)).store(true, Ordering::Relaxed);
+                            };
+                            i += 1;
+                            to_sleep /= flags.len() as u32;
+                        }
+                    }
+
+                    thread::sleep(to_sleep);
+                }
+            });
+
+            // The hart asking for the tree sum. The others only get anything to do
+            // because this one's heartbeat shares its jobs.
+            let stub = Job::stub();
+            let mut worker = Worker::new(&sched, std_park(), &stub);
+            flags
+                .lock()
+                .unwrap()
+                .push(&raw const *worker.heartbeat_flag() as usize);
+
+            assert_eq!(worker.scope(|s| sum(s, &root)), root.sum());
+
+            bench(&format!("Spice {num_threads} thr"), n, || {
+                worker.scope(|s| sum(s, std::hint::black_box(&root)))
+            });
+
+            sched.stop();
+
+            // A worker may not be dropped while another hart can still reach it: a
+            // thief unparks its owner *after* publishing the result. Join everyone
+            // before `worker` goes out of scope. See `Worker::new`.
+            for hart in idle {
+                hart.join().unwrap();
+            }
+            timer.join().unwrap();
+        });
+    }
+}

--- a/lib/heartbeat/src/lib.rs
+++ b/lib/heartbeat/src/lib.rs
@@ -34,7 +34,7 @@
 //!   function taking `&mut Scope` makes every frame's scope address escape, so
 //!   LLVM pins it to a stack slot and P1 silently evaporates (measured: the
 //!   entire benefit). Cold paths take `&Worker` and rebuild their own context —
-//!   see [`Worker::await_shared_job`].
+//!   see [`Worker::work_until`].
 //! - **P3 — Hoist loads above the fork.** A load written *after* a join
 //!   (`node.value + l + r`) gets sunk by LLVM below both recursive calls, onto
 //!   every frame's critical path. Loaded *before* the fork it waits out the
@@ -55,7 +55,7 @@
 //!   unlinked" traps disappear. See [`Worker::new`], [`Job::stub`].
 //! - **P7 — Inline discipline.** `#[inline(always)]` on `fork_join` and `call`
 //!   (the whole hot path must dissolve into the caller); `#[cold]` on
-//!   `heartbeat`; `#[inline(never)]` on `await_shared_job` (keeps the join's
+//!   `heartbeat`; `#[inline(never)]` on `work_until` (keeps the join's
 //!   fast path small enough to stay inline).
 //! - **P8 — Overlap closure and result in one union.** [`Stage`] stores `F`
 //!   and `R` in the same bytes; which is live follows from the job state, so a
@@ -141,7 +141,7 @@ mod park;
 
 use core::cell::{Cell, UnsafeCell};
 use core::fmt;
-use core::mem::{ManuallyDrop, offset_of};
+use core::mem::{offset_of, ManuallyDrop};
 use core::ptr::{self, NonNull};
 
 use cordyceps::list;
@@ -436,53 +436,7 @@ impl<'a> Worker<'a> {
     /// Run shared jobs, and sleep when there are none. Returns once the scheduler
     /// is [`stop`](Scheduler::stop)ped.
     pub fn main_loop(&mut self) {
-        loop {
-            let work = {
-                let mut synced = self.scheduler.synced.lock();
-
-                // `park` can return without anybody having dequeued us: a thief that
-                // ran one of our promoted jobs unparks us once it has published the
-                // result, and that token can land long after we joined the job and
-                // went idle. Take ourselves back out of the list before doing
-                // anything else — a worker that is about to run a job must not be
-                // holding a place in `idle`, because running it means it might
-                // promote, and promoting needs these very links.
-                synced.remove_idle(&self.header);
-
-                // Read under the lock, and `stop` writes it under the lock: seeing
-                // `false` here means `stop` has not drained `idle` yet, so it is
-                // guaranteed to find the node we are about to push.
-                if self.scheduler.is_stopping() {
-                    break;
-                }
-
-                match Scheduler::take_oldest_shared_work(&mut synced) {
-                    Some(work) => Some(work),
-                    // No work *and* registered as idle, decided together under the
-                    // guard. This is the whole point of taking the lock: we cannot
-                    // fall asleep while a job is sitting in `shared`.
-                    None => {
-                        synced.push_idle(&self.header);
-                        None
-                    }
-                }
-            };
-
-            match work {
-                Some((job, owner)) => {
-                    // An idle worker's own list is empty, so the executing scope
-                    // starts at the head.
-                    let mut scope = Scope {
-                        worker: self,
-                        job_tail: self.job_head,
-                    };
-                    scope.execute_job(job, owner);
-                }
-                // The guard is gone by now, so this never sleeps holding the lock.
-                // Whoever wakes us removed us from `idle` first.
-                None => self.header.park.park(),
-            }
-        }
+        self.work_until(|| self.scheduler.is_stopping());
     }
 
     /// Run `f` with fork/join access to this worker.
@@ -582,34 +536,42 @@ impl<'a> Worker<'a> {
         }
     }
 
-    /// Wait for one of our promoted jobs to come back, helping out in the meantime.
+    /// Pull and run shared jobs until `done`; park when there is nothing to pull.
     ///
-    /// `is_ready` belongs to the one job we are joining: several of our jobs can be
-    /// in flight at once, and their thieves finish in whatever order they like, so a
-    /// per-worker flag could not tell us *which* job is done. The unpark is only a
-    /// hint — any of our thieves, or a promoter with fresh work, may have sent it —
-    /// so the flag, not the wakeup, is what we trust.
+    /// The entire taker side of the scheduler, shared by its two users:
+    /// [`main_loop`](Worker::main_loop) runs it until [`stop`](Scheduler::stop),
+    /// and a join whose job was stolen runs it until the thief publishes the
+    /// result ([`fork_join`](Scope::fork_join)).
+    ///
+    /// `done` is checked under the guard, in the same critical section that
+    /// cleans up a stale registration and decides between taking work and
+    /// registering as idle — so every exit is deregistered and empty-handed,
+    /// and a worker can never fall asleep while a job sits in `shared`.
     ///
     /// A `Worker` method on purpose: this is `fork_join`'s cold path, and taking
     /// `&mut Scope` here would make every frame's scope address escape into this
     /// out-of-line call — pinning the scope to a stack slot and undoing the
-    /// whole by-value discipline. Taking only the worker keeps the hot path's
-    /// scope a pure register value.
+    /// whole by-value discipline (P2). Taking only the worker keeps the hot
+    /// path's scope a pure register value.
     #[inline(never)]
-    fn await_shared_job(&self, is_ready: &AtomicBool) {
+    fn work_until(&self, done: impl Fn() -> bool) {
         loop {
             let work = {
                 let mut synced = self.scheduler.synced.lock();
 
-                // The same stale-token cleanup as `main_loop`: our thief's
-                // unpark can land long after an advertise-wake already pulled
-                // us off the list. Take ourselves back out before anything
+                // Stale-token cleanup: our unpark can land long after an
+                // advertise-wake already pulled us off the list (a thief's
+                // result token, say). Take ourselves back out before anything
                 // else — a worker about to run a job (or return to user code)
                 // must not hold a place in `idle`, because running means
                 // promoting, and promoting needs these very links.
+                //
+                // For `stop`: it writes `stopping` under this lock, so seeing
+                // `false` in `done` here means it has not drained `idle` yet
+                // and is guaranteed to find the node we may push below.
                 synced.remove_idle(&self.header);
 
-                if is_ready.load(Ordering::Acquire) {
+                if done() {
                     break;
                 }
 
@@ -641,13 +603,14 @@ impl<'a> Worker<'a> {
             };
 
             if let Some((job, owner)) = work {
-                // Our queued list is empty right now: the job we are awaiting
+                // Our own queued list is empty right now — `main_loop` workers
+                // run nothing of their own, and for a joiner the job it awaits
                 // was promoted, a promoted job is older than anything queued —
                 // so everything older was promoted before it — and everything
-                // younger has already been joined. Helping therefore starts
-                // from the head, where its forks stay reachable by
-                // [`shift`](Worker::shift) (upstream's `executeJob`/`begin()`
-                // discipline, assert included).
+                // younger has already been joined. Executing from the head
+                // keeps the job's forks reachable by [`shift`](Worker::shift)
+                // (upstream's `executeJob`/`begin()` discipline, assert
+                // included).
                 // Safety: the stub outlives the worker (`Worker::new`'s contract).
                 debug_assert!(unsafe { self.job_head.as_ref() }.next.get().is_null());
                 let mut scope = Scope {
@@ -859,7 +822,14 @@ impl Scope<'_, '_> {
             let b = ManuallyDrop::into_inner(unsafe { job.stage.into_inner().f });
             call(self.worker, self.job_tail, b)
         } else {
-            self.worker.await_shared_job(&job.is_ready);
+            // Stolen: pull and run other shared jobs until the thief publishes
+            // ours. `is_ready` is per-job on purpose: several of our jobs can
+            // be in flight at once and finish in any order, so only a flag on
+            // the job itself can say *this* one is done — the unpark is only a
+            // hint (any of our thieves, or a promoter with fresh work, may
+            // have sent it); the flag is what we trust.
+            self.worker
+                .work_until(|| job.is_ready.load(Ordering::Acquire));
 
             // Safety: `is_ready` is set, so whoever ran the job replaced the closure
             // with its result and will never touch the stage again.
@@ -923,7 +893,7 @@ impl<F, R> TypedJob<F, R> {
         ) where
             F: FnOnce(Scope<'_, '_>) -> R,
         {
-            // Are we running our *own* promoted job? `await_shared_job` steals from
+            // Are we running our *own* promoted job? `work_until` steals from
             // `shared`, and what it finds may well be the very job it is waiting for.
             // There is nobody to wake in that case — we are who would have been woken
             // — and unparking ourselves would leave a token nobody consumes, which
@@ -1169,7 +1139,7 @@ mod tests {
     /// helping — push onto a detached node. With the heartbeat flag held high
     /// continuously, *every* fork promotes, so every join takes the
     /// promoted-job path and (with no other worker to steal) runs its own job
-    /// through `await_shared_job`'s "help out" arm — the "empty local list"
+    /// through `work_until`'s "help out" arm — the "empty local list"
     /// path (upstream's `Worker.begin()` assert).
     #[test]
     fn sequential_forks_survive_aggressive_promotion() {

--- a/lib/heartbeat/src/lib.rs
+++ b/lib/heartbeat/src/lib.rs
@@ -1,0 +1,1173 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Heartbeat-scheduled fork/join parallelism.
+//!
+//! Forking is nearly free — a few plain stores into a worker-local intrusive list
+//! — and *sharing* is rare: a timer interrupt periodically flips a per-worker
+//! flag, and the worker's next fork then promotes its oldest queued job so an
+//! idle worker can pick it up. Workers therefore never contend over fine-grained
+//! work items, and a program with no parallelism to exploit runs at sequential
+//! speed.
+//!
+//! # Index of performance techniques
+//!
+//! Everything that makes (or measurably made) this crate fast, numbered so a
+//! future rebuild can cite them. Benchmarked against the Zig reference
+//! implementation (Spice) summing a 10M-node balanced binary tree on an M3 Pro;
+//! "n-thread parity" below means within noise of Zig's ReleaseFast build.
+//!
+//! ## Hot-path codegen
+//!
+//! - **P1 — Pass the per-frame context by value.** The recursion boundary is
+//!   `fn(Scope, …)`: worker pointer and job-list tail cross every call in two
+//!   argument registers, and intra-frame updates are mem2reg'd away. A tail
+//!   living at a fixed address (a field) turns every push/pop at every depth
+//!   into a store→load round trip through that address. Upstream's
+//!   `callWithContext` comment calls this signature "extremely critical"; it is.
+//!   See [`Scope`], [`call`].
+//! - **P2 — Never lend the hot context to a cold path.** One `#[inline(never)]`
+//!   function taking `&mut Scope` makes every frame's scope address escape, so
+//!   LLVM pins it to a stack slot and P1 silently evaporates (measured: the
+//!   entire benefit). Cold paths take `&Worker` and rebuild their own context —
+//!   see [`Worker::await_shared_job`].
+//! - **P3 — Hoist loads above the fork.** A load written *after* a join
+//!   (`node.value + l + r`) gets sunk by LLVM below both recursive calls, onto
+//!   every frame's critical path. Loaded *before* the fork it waits out the
+//!   subtree in a callee-saved register. Worth ~20% end-to-end on the tree sum —
+//!   more than every scheduler tweak combined. User-code pattern; see the
+//!   `sum` examples.
+//! - **P4 — Pop through the job's own `prev`, adopt it as the new tail.** One
+//!   load + one store, and the only correct pop: promotion (`shift`) relinks a
+//!   queued job's `prev` to the head, so the frame's remembered tail can be
+//!   stale — popping through it dangles `head.next` into a dying frame. See
+//!   [`Scope::fork_join`].
+//! - **P5 — State packed into the link words.** `is_queued` — asked on every
+//!   join — is a single load + null-test of `prev` (queued: `prev` set;
+//!   promoted: `prev` null, `next` dead). No discriminant, no flags.
+//!   See [`Job`].
+//! - **P6 — A stub node makes the empty list unrepresentable.** Push and pop
+//!   never branch on emptiness, and `is_linked`-style "lone node reports
+//!   unlinked" traps disappear. See [`Worker::new`], [`Job::stub`].
+//! - **P7 — Inline discipline.** `#[inline(always)]` on `fork_join` and `call`
+//!   (the whole hot path must dissolve into the caller); `#[cold]` on
+//!   `heartbeat`; `#[inline(never)]` on `await_shared_job` (keeps the join's
+//!   fast path small enough to stay inline).
+//! - **P8 — Overlap closure and result in one union.** [`Stage`] stores `F`
+//!   and `R` in the same bytes; which is live follows from the job state, so a
+//!   fork costs `max(F, R)` stack bytes and no tag.
+//! - **P9 — Three-word type-erased jobs.** A [`Job`] is `execute` + two links;
+//!   the concrete closure/result live in the enclosing [`TypedJob`], and
+//!   `execute` is monomorphized per pair. Thieves read nothing else.
+//!
+//! ## Architecture
+//!
+//! - **P10 — Owner-only `Cell`s on the fork path.** The job list is only ever
+//!   touched by its owning hart, so links are plain `Cell`s: zero atomics, zero
+//!   fences on the per-fork path. Cross-hart reachability is confined to
+//!   [`WorkerHeader`].
+//! - **P11 — One global lock, taken only at heartbeat frequency.** Promote,
+//!   steal, sleep — never fork. "A global mutex is fine when there's no
+//!   contention" (Spice README).
+//! - **P12 — Heartbeat is a polled flag, not preemption.** The timer only does
+//!   a relaxed store; the worker folds one relaxed load + branch into each
+//!   fork. See [`Worker::heartbeat_flag`].
+//! - **P13 — Reclaim un-stolen promotions.** A join whose job was promoted but
+//!   never claimed takes it back under the lock and runs it inline, instead of
+//!   detouring through the await/steal machinery (which would often execute
+//!   somebody *else's* older job first — work inversion — and then run its own
+//!   type-erased). Upstream's `waitForJob` fast path. Worth ~9% at every
+//!   thread count, including single-threaded, where every promotion is
+//!   un-stolen. See [`Worker::reclaim_shared`].
+//! - **P14 — Stagger the heartbeats.** One worker per timer tick, round-robin
+//!   at `interval / workers` — not all flags at once. Synchronized heartbeats
+//!   make every worker promote in the same instant and stampede the scheduler
+//!   lock. Applies to the real kernel too: align each hart's heartbeat timer
+//!   phase-shifted, not simultaneous. See the example/bench timer threads.
+//!
+//! ## Measurement discipline (how the above were found)
+//!
+//! - **P15 — Verify the build you benchmark.** Buck2 applies a target's
+//!   `modifiers` only when it is the top-level target: our criterion runner
+//!   silently built the whole graph at `-Copt-level=0` (11× slower) until the
+//!   runner target carried the modifiers too. Confirm with
+//!   `buck2 cquery "deps(target, 1)"` — the configuration *hash* must match a
+//!   known-optimized build.
+//! - **P16 — Diff disassembly against the reference, don't guess.** Every real
+//!   finding here (P1, P2, P3) was visible as a concrete instruction-level
+//!   difference (`objdump -d --disassemble-symbols=…`) between our hot loop and
+//!   Zig's; hypotheses that sounded plausible (store-count pressure) were
+//!   refuted by measuring, not argued.
+//! - **P17 — Benchmark hygiene.** Back-to-back A/B runs on the same machine
+//!   state; compare min as well as mean (variance is a finding); allocate the
+//!   benchmark tree pre-order so walk order matches layout (~2× on its own);
+//!   `black_box` the recursion input or LLVM merges iterations.
+//!
+//! # Where the state lives
+//!
+//! Two places, and which is which is what makes the scheduler reasonable about:
+//!
+//! 1. **The running hart's stack** — the job list, rooted at [`Worker`] with
+//!    its hot end, the tail, riding by value in the [`Scope`] threaded through
+//!    the recursion. No other hart can name either, so forking and joining need
+//!    no synchronization at all.
+//! 2. **[`Scheduler::synced`]** — the promoted jobs, and the workers parked
+//!    looking for work. It lives *inside* the lock, so there is no way to write
+//!    down an access to it without holding the guard.
+//!
+//! The single lock is only taken at heartbeat frequency — on a promote, a steal,
+//! or a worker going to sleep — never on the per-fork hot path. "A global mutex
+//! is fine when there's no contention", as the Spice README puts it, and this
+//! follows the original in taking it.
+//!
+//! Taking a lock is also what makes the sleep protocol correct: deciding *there
+//! is no work* and *registering as idle* happen together, under the guard, so a
+//! worker cannot go to sleep while a job is sitting in the queue. The original
+//! gets the same atomicity from a condition variable, which releases its mutex as
+//! it sleeps; we cannot hold a spinlock across a `wfi`, so the gap between
+//! dropping the guard and actually sleeping is covered by [`Park`]'s token
+//! instead — see [`ParkVTable`]'s stickiness requirement.
+
+// #![no_std]
+#![feature(never_type)]
+
+mod loom;
+#[cfg(all(test, loom))]
+mod loom_tests;
+mod park;
+
+use core::cell::{Cell, UnsafeCell};
+use core::fmt;
+use core::mem::{ManuallyDrop, offset_of};
+use core::ptr::{self, NonNull};
+
+use cordyceps::list;
+use loom::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+pub use park::{Park, ParkVTable};
+use spin::IrqMutex;
+
+/// The state every worker shares.
+pub struct Scheduler {
+    /// Read on every pass of [`Worker::main_loop`], so it stays an atomic rather
+    /// than moving into [`Synced`] — but it is only ever *written* under the lock.
+    /// That is what closes the race between a worker deciding to sleep and
+    /// [`stop`](Scheduler::stop) draining the idle list: a worker that reads
+    /// `false` while holding the guard is guaranteed to have registered itself
+    /// before `stop` looks.
+    stopping: AtomicBool,
+    synced: IrqMutex<Synced>,
+}
+
+/// Everything the scheduler's lock guards. The only way to name it is to hold the
+/// guard.
+struct Synced {
+    /// Workers advertising a promoted job, oldest first: promotions append, steals
+    /// take from the front. That ordering *is* the oldest-first steal the original
+    /// gets from a logical clock plus a scan over every worker.
+    ///
+    /// A worker is in here exactly while its `shared_job` is non-null, so it needs
+    /// no membership flag of its own.
+    shared: list::List<WorkerHeader>,
+    /// Workers parked in [`Worker::main_loop`] with nothing left to do. Membership
+    /// is tracked by [`WorkerHeader::in_idle_list`].
+    idle: list::List<WorkerHeader>,
+}
+
+impl Synced {
+    /// Register `worker` as idle.
+    fn push_idle(&mut self, worker: &WorkerHeader) {
+        debug_assert!(
+            !worker.in_idle_list.load(Ordering::Relaxed),
+            "worker registered as idle twice"
+        );
+        worker.in_idle_list.store(true, Ordering::Relaxed);
+        self.idle.push_back(NonNull::from_ref(worker));
+    }
+
+    /// Take one idle worker off the list, to hand it work or to stop it.
+    fn pop_idle(&mut self) -> Option<NonNull<WorkerHeader>> {
+        let worker = self.idle.pop_front()?;
+        // Safety: workers outlive the scheduler's use of them. See `Worker::new`.
+        unsafe { worker.as_ref() }
+            .in_idle_list
+            .store(false, Ordering::Relaxed);
+        Some(worker)
+    }
+
+    /// Take `worker` back off the idle list, if it is on it. This is the one thing an
+    /// `MpscQueue` could not do, and the reason these are doubly linked.
+    fn remove_idle(&mut self, worker: &WorkerHeader) {
+        if worker.in_idle_list.swap(false, Ordering::Relaxed) {
+            // Safety: the flag says this worker is linked into `idle`, and `idle` is
+            // the only list that flag ever refers to.
+            unsafe { self.idle.remove(NonNull::from_ref(worker)) };
+        }
+    }
+}
+
+impl Default for Scheduler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Scheduler {
+    // Not `const`: under `--cfg loom` the atomics are not const-constructible.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            stopping: AtomicBool::new(false),
+            synced: IrqMutex::new(Synced {
+                shared: list::List::new(),
+                idle: list::List::new(),
+            }),
+        }
+    }
+
+    pub fn is_stopping(&self) -> bool {
+        self.stopping.load(Ordering::Acquire)
+    }
+
+    /// Ask every worker in [`Worker::main_loop`] to return. Idempotent.
+    pub fn stop(&self) {
+        {
+            // Under the lock, so it cannot land between a worker finding no work
+            // and that worker adding itself to `idle`.
+            let _synced = self.synced.lock();
+            self.stopping.store(true, Ordering::Release);
+        }
+
+        loop {
+            let worker = self.synced.lock().pop_idle();
+            let Some(worker) = worker else { break };
+
+            // Never unpark with the lock held: `IrqMutex` keeps interrupts off for
+            // as long as it is held, and an unpark can be an `ecall` into the SBI.
+            //
+            // Safety: workers outlive the scheduler's use of them. See `Worker::new`.
+            unsafe { worker.as_ref() }.park.unpark();
+        }
+    }
+
+    /// Claim the oldest promoted job, and the worker that owns it.
+    ///
+    /// The caller must hold the lock, which is what makes the job ours to run: a
+    /// job is in `shared` exactly once, and taking it removes it.
+    fn take_oldest_shared_work(
+        synced: &mut Synced,
+    ) -> Option<(NonNull<Job>, NonNull<WorkerHeader>)> {
+        let owner = synced.shared.pop_front()?;
+
+        // Safety: workers outlive the scheduler's use of them. See `Worker::new`.
+        let job = unsafe { owner.as_ref() }
+            .shared_job
+            .swap(ptr::null_mut(), Ordering::Relaxed);
+
+        // A worker is linked into `shared` if and only if its slot is full, and
+        // both happen together under this lock. Bailing rather than unwrapping
+        // keeps the scheduler core panic-free even if that ever stopped holding.
+        debug_assert!(!job.is_null(), "a worker in `shared` had no job to share");
+
+        Some((NonNull::new(job)?, owner))
+    }
+}
+
+/// The part of a worker that *other* harts can reach.
+pub struct WorkerHeader {
+    /// The job this worker is advertising. Non-null exactly while the worker is
+    /// linked into [`Synced::shared`].
+    ///
+    /// Guarded by the scheduler's lock — every access below is `Relaxed`, because
+    /// the lock already orders them. It is an atomic only so that `WorkerHeader`
+    /// stays `Sync` without an `unsafe impl`.
+    shared_job: AtomicPtr<Job>,
+
+    /// Set by this hart's timer interrupt; read and cleared by the worker's next
+    /// fork. See [`Worker::heartbeat_flag`].
+    ///
+    /// The one piece of shared state the lock does *not* guard, because an
+    /// interrupt handler must never take a lock. So it is a genuine atomic, and a
+    /// single relaxed store is the whole of what the ISR does.
+    heartbeat: AtomicBool,
+
+    /// Whether this worker is currently linked into [`Synced::idle`].
+    ///
+    /// `Links::is_linked` cannot answer this. It is `next.is_some() ||
+    /// prev.is_some()`, so the *only* node in a list reports itself as **unlinked** —
+    /// the same trap the job list keeps a stub node around to avoid (see
+    /// [`Worker::new`]). A lone idle worker would therefore fail to take itself back
+    /// off the list and enqueue itself twice.
+    ///
+    /// Guarded by the scheduler's lock, like `shared_job`.
+    in_idle_list: AtomicBool,
+
+    park: Park,
+
+    /// This worker's node in **either** [`Synced::shared`] or [`Synced::idle`].
+    ///
+    /// One set of links for both lists, which is sound because membership in them
+    /// is mutually exclusive: a worker is in `idle` only while it is parked in
+    /// `main_loop` with nothing to do, and in `shared` only while it has a promoted
+    /// job in flight — and a worker with nothing to do has no promoted job, because
+    /// every fork is joined before its `fork_join` returns. `heartbeat`
+    /// debug-asserts it.
+    ///
+    /// The lists are doubly linked, so a worker can take *itself* back out of one.
+    /// That is what lets `main_loop` clean up after a `park` that returned without
+    /// anybody having dequeued it.
+    links: list::Links<WorkerHeader>,
+}
+
+impl WorkerHeader {
+    fn new(park: Park) -> Self {
+        Self {
+            shared_job: AtomicPtr::new(ptr::null_mut()),
+            heartbeat: AtomicBool::new(false),
+            in_idle_list: AtomicBool::new(false),
+            park,
+            links: list::Links::new(),
+        }
+    }
+}
+
+// Safety: the links are at the `links` field, and `map_addr` preserves the
+// provenance of the header the pointer came from.
+unsafe impl cordyceps::Linked<list::Links<Self>> for WorkerHeader {
+    type Handle = NonNull<Self>;
+
+    fn into_ptr(r: Self::Handle) -> NonNull<Self> {
+        r
+    }
+
+    unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+        ptr
+    }
+
+    unsafe fn links(ptr: NonNull<Self>) -> NonNull<list::Links<Self>> {
+        ptr.map_addr(|addr| {
+            let offset = offset_of!(Self, links);
+            addr.checked_add(offset).unwrap()
+        })
+        .cast()
+    }
+}
+
+/// One hart's handle on the scheduler.
+///
+/// The job list is rooted here — its tail rides in the [`Scope`] — and lives on
+/// the owning hart's stack, where no other hart can name it. Everything another
+/// hart *can* reach is in the [`WorkerHeader`].
+pub struct Worker<'a> {
+    header: WorkerHeader,
+
+    /// The stub handed to [`Worker::new`]: the permanent front of this worker's
+    /// job list. The list itself is an intrusive doubly-linked chain threaded
+    /// through the three-word [`Job`]s, which live in their `fork_join` frames
+    /// on this hart's stack. Forks push at the tail and joins pop from it
+    /// (LIFO); the heartbeat [`shift`](Worker::shift)s from the front (FIFO),
+    /// so thieves always get the *oldest* job. That asymmetry is the heart of
+    /// heartbeat scheduling.
+    ///
+    /// **Owner-only.** Every link is only ever touched by the hart that owns
+    /// the worker, which is what makes the plain `Cell`s in [`Job`] sound:
+    /// there is never a concurrent reader or writer. There is deliberately no
+    /// `len` and no emptiness branch — the stub means the empty case is not
+    /// special.
+    job_head: NonNull<Job>,
+    scheduler: &'a Scheduler,
+}
+
+impl<'a> Worker<'a> {
+    /// Attach a worker to `scheduler`.
+    ///
+    /// `stub` is the sentinel that sits at the front of this worker's job list.
+    /// It must belong to this worker alone: `Links::is_linked` is
+    /// `next.is_some() || prev.is_some()`, so a job that is the *only* node in
+    /// the list would report itself as unlinked. Keeping a node in front of
+    /// every real job makes `is_linked` mean what `fork_join` needs it to mean —
+    /// "still mine, nobody took it".
+    ///
+    /// # A worker must outlive the scheduler's use of it
+    ///
+    /// A `Worker` owns its [`WorkerHeader`], and the header is what other harts
+    /// reach it through — so a worker may not be dropped while any hart can still
+    /// touch it. Concretely, a thief unparks the owner *after* it has published a
+    /// job's result, and the owner may already have returned from `fork_join` by
+    /// then. Dropping the `Worker` in that window is a use-after-free of its
+    /// header.
+    ///
+    /// On bare metal this is free — [`main_loop`](Worker::main_loop) diverges, so a
+    /// worker lives as long as its hart. On a hosted target, join every worker
+    /// thread before the last `Worker` goes out of scope.
+    pub fn new(scheduler: &'a Scheduler, park: Park, stub: &'a Job) -> Self {
+        Self {
+            header: WorkerHeader::new(park),
+            job_head: NonNull::from_ref(stub),
+            scheduler,
+        }
+    }
+
+    /// The flag that hands this worker a heartbeat, i.e. permission to share its
+    /// oldest job with someone else the next time it forks.
+    ///
+    /// It is set from this hart's timer interrupt, which is the only reason any of
+    /// this worker has to be reachable from another CPU at all.
+    pub fn heartbeat_flag(&self) -> &AtomicBool {
+        &self.header.heartbeat
+    }
+
+    /// Run shared jobs, and sleep when there are none. Returns once the scheduler
+    /// is [`stop`](Scheduler::stop)ped.
+    ///
+    /// # Errors
+    ///
+    /// Always `Err(())` — it only ever returns because the scheduler is stopping,
+    /// and it can produce no value.
+    pub fn main_loop(&mut self) -> Result<!, ()> {
+        loop {
+            let work = {
+                let mut synced = self.scheduler.synced.lock();
+
+                // `park` can return without anybody having dequeued us: a thief that
+                // ran one of our promoted jobs unparks us once it has published the
+                // result, and that token can land long after we joined the job and
+                // went idle. Take ourselves back out of the list before doing
+                // anything else — a worker that is about to run a job must not be
+                // holding a place in `idle`, because running it means it might
+                // promote, and promoting needs these very links.
+                synced.remove_idle(&self.header);
+
+                // Read under the lock, and `stop` writes it under the lock: seeing
+                // `false` here means `stop` has not drained `idle` yet, so it is
+                // guaranteed to find the node we are about to push.
+                if self.scheduler.is_stopping() {
+                    break;
+                }
+
+                match Scheduler::take_oldest_shared_work(&mut synced) {
+                    Some(work) => Some(work),
+                    // No work *and* registered as idle, decided together under the
+                    // guard. This is the whole point of taking the lock: we cannot
+                    // fall asleep while a job is sitting in `shared`.
+                    None => {
+                        synced.push_idle(&self.header);
+                        None
+                    }
+                }
+            };
+
+            match work {
+                Some((job, owner)) => {
+                    // An idle worker's own list is empty, so the executing scope
+                    // starts at the head.
+                    let mut scope = Scope {
+                        worker: self,
+                        job_tail: self.job_head,
+                    };
+                    scope.execute_job(job, owner);
+                }
+                // The guard is gone by now, so this never sleeps holding the lock.
+                // Whoever wakes us removed us from `idle` first.
+                None => self.header.park.park(),
+            }
+        }
+
+        Err(())
+    }
+
+    /// Run `f` with fork/join access to this worker.
+    ///
+    /// This is how a hart that *has* work enters the scheduler (the equivalent
+    /// of upstream's `pool.call`); [`main_loop`](Worker::main_loop) is how a
+    /// hart *without* work does.
+    pub fn scope<R>(&mut self, f: impl FnOnce(Scope<'_, '_>) -> R) -> R {
+        // The list must be empty: the stub is its own tail.
+        // Safety: the stub outlives the worker (`Worker::new`'s contract).
+        debug_assert!(unsafe { self.job_head.as_ref() }.next.get().is_null());
+
+        let r = f(Scope {
+            worker: self,
+            job_tail: self.job_head,
+        });
+
+        // Everything forked was joined, so it is empty again.
+        // Safety: as above.
+        debug_assert!(unsafe { self.job_head.as_ref() }.next.get().is_null());
+
+        r
+    }
+
+    /// Promote our oldest queued job so another worker can pick it up, and wake one
+    /// if any is asleep.
+    ///
+    /// `&self`: only the owning hart calls this (from [`Scope::fork_join`]), and
+    /// everything it touches is a `Cell` behind the owner-only discipline, an
+    /// atomic, or lives inside the scheduler's lock.
+    #[cold]
+    fn heartbeat(&self) {
+        let to_wake = {
+            let mut synced = self.scheduler.synced.lock();
+
+            // Already advertising a job? Then there is nothing to share: one promoted
+            // job per worker, as upstream.
+            if self.header.shared_job.load(Ordering::Relaxed).is_null() {
+                if let Some(job) = self.shift() {
+                    self.header
+                        .shared_job
+                        .store(job.as_ptr(), Ordering::Relaxed);
+
+                    // The two lists share one set of links, so this must hold — a
+                    // worker that is running (and therefore able to promote) has
+                    // already taken itself off `idle`.
+                    debug_assert!(
+                        !self.header.in_idle_list.load(Ordering::Relaxed),
+                        "a worker promoting a job cannot also be idle"
+                    );
+                    synced.shared.push_back(NonNull::from_ref(&self.header));
+
+                    synced.pop_idle()
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        // Never signal with the lock held: `IrqMutex` keeps interrupts off, and an
+        // unpark can be an `ecall` into the SBI.
+        if let Some(worker) = to_wake {
+            // Safety: workers outlive the scheduler's use of them. See `Worker::new`.
+            unsafe { worker.as_ref() }.park.unpark();
+        }
+
+        // Publishes nothing, so it needs no ordering: it is the same flag the timer
+        // interrupt sets with a relaxed store.
+        self.header.heartbeat.store(false, Ordering::Relaxed);
+    }
+
+    /// Take a promoted-but-unclaimed job back from the shared set.
+    ///
+    /// Returns `true` if `job` was still ours to take — nobody claimed it — in
+    /// which case its stage still holds the untouched closure and the caller
+    /// runs it inline, exactly as if it had never been promoted. That is much
+    /// cheaper than the alternative (executing it type-erased via
+    /// [`await_shared_job`], often *after* first executing somebody else's
+    /// older job), and it is what upstream's `waitForJob` does first.
+    #[cold]
+    fn reclaim_shared(&self, job: &Job) -> bool {
+        let mut synced = self.scheduler.synced.lock();
+
+        // Relaxed: guarded by the lock, like every `shared_job` access.
+        if ptr::eq(self.header.shared_job.load(Ordering::Relaxed), job) {
+            self.header
+                .shared_job
+                .store(ptr::null_mut(), Ordering::Relaxed);
+            // Safety: a worker whose `shared_job` is non-null is linked into
+            // `shared` — the two change together, under this lock.
+            unsafe { synced.shared.remove(NonNull::from_ref(&self.header)) };
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Wait for one of our promoted jobs to come back, helping out in the meantime.
+    ///
+    /// `is_ready` belongs to the one job we are joining: several of our jobs can be
+    /// in flight at once, and their thieves finish in whatever order they like, so a
+    /// per-worker flag could not tell us *which* job is done. The unpark is only a
+    /// hint — any of our thieves may have sent it — so the flag, not the wakeup, is
+    /// what we trust.
+    ///
+    /// A `Worker` method on purpose: this is `fork_join`'s cold path, and taking
+    /// `&mut Scope` here would make every frame's scope address escape into this
+    /// out-of-line call — pinning the scope to a stack slot and undoing the
+    /// whole by-value discipline. Taking only the worker keeps the hot path's
+    /// scope a pure register value.
+    #[inline(never)]
+    fn await_shared_job(&self, is_ready: &AtomicBool) {
+        while !is_ready.load(Ordering::Acquire) {
+            let work = {
+                let mut synced = self.scheduler.synced.lock();
+                Scheduler::take_oldest_shared_work(&mut synced)
+            };
+
+            if let Some((job, owner)) = work {
+                // Our queued list is empty right now: the job we are awaiting
+                // was promoted, a promoted job is older than anything queued —
+                // so everything older was promoted before it — and everything
+                // younger has already been joined. Helping therefore starts
+                // from the head, where its forks stay reachable by
+                // [`shift`](Worker::shift) (upstream's `executeJob`/`begin()`
+                // discipline, assert included).
+                // Safety: the stub outlives the worker (`Worker::new`'s contract).
+                debug_assert!(unsafe { self.job_head.as_ref() }.next.get().is_null());
+                let mut scope = Scope {
+                    worker: self,
+                    job_tail: self.job_head,
+                };
+                scope.execute_job(job, owner);
+                continue;
+            }
+
+            // We are not idle — we have a job outstanding — so we never enter the
+            // idle list, and wait on our own token instead. Nobody else can hand our
+            // job back to us; whoever ran it unparks us.
+            self.header.park.park();
+        }
+    }
+
+    /// Unlink and return the oldest queued job, moving it to the promoted state
+    /// (its `prev` nulled — what [`Job::is_queued`] tests). Returns `None` if
+    /// the list is empty **or** the oldest job is also the (linked) tail: the
+    /// tail is what the innermost `fork_join` is about to join, and the join's
+    /// cheap pop relies on a joined job being the tail. (The Zig original's
+    /// `shift`, tail refusal included.)
+    fn shift(&self) -> Option<NonNull<Job>> {
+        // Safety: every node in the list was pushed by this hart and is kept
+        // alive by its blocked `fork_join` frame (push's contract).
+        unsafe {
+            let head = self.job_head.as_ref();
+            let oldest = head.next.get();
+            if oldest.is_null() {
+                return None;
+            }
+            let next = (*oldest).next.get();
+            if next.is_null() {
+                return None;
+            }
+            (*next).prev.set(self.job_head.as_ptr());
+            head.next.set(next);
+            (*oldest).prev.set(ptr::null_mut());
+            Some(NonNull::new_unchecked(oldest))
+        }
+    }
+}
+
+/// A unit of work that *could* run on another hart.
+///
+/// Type-erased: the concrete closure and result types live in the [`TypedJob`] this
+/// is the first field of, and `execute` is monomorphized per pair.
+///
+/// Exactly three words, like the upstream Zig `Job`, with the queued/promoted
+/// state packed into `prev`:
+///
+/// - **queued**: `prev` points at the previous node (possibly the stub), `next`
+///   at the following one (or null at the tail);
+/// - **promoted/executing**: `prev` is null; `next` is dead.
+///
+/// So [`is_queued`](Job::is_queued) — the question `fork_join` asks on every
+/// join — is a *single* load and null-test, instead of `Links::is_linked`'s two
+/// loads and two tests.
+///
+/// The links are `Cell`s because only the owning hart ever touches them — the
+/// pushes and pops inlined into [`Scope::fork_join`], and [`Worker::shift`]. A
+/// thief is handed the job only *after* `shift` has unlinked it under the
+/// scheduler's lock, and reads nothing but `execute` and the [`TypedJob`]
+/// fields around it.
+#[derive(Debug)]
+pub struct Job {
+    execute: unsafe fn(NonNull<Job>, &mut Scope<'_, '_>, &WorkerHeader),
+    prev: Cell<*mut Job>,
+    next: Cell<*mut Job>,
+}
+
+impl Job {
+    /// The sentinel a [`Worker`] keeps at the front of its job list. It is never
+    /// promoted — [`Worker::shift`] shares the job *after* it — so it is never
+    /// executed.
+    pub const fn stub() -> Self {
+        unsafe fn stub_execute(
+            _job: NonNull<Job>,
+            _executing_scope: &mut Scope<'_, '_>,
+            _owning_worker: &WorkerHeader,
+        ) {
+            unreachable!("the job list stub was executed")
+        }
+
+        Self {
+            execute: stub_execute,
+            prev: Cell::new(ptr::null_mut()),
+            next: Cell::new(ptr::null_mut()),
+        }
+    }
+
+    /// Still in the owner's [`JobList`], i.e. nobody promoted it. One load.
+    #[inline(always)]
+    fn is_queued(&self) -> bool {
+        !self.prev.get().is_null()
+    }
+}
+
+/// The per-frame execution context: everything the hot path needs, **by value**.
+///
+/// Two words — a pointer to the hart's [`Worker`] and the current job-list
+/// tail — passed by value into every user function and rebuilt fresh per frame
+/// by [`call`]. That is upstream's `callWithContext` discipline, and it is
+/// load-bearing: a tail that lives at one memory address (a field) turns every
+/// push and pop, at every recursion depth, into a store→load→store round trip
+/// through that one address; a per-frame value crosses call boundaries in an
+/// argument register and its intra-frame updates are mem2reg'd away entirely.
+///
+/// `Scope` is deliberately **not `Copy`**: a frame duplicating its scope and
+/// forking on both copies would give the two diverging pictures of the same
+/// list. Move semantics make that unrepresentable, while `fork_join(&mut self)`
+/// on the frame's one binding stays ergonomic.
+///
+/// Coherence between the frames' copies is the fork/join *balance*: every job a
+/// frame pushes is joined before the frame returns, so a callee hands back the
+/// list exactly as it found it, and the caller's copy is still correct — with
+/// one exception, the promoted-job join, documented in
+/// [`fork_join`](Scope::fork_join).
+pub struct Scope<'a, 'b> {
+    worker: &'a Worker<'b>,
+    job_tail: NonNull<Job>,
+}
+
+/// Upstream's `callWithContext`: enter user code with a *fresh* context passed
+/// **by value** — two words, two argument registers, no frame slot. This is the
+/// literal shape of the Zig boundary (`callWithContext(worker, job_tail, …)`),
+/// visible in its disassembly as `mov x1, sp` where a by-reference context
+/// would store the tail to memory.
+#[inline(always)]
+fn call<R>(worker: &Worker<'_>, job_tail: NonNull<Job>, f: impl FnOnce(Scope<'_, '_>) -> R) -> R {
+    f(Scope { worker, job_tail })
+}
+
+impl Scope<'_, '_> {
+    /// Fork `b` off as a stealable job, run `a`, then join: either `b` was
+    /// never stolen and runs inline (the overwhelmingly common case), or its
+    /// result is awaited from whoever ran it.
+    ///
+    /// # The promoted-job join
+    ///
+    /// A join that finds its job promoted returns with this frame's tail
+    /// pointing at a node [`shift`](Worker::shift) has since detached from the
+    /// list. That is deliberate, and harmless: pushes onto a detached node
+    /// still form a well-linked chain — joins walk `prev`, which stays intact —
+    /// the chain is merely invisible to `shift`, so jobs forked after such a
+    /// join cannot be promoted until the stack unwinds past the detached node.
+    /// Promotion is only a parallelism hint; correctness never depends on it.
+    #[inline(always)]
+    pub fn fork_join<A, B, RA, RB>(&mut self, a: A, b: B) -> (RA, RB)
+    where
+        A: FnOnce(Scope<'_, '_>) -> RA,
+        B: FnOnce(Scope<'_, '_>) -> RB + Send,
+        RB: Send,
+    {
+        let job = TypedJob::new(b);
+
+        // Push onto the frame's tail: three stores, no branches. (`job.next` is
+        // already null from `TypedJob::new`, and a pushed job is the new tail.)
+        //
+        // Safety: joined (or awaited) below, on every path, before this frame
+        // dies — so the job outlives its time in the list. The tail is the stub
+        // or a job in a still-live caller frame.
+        unsafe {
+            self.job_tail
+                .as_ref()
+                .next
+                .set(ptr::from_ref(&job.job).cast_mut());
+            job.job.prev.set(self.job_tail.as_ptr());
+        }
+
+        if self.worker.header.heartbeat.load(Ordering::Relaxed) {
+            self.worker.heartbeat();
+        }
+
+        let ra = call(self.worker, NonNull::from_ref(&job.job), a);
+
+        let prev = job.job.prev.get();
+        let rb = if !prev.is_null() {
+            // Still queued — nobody promoted it; run it inline. This is the hot
+            // path.
+            //
+            // Pop through the job's *own* `prev`, not this frame's `job_tail`:
+            // forks are joined LIFO, so our job is the innermost queued one, but
+            // `shift` may have promoted everything older and relinked our `prev`
+            // to the head. Popping via `job_tail` would then unlink a detached
+            // node and leave `head.next` pointing at this dying frame's job —
+            // the next `shift` would walk into a dead stack. Adopting `prev` as
+            // the frame's tail is what keeps later forks reachable (upstream's
+            // `pop(&task.job_tail)` does exactly this), and it is the one place
+            // a callee hands its caller back a *different* list position.
+            //
+            // Safety: a queued job's `prev` is the stub or a job in a still-live
+            // caller frame.
+            unsafe {
+                (*prev).next.set(ptr::null_mut());
+                self.job_tail = NonNull::new_unchecked(prev);
+            }
+
+            // Safety: still queued means nobody promoted it, so the stage still
+            // holds the closure we put there.
+            let b = ManuallyDrop::into_inner(unsafe { job.stage.into_inner().f });
+            call(self.worker, self.job_tail, b)
+        } else if self.worker.reclaim_shared(&job.job) {
+            // Promoted, but nobody claimed it: take it back and run it inline.
+            //
+            // Safety: reclaimed under the lock, so no thief has touched the
+            // stage — the closure is still there.
+            let b = ManuallyDrop::into_inner(unsafe { job.stage.into_inner().f });
+            call(self.worker, self.job_tail, b)
+        } else {
+            self.worker.await_shared_job(&job.is_ready);
+
+            // Safety: `is_ready` is set, so whoever ran the job replaced the closure
+            // with its result and will never touch the stage again.
+            ManuallyDrop::into_inner(unsafe { job.stage.into_inner().r })
+        };
+
+        (ra, rb)
+    }
+
+    fn execute_job(&mut self, job: NonNull<Job>, owner: NonNull<WorkerHeader>) {
+        // Safety: the job belongs to a `fork_join` frame that stays blocked until we
+        // set its `is_ready`, so it is live for as long as we hold it.
+        let j = unsafe { job.as_ref() };
+        // Safety: workers outlive the scheduler's use of them. See `Worker::new`.
+        let owner = unsafe { owner.as_ref() };
+
+        // Safety: we claimed this job out of `shared` under the lock, so it is ours
+        // to run and its stage still holds the closure.
+        unsafe {
+            (j.execute)(job, self, owner);
+        }
+    }
+}
+
+#[repr(C)]
+struct TypedJob<F, R> {
+    job: Job,
+    is_ready: AtomicBool,
+    stage: UnsafeCell<Stage<F, R>>,
+}
+
+impl<F, R> fmt::Debug for TypedJob<F, R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TypedJob")
+            .field("job", &self.job)
+            .field("is_ready", &self.is_ready)
+            .field("stage", &"<...>")
+            .finish()
+    }
+}
+
+/// The closure and its result, overlapping in one slot: whoever runs the job moves
+/// `F` out, runs it, and writes `R` back over the same bytes. Which one is live
+/// follows from `is_ready`, so no discriminant is stored.
+#[repr(C)]
+union Stage<F, R> {
+    f: ManuallyDrop<F>,
+    r: ManuallyDrop<R>,
+}
+
+impl<F, R> TypedJob<F, R> {
+    pub fn new(f: F) -> Self
+    where
+        F: FnOnce(Scope<'_, '_>) -> R + Send,
+        R: Send,
+    {
+        unsafe fn execute<F, R>(
+            job: NonNull<Job>,
+            executing_scope: &mut Scope<'_, '_>,
+            owning_worker: &WorkerHeader,
+        ) where
+            F: FnOnce(Scope<'_, '_>) -> R,
+        {
+            // Are we running our *own* promoted job? `await_shared_job` steals from
+            // `shared`, and what it finds may well be the very job it is waiting for.
+            // There is nobody to wake in that case — we are who would have been woken
+            // — and unparking ourselves would leave a token nobody consumes, which
+            // the next `park` would burn on a phantom wakeup.
+            let is_own = ptr::eq(owning_worker, &executing_scope.worker.header);
+
+            // Safety: the caller claimed this job from `shared` under the lock, so it
+            // is in the executing state and this `TypedJob` frame is still live.
+            let job = unsafe { job.cast::<TypedJob<F, R>>().as_ref() };
+            // Safety: an executing job's closure has not been taken — only this
+            // function takes it, and a job is claimed exactly once.
+            let f = unsafe { job.stage.get().cast::<F>().read() };
+            // Hand the closure a by-value scope at the executing worker's
+            // current position; its forks balance out before it returns.
+            let scope = Scope {
+                worker: executing_scope.worker,
+                job_tail: executing_scope.job_tail,
+            };
+            // Safety: the stage is ours until `is_ready` below hands it back to
+            // the owner, and `f` was read out above, so the slot is dead.
+            unsafe {
+                job.stage.get().cast::<R>().write(f(scope));
+            }
+
+            // Our last touch of the *job*: the `fork_join` frame it lives in may
+            // return, and die, the instant this lands. The owner's *header* outlives
+            // that frame — it belongs to the `Worker`, which outlives the whole
+            // scheduler (see `Worker::new`) — so the unpark below is still sound.
+            job.is_ready.store(true, Ordering::Release);
+
+            if !is_own {
+                owning_worker.park.unpark();
+            }
+        }
+
+        Self {
+            job: Job {
+                execute: execute::<F, R>,
+                // `fork_join`'s push overwrites `prev` and relies on `next`
+                // starting null (a pushed job is the new tail). A null `prev`
+                // is also what makes a never-forked job read as not-queued.
+                prev: Cell::new(ptr::null_mut()),
+                next: Cell::new(ptr::null_mut()),
+            },
+            is_ready: AtomicBool::new(false),
+            stage: UnsafeCell::new(Stage {
+                f: ManuallyDrop::new(f),
+            }),
+        }
+    }
+}
+
+#[cfg(all(test, not(loom)))]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+
+    /// Interval at which each worker is handed a heartbeat.
+    const HEARTBEAT_INTERVAL: Duration = Duration::from_micros(100);
+
+    struct Node {
+        value: i64,
+        left: Option<Box<Node>>,
+        right: Option<Box<Node>>,
+    }
+
+    impl Node {
+        /// Parent-first (pre-order) allocation, like the Zig example.
+        fn balanced(from: i64, to: i64) -> Box<Node> {
+            let value = from + (to - from) / 2;
+            let mut node = Box::new(Node {
+                value,
+                left: None,
+                right: None,
+            });
+            if value > from {
+                node.left = Some(Self::balanced(from, value - 1));
+            }
+            if value < to {
+                node.right = Some(Self::balanced(value + 1, to));
+            }
+            node
+        }
+
+        fn sum(&self) -> i64 {
+            let mut res = self.value;
+            if let Some(child) = &self.left {
+                res += child.sum();
+            }
+            if let Some(child) = &self.right {
+                res += child.sum();
+            }
+            res
+        }
+    }
+
+    fn sum(mut s: Scope<'_, '_>, node: &Node) -> i64 {
+        // Loaded before the forks so the load's latency hides behind the
+        // subtree walk; see the note in `examples/binary_tree.rs`.
+        let value = node.value;
+        match (&node.left, &node.right) {
+            (Some(left), Some(right)) => {
+                let (l, r) = s.fork_join(|s| sum(s, left), |s| sum(s, right));
+                value + l + r
+            }
+            (Some(child), None) | (None, Some(child)) => value + sum(s, child),
+            (None, None) => value,
+        }
+    }
+
+    fn std_park() -> Park {
+        fn park(ptr: *const ()) {
+            let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+            debug_assert_eq!(me.id(), thread::current().id());
+
+            thread::park();
+        }
+        fn unpark(ptr: *const ()) {
+            let me = ManuallyDrop::new(unsafe { Arc::from_raw(ptr.cast::<thread::Thread>()) });
+            me.unpark();
+        }
+        fn drop(ptr: *const ()) {
+            unsafe { Arc::decrement_strong_count(ptr.cast::<thread::Thread>()) };
+        }
+
+        static STD_PARK_VTABLE: ParkVTable = ParkVTable { park, unpark, drop };
+
+        let state = Arc::new(thread::current());
+        // Safety: `std::thread::park`/`unpark` is a sticky permit, exactly what
+        // `ParkVTable` asks for, and the `Arc` keeps the handle alive until `drop`
+        // releases it.
+        unsafe { Park::new(Arc::into_raw(state).cast::<()>(), &STD_PARK_VTABLE) }
+    }
+
+    /// The trap [`WorkerHeader::in_idle_list`] exists for.
+    ///
+    /// `Links::is_linked` is `next.is_some() || prev.is_some()`, so the *only* node
+    /// in a list reports itself as **unlinked**. A lone idle worker whose `park`
+    /// returned on a stale token would therefore fail to take itself back off the
+    /// idle list, and register a second time — which `List::push_back` catches with
+    /// an assertion, but only once some interleaving actually produces it.
+    ///
+    /// Nothing here is concurrent: the bug is a state-machine bug, and a race is
+    /// only what triggers it. So it is checked deterministically.
+    #[test]
+    fn a_lone_idle_worker_can_take_itself_back_off_the_list() {
+        let sched = Scheduler::new();
+        let stub = Job::stub();
+        let worker = Worker::new(&sched, std_park(), &stub);
+
+        let mut synced = sched.synced.lock();
+
+        synced.push_idle(&worker.header);
+        assert!(worker.header.in_idle_list.load(Ordering::Relaxed));
+        // The trap: the sole node in the list still reports itself as unlinked.
+        assert!(!worker.header.links.is_linked());
+
+        // `main_loop` coming back from a park nobody dequeued it for. It has to find
+        // itself and unregister, or the next pass registers an already-linked node.
+        synced.remove_idle(&worker.header);
+        assert!(!worker.header.in_idle_list.load(Ordering::Relaxed));
+
+        // Panics inside `List::push_back` if the removal above did not happen.
+        synced.push_idle(&worker.header);
+
+        assert!(synced.pop_idle().is_some());
+        assert!(synced.pop_idle().is_none());
+    }
+
+    #[test]
+    fn tree_sum() {
+        let harts = thread::available_parallelism().unwrap().get();
+
+        let sched = Scheduler::new();
+        let root = Node::balanced(1, 10_000_000);
+        let expected = root.sum();
+
+        // On real hardware each hart's timer ISR sets its own CPU-local heartbeat
+        // flag. Here one thread plays the timer for every hart, so each worker has to
+        // publish the address of its flag first.
+        let flags: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+        thread::scope(|scope| {
+            // The idle harts, running whatever gets shared with them.
+            let idle: Vec<_> = (1..harts)
+                .map(|_| {
+                    scope.spawn(|| {
+                        let stub = Job::stub();
+                        let mut worker = Worker::new(&sched, std_park(), &stub);
+                        flags
+                            .lock()
+                            .unwrap()
+                            .push(ptr::from_ref(worker.heartbeat_flag()) as usize);
+
+                        let _ = worker.main_loop();
+                    })
+                })
+                .collect();
+
+            // The "timer interrupt".
+            let timer = scope.spawn(|| {
+                while !sched.is_stopping() {
+                    for &flag in flags.lock().unwrap().iter() {
+                        // Safety: every worker outlives the joins below, and this loop
+                        // ends once the scheduler is stopping — which is also the only
+                        // way a worker returns.
+                        unsafe { (*(flag as *const AtomicBool)).store(true, Ordering::Relaxed) };
+                    }
+
+                    thread::sleep(HEARTBEAT_INTERVAL);
+                }
+            });
+
+            // The hart asking for the tree sum. The others only get anything to do
+            // because this one's heartbeat shares its jobs.
+            let stub = Job::stub();
+            let mut worker = Worker::new(&sched, std_park(), &stub);
+            flags
+                .lock()
+                .unwrap()
+                .push(ptr::from_ref(worker.heartbeat_flag()) as usize);
+
+            let got = worker.scope(|s| sum(s, &root));
+            sched.stop();
+
+            // A worker may not be dropped while another hart can still reach it: a
+            // thief unparks its owner *after* publishing the result. Join everyone
+            // before `worker` goes out of scope. See `Worker::new`.
+            for hart in idle {
+                hart.join().unwrap();
+            }
+            timer.join().unwrap();
+
+            assert_eq!(got, expected);
+        });
+    }
+
+    /// Promotion detaches a job from the list while its `fork_join` frame still
+    /// holds the frame's tail, so later forks — in the same frame, or while
+    /// helping — push onto a detached node. With the heartbeat flag held high
+    /// continuously, *every* fork promotes, so every join takes the
+    /// promoted-job path and (with no other worker to steal) runs its own job
+    /// through `await_shared_job`'s "help out" arm — the "empty local list"
+    /// path (upstream's `Worker.begin()` assert).
+    #[test]
+    fn sequential_forks_survive_aggressive_promotion() {
+        fn chain(mut s: Scope<'_, '_>, depth: u32) -> i64 {
+            if depth == 0 {
+                return 1;
+            }
+            // Two fork_joins per frame: the second pushes onto whatever the
+            // first join left the frame's tail pointing at.
+            let (a, b) = s.fork_join(|s| chain(s, depth - 1), |_| 1_i64);
+            let (c, d) = s.fork_join(|_| 1_i64, |_| 1_i64);
+            a + b + c + d
+        }
+
+        const DEPTH: u32 = 64;
+
+        let sched = Scheduler::new();
+        let stub = Job::stub();
+        let mut worker = Worker::new(&sched, std_park(), &stub);
+        let flag = ptr::from_ref(worker.heartbeat_flag()) as usize;
+
+        let done = AtomicBool::new(false);
+        thread::scope(|scope| {
+            // A "timer" that never stops beating: every fork sees the flag set.
+            let timer = scope.spawn(|| {
+                // Safety: `worker` outlives the join below, and this loop stops
+                // before `thread::scope` lets it drop.
+                let flag = flag as *const AtomicBool;
+                while !done.load(Ordering::Acquire) {
+                    unsafe { (*flag).store(true, Ordering::Relaxed) };
+                    std::hint::spin_loop();
+                }
+            });
+
+            let got = worker.scope(|s| chain(s, DEPTH));
+            done.store(true, Ordering::Release);
+            timer.join().unwrap();
+
+            // Each level adds its own 1 + 1 (second fork_join) + 1 (b); the
+            // deepest frame returns 1.
+            assert_eq!(got, i64::from(DEPTH) * 3 + 1);
+        });
+    }
+}

--- a/lib/heartbeat/src/lib.rs
+++ b/lib/heartbeat/src/lib.rs
@@ -133,7 +133,6 @@
 //! instead — see [`ParkVTable`]'s stickiness requirement.
 
 // #![no_std]
-#![feature(never_type)]
 
 mod loom;
 #[cfg(all(test, loom))]
@@ -422,12 +421,7 @@ impl<'a> Worker<'a> {
 
     /// Run shared jobs, and sleep when there are none. Returns once the scheduler
     /// is [`stop`](Scheduler::stop)ped.
-    ///
-    /// # Errors
-    ///
-    /// Always `Err(())` — it only ever returns because the scheduler is stopping,
-    /// and it can produce no value.
-    pub fn main_loop(&mut self) -> Result<!, ()> {
+    pub fn main_loop(&mut self) {
         loop {
             let work = {
                 let mut synced = self.scheduler.synced.lock();
@@ -475,8 +469,6 @@ impl<'a> Worker<'a> {
                 None => self.header.park.park(),
             }
         }
-
-        Err(())
     }
 
     /// Run `f` with fork/join access to this worker.
@@ -1078,7 +1070,7 @@ mod tests {
                             .unwrap()
                             .push(ptr::from_ref(worker.heartbeat_flag()) as usize);
 
-                        let _ = worker.main_loop();
+                        worker.main_loop();
                     })
                 })
                 .collect();

--- a/lib/heartbeat/src/lib.rs
+++ b/lib/heartbeat/src/lib.rs
@@ -178,10 +178,19 @@ struct Synced {
 
 impl Synced {
     /// Register `worker` as idle.
+    ///
+    /// The caller must guarantee `worker` is not linked into [`Synced::shared`]
+    /// — the lists share one set of links — which is equivalent to its
+    /// `shared_job` slot being empty (the two change together, under the lock
+    /// the caller already holds).
     fn push_idle(&mut self, worker: &WorkerHeader) {
         debug_assert!(
             !worker.in_idle_list.load(Ordering::Relaxed),
             "worker registered as idle twice"
+        );
+        debug_assert!(
+            worker.shared_job.load(Ordering::Relaxed).is_null(),
+            "a worker registering as idle must not be advertising (the lists share links)"
         );
         worker.in_idle_list.store(true, Ordering::Relaxed);
         self.idle.push_back(NonNull::from_ref(worker));
@@ -232,6 +241,11 @@ impl Scheduler {
     }
 
     /// Ask every worker in [`Worker::main_loop`] to return. Idempotent.
+    ///
+    /// May transiently pop (and wake) joiners waiting out a stolen job; they
+    /// re-register until their join completes, which it always does — a thief
+    /// finishes the job it is running regardless of `stopping` — so this drain
+    /// terminates.
     pub fn stop(&self) {
         {
             // Under the lock, so it cannot land between a worker finding no work
@@ -573,8 +587,8 @@ impl<'a> Worker<'a> {
     /// `is_ready` belongs to the one job we are joining: several of our jobs can be
     /// in flight at once, and their thieves finish in whatever order they like, so a
     /// per-worker flag could not tell us *which* job is done. The unpark is only a
-    /// hint — any of our thieves may have sent it — so the flag, not the wakeup, is
-    /// what we trust.
+    /// hint — any of our thieves, or a promoter with fresh work, may have sent it —
+    /// so the flag, not the wakeup, is what we trust.
     ///
     /// A `Worker` method on purpose: this is `fork_join`'s cold path, and taking
     /// `&mut Scope` here would make every frame's scope address escape into this
@@ -583,10 +597,47 @@ impl<'a> Worker<'a> {
     /// scope a pure register value.
     #[inline(never)]
     fn await_shared_job(&self, is_ready: &AtomicBool) {
-        while !is_ready.load(Ordering::Acquire) {
+        loop {
             let work = {
                 let mut synced = self.scheduler.synced.lock();
-                Scheduler::take_oldest_shared_work(&mut synced)
+
+                // The same stale-token cleanup as `main_loop`: our thief's
+                // unpark can land long after an advertise-wake already pulled
+                // us off the list. Take ourselves back out before anything
+                // else — a worker about to run a job (or return to user code)
+                // must not hold a place in `idle`, because running means
+                // promoting, and promoting needs these very links.
+                synced.remove_idle(&self.header);
+
+                if is_ready.load(Ordering::Acquire) {
+                    break;
+                }
+
+                match Scheduler::take_oldest_shared_work(&mut synced) {
+                    Some(work) => Some(work),
+                    // Register as idle, decided together with "there is
+                    // nothing to pull" under the guard. Being in `idle` means
+                    // a heartbeat's advertise now wakes blocked joiners too,
+                    // instead of letting available parallelism sleep until the
+                    // joiner's own job completes.
+                    //
+                    // **Unless we are advertising.** A joiner can get here
+                    // with an older promotion of its own still unclaimed (the
+                    // job being joined was stolen while the slot holds an
+                    // older one), and a worker in `shared` must never enter
+                    // `idle`: the two lists share one set of links, so pushing
+                    // here would silently corrupt both. Checked under this
+                    // lock, which is what the slot changes under. Such a
+                    // joiner waits on its own token exactly as before — its
+                    // wake comes from its thief, or from whoever steals the
+                    // advertised job.
+                    None => {
+                        if self.header.shared_job.load(Ordering::Relaxed).is_null() {
+                            synced.push_idle(&self.header);
+                        }
+                        None
+                    }
+                }
             };
 
             if let Some((job, owner)) = work {
@@ -604,13 +655,13 @@ impl<'a> Worker<'a> {
                     job_tail: self.job_head,
                 };
                 scope.execute_job(job, owner);
-                continue;
+            } else {
+                // The guard is gone by now, so this never sleeps holding the
+                // lock. Whoever wakes us — our thief publishing the result, or
+                // a promoter with fresh work — removed us from `idle` first or
+                // left a token.
+                self.header.park.park();
             }
-
-            // We are not idle — we have a job outstanding — so we never enter the
-            // idle list, and wait on our own token instead. Nobody else can hand our
-            // job back to us; whoever ran it unparks us.
-            self.header.park.park();
         }
     }
 

--- a/lib/heartbeat/src/loom.rs
+++ b/lib/heartbeat/src/loom.rs
@@ -1,0 +1,72 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+cfg_if::cfg_if! {
+    if #[cfg(loom)] {
+        pub(crate) use loom::sync;
+        // pub(crate) use loom::cell;
+        // pub(crate) use loom::thread;
+        // pub(crate) use loom::model;
+        // pub(crate) use loom::lazy_static;
+        // pub(crate) use loom::MAX_THREADS;
+    } else {
+        pub(crate) use core::sync;
+        // #[cfg(test)]
+        // pub(crate) use std::sync;
+        // #[cfg(test)]
+        // pub(crate) use std::thread;
+        // #[cfg(test)]
+        // pub(crate) use lazy_static::lazy_static;
+        // #[cfg(test)]
+        // pub const MAX_THREADS: usize = 8;
+
+        // pub(crate) mod cell {
+        //     #[derive(Debug)]
+        //     #[repr(transparent)]
+        //     pub(crate) struct UnsafeCell<T: ?Sized>(core::cell::UnsafeCell<T>);
+
+        //     impl<T> UnsafeCell<T> {
+        //         pub const fn new(data: T) -> UnsafeCell<T> {
+        //             UnsafeCell(core::cell::UnsafeCell::new(data))
+        //         }
+        //     }
+
+        //     impl<T: ?Sized> UnsafeCell<T> {
+        //         #[inline(always)]
+        //         pub fn with<F, R>(&self, f: F) -> R
+        //         where
+        //             F: FnOnce(*const T) -> R,
+        //         {
+        //             f(self.0.get())
+        //         }
+        //         #[inline(always)]
+        //         pub fn with_mut<F, R>(&self, f: F) -> R
+        //         where
+        //             F: FnOnce(*mut T) -> R,
+        //         {
+        //             f(self.0.get())
+        //         }
+        //     }
+        //     impl<T> UnsafeCell<T> {
+        //         #[inline(always)]
+        //         #[must_use]
+        //         pub(crate) fn into_inner(self) -> T {
+        //             self.0.into_inner()
+        //         }
+        //     }
+        // }
+
+        // #[cfg(test)]
+        // #[inline(always)]
+        // pub(crate) fn model<F>(f: F)
+        // where
+        //     F: Fn() + Sync + Send + 'static,
+        // {
+        //     f()
+        // }
+    }
+}

--- a/lib/heartbeat/src/loom_tests.rs
+++ b/lib/heartbeat/src/loom_tests.rs
@@ -1,0 +1,280 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Model-checking the scheduler's handshakes with [`loom`](https://docs.rs/loom).
+//!
+//! ```sh
+//! just loom //lib/heartbeat:heartbeat_loom_tests
+//! ```
+//!
+//! # What is left to check
+//!
+//! Almost all of the scheduler's shared state lives inside the lock, and is
+//! therefore not interesting to loom: the promoted-job list and the idle list are
+//! plain data structures that can only be named through the guard. What the lock
+//! does *not* cover is the handoff at its edges, and that is what these tests are
+//! about:
+//!
+//! - a worker decides to sleep under the guard, but sleeps only after dropping it
+//!   (we cannot hold a spinlock across a `wfi`), and a waker signals only after
+//!   dropping it (a signal can be an `ecall`). The window between the two is
+//!   covered by nothing but [`Park`]'s token;
+//! - a thief publishes a job's result and then unparks its owner, while the owner
+//!   is polling that same result.
+//!
+//! Both are exactly the shape "make a condition true, then record a token" against
+//! "check the condition, then sleep", and neither is safe to eyeball.
+//!
+//! # Scope
+//!
+//! These tests do **not** drive [`Scheduler`](crate::Scheduler) itself. It locks
+//! with `spin::IrqMutex`, and `spin` is not built with `--cfg loom` here, so its
+//! atomics are invisible to the model and its spin loop would never yield — a loom
+//! model would hang inside it. The lock is stood in for by `loom::sync::Mutex`,
+//! which is the same mutual exclusion with a scheduler loom can actually drive.
+
+use loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use loom::sync::{Arc, Mutex};
+use loom::thread;
+
+use crate::{Park, ParkVTable};
+
+/// A [`Park`] whose backend never sleeps — it just yields, which lets loom schedule
+/// the other thread anywhere it likes. That is a strictly stronger adversary than a
+/// real `wfi`, and a legal backend: [`ParkVTable`] permits spurious returns, and
+/// permits not sleeping at all.
+fn loom_park() -> Park {
+    fn park(_ptr: *const ()) {
+        thread::yield_now();
+    }
+    fn unpark(_ptr: *const ()) {}
+    fn drop(_ptr: *const ()) {}
+
+    static LOOM_PARK_VTABLE: ParkVTable = ParkVTable { park, unpark, drop };
+
+    // Safety: `ptr` is never dereferenced by any of the three functions above.
+    unsafe { Park::new(core::ptr::null(), &LOOM_PARK_VTABLE) }
+}
+
+/// The scheduler's wake protocol, which every park site in the crate is an instance
+/// of: a waker makes a *persistent condition* true and then records a token; a
+/// sleeper parks and re-checks the condition. **No interleaving may leave the
+/// sleeper asleep while the condition is true.**
+///
+/// Swap the two stores in the waker — token before condition — and loom finds the
+/// resulting deadlock in well under a second.
+#[test]
+fn wake_racing_park_is_never_lost() {
+    loom::model(|| {
+        let park = Arc::new(loom_park());
+        let ready = Arc::new(AtomicBool::new(false));
+
+        let waker = {
+            let (park, ready) = (park.clone(), ready.clone());
+            thread::spawn(move || {
+                // Condition first, token second. This order is the contract, and it
+                // is what `TypedJob::execute` does with `is_ready`.
+                ready.store(true, Ordering::Release);
+                park.unpark();
+            })
+        };
+
+        // Exactly `Worker::await_shared_job`.
+        while !ready.load(Ordering::Acquire) {
+            park.park();
+        }
+
+        waker.join().unwrap();
+    });
+}
+
+/// `Worker::main_loop` against `Worker::heartbeat`, which is the one place the lock
+/// hands off to the token.
+///
+/// The worker decides *there is no work* and *registers as idle* together, under the
+/// guard — that is the whole reason the scheduler takes a lock at all — but it only
+/// sleeps after dropping it. The promoter publishes the job and takes the worker off
+/// the idle list together, under the guard, but only signals after dropping it. So
+/// the two threads can interleave freely in the gap, and the token is all that keeps
+/// the worker from sleeping through the job.
+///
+/// **A worker that goes to sleep must always be woken again.** Every deadlock this
+/// scheduler has had was a violation of that; if one comes back, loom reports a
+/// deadlock here rather than a benchmark hanging for ten minutes.
+#[test]
+fn a_worker_that_registers_as_idle_is_never_left_asleep() {
+    /// Stands in for `Synced`. Whether a job is waiting, and whether the worker is
+    /// linked into the idle list.
+    struct Synced {
+        shared: bool,
+        idle: bool,
+    }
+
+    loom::model(|| {
+        let synced = Arc::new(Mutex::new(Synced {
+            shared: false,
+            idle: false,
+        }));
+        let park = Arc::new(loom_park());
+        let ran = Arc::new(AtomicBool::new(false));
+
+        // `Worker::heartbeat`: publish the job and pop an idle worker under the
+        // guard; unpark it *outside* the guard.
+        let promoter = {
+            let (synced, park) = (synced.clone(), park.clone());
+            thread::spawn(move || {
+                let to_wake = {
+                    let mut synced = synced.lock().unwrap();
+                    synced.shared = true;
+                    core::mem::replace(&mut synced.idle, false)
+                };
+
+                if to_wake {
+                    park.unpark();
+                }
+            })
+        };
+
+        // `Worker::main_loop`.
+        loop {
+            let work = {
+                let mut synced = synced.lock().unwrap();
+                if synced.shared {
+                    // Take the job, and take ourselves back out of the idle list —
+                    // `main_loop`'s `links.is_linked()` cleanup.
+                    synced.shared = false;
+                    synced.idle = false;
+                    true
+                } else {
+                    synced.idle = true;
+                    false
+                }
+            };
+
+            if work {
+                ran.store(true, Ordering::Release);
+                break;
+            }
+
+            // The guard is gone: from here to the token being consumed, nothing but
+            // `Park` is holding this together.
+            park.park();
+        }
+
+        promoter.join().unwrap();
+        assert!(
+            ran.load(Ordering::Acquire),
+            "the worker never ran the shared job"
+        );
+    });
+}
+
+/// Two wakers racing: the token hands exactly one of them the "you woke it" edge, so
+/// exactly one signal is issued. Under-signalling would strand a parked hart;
+/// over-signalling is only a wasted IPI. The token must survive either way.
+#[test]
+fn concurrent_unparks_record_exactly_one_token() {
+    loom::model(|| {
+        let park = Arc::new(loom_park());
+        let woke = Arc::new(AtomicUsize::new(0));
+
+        let wakers: Vec<_> = (0..2)
+            .map(|_| {
+                let (park, woke) = (park.clone(), woke.clone());
+                thread::spawn(move || {
+                    if park.unpark() {
+                        woke.fetch_add(1, Ordering::AcqRel);
+                    }
+                })
+            })
+            .collect();
+
+        for w in wakers {
+            w.join().unwrap();
+        }
+
+        assert_eq!(
+            woke.load(Ordering::Acquire),
+            1,
+            "the token must be claimed exactly once"
+        );
+
+        // And the surviving token must still wake the parker.
+        park.park();
+    });
+}
+
+/// A worker can park *inside* a job it is helping to execute: `await_shared_job` runs
+/// stolen jobs, and those jobs fork and join in turn. So an inner park loop can
+/// consume a token that was meant for an outer one. That must strand nobody — the
+/// *condition* is the state, and the token is only ever a kick.
+#[test]
+fn a_token_stolen_by_a_nested_loop_strands_nobody() {
+    loom::model(|| {
+        let park = Arc::new(loom_park());
+        let outer = Arc::new(AtomicBool::new(false));
+        let inner = Arc::new(AtomicBool::new(false));
+
+        let wakers: Vec<_> = [outer.clone(), inner.clone()]
+            .into_iter()
+            .map(|flag| {
+                let park = park.clone();
+                thread::spawn(move || {
+                    flag.store(true, Ordering::Release);
+                    park.unpark();
+                })
+            })
+            .collect();
+
+        // The inner loop drains tokens meant for either condition...
+        while !inner.load(Ordering::Acquire) {
+            park.park();
+        }
+        // ...and the outer one must still make progress.
+        while !outer.load(Ordering::Acquire) {
+            park.park();
+        }
+
+        for w in wakers {
+            w.join().unwrap();
+        }
+    });
+}
+
+/// The join handshake, end to end: a thief publishes a job's result, sets `is_ready`,
+/// and unparks the owner; the owner waits on `is_ready` and then reads the result.
+/// The result must always be visible — this is what the `Release` on `is_ready` and
+/// the `Acquire` in `await_shared_job` are for.
+#[test]
+fn a_stolen_jobs_result_is_always_visible_to_the_joiner() {
+    loom::model(|| {
+        let park = Arc::new(loom_park());
+        let is_ready = Arc::new(AtomicBool::new(false));
+        // Stands in for the `Stage` union the thief writes the result into.
+        let result = Arc::new(AtomicUsize::new(0));
+
+        let thief = {
+            let (park, is_ready, result) = (park.clone(), is_ready.clone(), result.clone());
+            thread::spawn(move || {
+                result.store(42, Ordering::Relaxed);
+                is_ready.store(true, Ordering::Release);
+                park.unpark();
+            })
+        };
+
+        while !is_ready.load(Ordering::Acquire) {
+            park.park();
+        }
+        assert_eq!(
+            result.load(Ordering::Relaxed),
+            42,
+            "the joiner read a result the thief had not published yet"
+        );
+
+        thief.join().unwrap();
+    });
+}

--- a/lib/heartbeat/src/loom_tests.rs
+++ b/lib/heartbeat/src/loom_tests.rs
@@ -83,7 +83,7 @@ fn wake_racing_park_is_never_lost() {
             })
         };
 
-        // Exactly `Worker::await_shared_job`.
+        // Exactly `Worker::work_until`'s park loop.
         while !ready.load(Ordering::Acquire) {
             park.park();
         }

--- a/lib/heartbeat/src/park.rs
+++ b/lib/heartbeat/src/park.rs
@@ -1,0 +1,176 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Per-worker blocking: a wake token, and a backend that sleeps the hart.
+//!
+//! Blocking is per-*worker*, never per-job: a hart can only block on itself, and
+//! only another hart can wake it. The whole synchronization lives in the token —
+//! the three-state [`Park::state`] below — and *not* in the sleep instruction. A
+//! waker makes its condition true and then records a token; a sleeper commits to
+//! sleeping and then re-checks. So the backend is free to return spuriously, or
+//! never to sleep at all: a [`ParkVTable`] whose `park` is a bare
+//! [`spin_loop`](core::hint::spin_loop) is correct, merely wasteful, and
+//! everything else is an optimization on top of that.
+
+use crate::loom::sync::atomic::{AtomicI8, Ordering};
+
+/// No token, and nobody sleeping.
+const EMPTY: i8 = 0;
+
+/// Committed to sleeping: the parker has decided to sleep, but may not have
+/// reached [`ParkVTable::park`] yet. This is the state the stickiness
+/// requirement is about.
+const PARKED: i8 = -1;
+
+/// A token is available; the next [`Park::park`] consumes it and returns at once.
+const NOTIFIED: i8 = 1;
+
+/// A worker's wake permit, plus the backend that actually sleeps its hart.
+///
+/// The permit is exactly `std::thread::park`'s, k23's `Notify`, or maitake's
+/// `WaitCell`: recording a token when one is already recorded means the target
+/// has an unconsumed permit, and therefore *cannot stay asleep* — it is
+/// guaranteed to wake, consume it, and re-check its own condition.
+pub struct Park {
+    ptr: *const (),
+    vtable: &'static ParkVTable,
+    state: AtomicI8,
+}
+
+/// How to sleep and wake one hart. Each function receives the `ptr` given to
+/// [`Park::new`].
+///
+/// # The one hard requirement: the backend must be sticky
+///
+/// [`unpark`](ParkVTable::unpark) may be called *before* the matching
+/// [`park`](ParkVTable::park). A parker commits to sleeping (the state becomes
+/// [`PARKED`]) and only then calls into the backend; a waker that sees `PARKED`
+/// signals immediately. Nothing closes the window in between — nothing *can*,
+/// without a lock — so a backend has to behave like a **permit**, not like a
+/// condition-variable signal:
+///
+/// > once unparked, the *next* `park` must return immediately rather than sleep,
+/// > even if that `park` had not been entered yet when the wake arrived.
+///
+/// `std::thread::park`/`unpark` is sticky. A bare `wfi` + IPI is sticky *only*
+/// if the hart parks with interrupts globally masked but individually enabled
+/// (on RISC-V: `sstatus.SIE` clear, `sie.SSIE` set) — the IPI then becomes
+/// pending rather than taken, and a pending interrupt makes `wfi` fall through
+/// instead of sleeping. Clearing `sie.SSIE` instead is the mistake worth
+/// fearing: `wfi` then really does sleep forever. A plain condition variable, or
+/// a notification primitive that drops a wake when nobody is waiting, is **not**
+/// sticky and will lose wakeups here.
+///
+/// The always-correct fallback is not to sleep at all:
+///
+/// ```
+/// # use heartbeat::ParkVTable;
+/// fn park(_ptr: *const ()) {
+///     core::hint::spin_loop();
+/// }
+/// fn unpark(_ptr: *const ()) {}
+/// fn drop(_ptr: *const ()) {}
+///
+/// static SPIN: ParkVTable = ParkVTable { park, unpark, drop };
+/// ```
+///
+/// which burns power but cannot hang, because [`Park::park`] re-checks the token
+/// in a loop. Spurious returns from `park` are always permitted.
+///
+/// The scheduler itself never touches interrupt state; that is entirely
+/// `park`'s business. `park` must also never take a lock another worker could
+/// hold — it is never called with any scheduler state locked, so an `ecall` into
+/// the SBI is fine.
+pub struct ParkVTable {
+    /// Sleep until unparked. May return spuriously, at any time, for any reason;
+    /// may also not sleep at all. Must be sticky — see the type docs.
+    pub park: fn(*const ()),
+    /// Wake the hart, whether or not it is currently parked.
+    pub unpark: fn(*const ()),
+    /// Release the `ptr` given to [`Park::new`]. Called exactly once, when the
+    /// `Park` is dropped.
+    pub drop: fn(*const ()),
+}
+
+// Safety: `ptr` is only ever handed back to the vtable's own functions, which
+// `Park::new`'s contract requires to be callable from any hart. All mutable
+// state is in `state`, which is atomic.
+unsafe impl Send for Park {}
+
+// Safety: as above.
+unsafe impl Sync for Park {}
+
+impl Park {
+    /// Bind a backend to a new, untokened `Park`.
+    ///
+    /// # Safety
+    ///
+    /// - `ptr` must stay valid until this `Park` is dropped. The scheduler hands
+    ///   it to `vtable`'s functions from *other* harts, so whatever it points at
+    ///   must be `Send + Sync`.
+    /// - `vtable` must be sticky, as described on [`ParkVTable`].
+    // Not `const`: under `--cfg loom` the atomics are not const-constructible.
+    #[must_use]
+    pub unsafe fn new(ptr: *const (), vtable: &'static ParkVTable) -> Self {
+        Self {
+            ptr,
+            vtable,
+            state: AtomicI8::new(EMPTY),
+        }
+    }
+
+    /// Consume one token, sleeping until one arrives.
+    ///
+    /// May return spuriously: the caller re-checks its own condition.
+    pub fn park(&self) {
+        // NOTIFIED => EMPTY (consume the token and return), or EMPTY => PARKED.
+        if self.state.fetch_sub(1, Ordering::Acquire) == NOTIFIED {
+            return;
+        }
+
+        loop {
+            (self.vtable.park)(self.ptr);
+
+            // NOTIFIED => EMPTY: our token, consumed. Anything else was spurious
+            // — the state is still PARKED — so sleep again.
+            if self
+                .state
+                .compare_exchange(NOTIFIED, EMPTY, Ordering::Acquire, Ordering::Acquire)
+                .is_ok()
+            {
+                return;
+            }
+        }
+    }
+
+    /// Record a token, and signal the hart if it is asleep. Idempotent.
+    ///
+    /// Returns `true` if this call recorded the token, i.e. if the target had no
+    /// unconsumed permit. Callers must make their condition true *before* calling
+    /// this.
+    pub fn unpark(&self) -> bool {
+        match self.state.swap(NOTIFIED, Ordering::AcqRel) {
+            // Awake, and now holding a token: its next `park` returns at once, so
+            // there is nothing to signal.
+            EMPTY => true,
+            // Committed to sleeping — though possibly not yet inside the
+            // backend's `park`, which is exactly what stickiness covers.
+            PARKED => {
+                (self.vtable.unpark)(self.ptr);
+                true
+            }
+            // Already NOTIFIED: somebody beat us to it, and one token is enough.
+            _ => false,
+        }
+    }
+}
+
+impl Drop for Park {
+    fn drop(&mut self) {
+        (self.vtable.drop)(self.ptr);
+    }
+}

--- a/sample.txt
+++ b/sample.txt
@@ -1,0 +1,640 @@
+Analysis of sampling heartbeat_benchmarks_bin (pid 56465) every 1 millisecond
+Process:         heartbeat_benchmarks_bin [56465]
+Path:            /Users/USER/Documents/*/heartbeat_benchmarks_bin
+Load Address:    0x100254000
+Identifier:      heartbeat_benchmarks_bin
+Version:         ???
+Code Type:       ARM64
+Platform:        macOS
+Parent Process:  bash [56464]
+Target Type:     live task
+
+Date/Time:       2026-07-14 11:24:29.442 +0200
+Launch Time:     2026-07-14 11:17:36.721 +0200
+OS Version:      macOS 26.5.1 (25F80)
+Report Version:  7
+Analysis Tool:   /usr/bin/sample
+
+Physical footprint:         324.8M
+Physical footprint (peak):  324.8M
+Idle exit:                  untracked
+----
+
+Call graph:
+    7601 Thread_5035854   DispatchQueue_1: com.apple.main-thread  (serial)
+    + 7601 start  (in dyld) + 6992  [0x18995fe00]
+    +   7601 main  (in heartbeat_benchmarks_bin) + 36  [0x1002705f0]
+    +     7601 _RINvNtCsblkilOWXfC6_3std2rt10lang_startuECs2VdSuciCVdQ_24heartbeat_benchmarks_bin  (in heartbeat_benchmarks_bin) + 84  [0x10027ace4]  rt.rs:205
+    +       7601 _RNvNtCsblkilOWXfC6_3std2rt19lang_start_internal  (in heartbeat_benchmarks_bin) + 952  [0x1006bf53c]  rt.rs:171
+    +         7601 _RNCINvNtCsblkilOWXfC6_3std2rt10lang_startuE0Cs2VdSuciCVdQ_24heartbeat_benchmarks_bin  (in heartbeat_benchmarks_bin) + 28  [0x10027c958]  rt.rs:206
+    +           7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceFEuuECs2VdSuciCVdQ_24heartbeat_benchmarks_bin  (in heartbeat_benchmarks_bin) + 24  [0x100261754]  backtrace.rs:166
+    +             7601 _RNvYFEuINtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_onceCs2VdSuciCVdQ_24heartbeat_benchmarks_bin  (in heartbeat_benchmarks_bin) + 20  [0x10026b66c]  function.rs:250
+    +               7601 _RNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin4main  (in heartbeat_benchmarks_bin) + 20  [0x10026dd38]  macros.rs:120
+    +                 7601 _RNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin7benches  (in heartbeat_benchmarks_bin) + 52  [0x10026ddd4]  macros.rs:69
+    +                   7601 _RNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin19criterion_benchmark  (in heartbeat_benchmarks_bin) + 1192  [0x10026da94]  binary_tree.rs:229
+    +                     7601 _RNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts  (in heartbeat_benchmarks_bin) + 264  [0x10026d584]  binary_tree.rs:135
+    +                       7601 _RINvNtNtCsblkilOWXfC6_3std6thread6scoped5scopeNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts0uEBM_  (in heartbeat_benchmarks_bin) + 500  [0x100275454]  scoped.rs:158
+    +                         7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x100279674]
+    +                           7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCINvNtNtB6_6thread6scoped5scopeNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts0uE0EuEB2v_  (in heartbeat_benchmarks_bin) + 48  [0x10027c4e8]  panicking.rs:575
+    +                             7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCINvNtNtCsblkilOWXfC6_3std6thread6scoped5scopeNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts0uE0EINtNtNtB9_3ops8function6FnOnceuE9call_onceB1Y_  (in heartbeat_benchmarks_bin) + 44  [0x1002704d0]  unwind_safe.rs:275
+    +                               7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread6scoped5scopeNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts0uE0BO_  (in heartbeat_benchmarks_bin) + 56  [0x10027775c]  scoped.rs:158
+    +                                 7601 _RNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts0B3_  (in heartbeat_benchmarks_bin) + 1044  [0x10026d1b0]  binary_tree.rs:190
+    +                                   7601 _RNvMs1_NtNtCsblkilOWXfC6_3std6thread6scopedINtB5_16ScopedJoinHandleuE4joinCs2VdSuciCVdQ_24heartbeat_benchmarks_bin  (in heartbeat_benchmarks_bin) + 40  [0x1002782a4]  scoped.rs:323
+    +                                     7601 _RNvMs1_NtNtCsblkilOWXfC6_3std6thread9lifecycleINtB5_9JoinInneruE4joinCs2VdSuciCVdQ_24heartbeat_benchmarks_bin  (in heartbeat_benchmarks_bin) + 44  [0x10025cf24]  lifecycle.rs:220
+    +                                       7601 _RNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB5_6Thread4join  (in heartbeat_benchmarks_bin) + 24  [0x1006aff8c]  unix.rs:126
+    +                                         7601 _pthread_join  (in libsystem_pthread.dylib) + 616  [0x189d20114]
+    +                                           7601 __ulock_wait  (in libsystem_kernel.dylib) + 8  [0x189cdbaf8]
+    7601 Thread_5036016
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036017
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036018
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036019
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036020
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036021
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036022
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036023
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036024
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036025
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5036026
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+    +                     7601 _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+    +                       7601 _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+    +                         7601 _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+    +                           7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+    +                             7601 _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+    +                               7601 _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+    +                                 7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+    +                                   7601 _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+    +                                     7601 _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+    +                                       7601 _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+    +                                         7601 _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+    +                                           7601 __psynch_cvwait  (in libsystem_kernel.dylib) + 8  [0x189cdd50c]
+    7601 Thread_5038093
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038094
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038095
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038096
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038098
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038099
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038100
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038102
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038103
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038104
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038105
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038106
+    + 7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+    +   7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+    +     7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+    +       7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+    +         7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+    +           7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+    +             7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+    +               7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+    +                 7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+    +                   7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+    +                     7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+    +                       7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+    +                         7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+    +                           7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+    +                             7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+    +                               7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+    +                                 7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+    +                                   7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+    7601 Thread_5038107
+      7601 thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+        7601 _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+          7601 _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+            7601 _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+              7601 _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+                7601 __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+                  7601 _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+                    7601 _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+                      7601 _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+                        7601 _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+                          7601 _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+                            7601 _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+                              7601 _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+                                7601 _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+                                  7601 _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+                                    7601 _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+                                      7601 _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+                                        7601 semaphore_wait_trap  (in libsystem_kernel.dylib) + 8  [0x189cd9bb0]
+
+Total number in stack (recursive counted multiple, when >=5):
+        24       _RNvNvMs0_NtNtNtCsblkilOWXfC6_3std3sys6thread4unixNtB7_6Thread3new12thread_start  (in heartbeat_benchmarks_bin) + 408  [0x1006c69ec]  unix.rs:118
+        24       _pthread_start  (in libsystem_pthread.dylib) + 136  [0x189d1dc58]
+        24       thread_start  (in libsystem_pthread.dylib) + 8  [0x189d18c1c]
+        13       _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEB1f_  (in heartbeat_benchmarks_bin) + 32  [0x1002617b8]  backtrace.rs:166
+        13       _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EuEB2P_  (in heartbeat_benchmarks_bin) + 48  [0x10027c5b4]  panicking.rs:575
+        13       _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0B16_  (in heartbeat_benchmarks_bin) + 180  [0x10025c430]  lifecycle.rs:68
+        13       _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00B18_  (in heartbeat_benchmarks_bin) + 104  [0x10025c9c0]  lifecycle.rs:70
+        13       _RNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000B7_  (in heartbeat_benchmarks_bin) + 416  [0x10026c9e0]  binary_tree.rs:147
+        13       _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1b_  (in heartbeat_benchmarks_bin) + 24  [0x100269ec0]  function.rs:250
+        13       _RNvMs0_NtCsaO1TPFUP5Jh_9heartbeat4parkNtB5_4Park4park  (in heartbeat_benchmarks_bin) + 76  [0x100282c0c]  park.rs:138
+        13       _RNvMs1_CsaO1TPFUP5Jh_9heartbeatNtB5_6Worker9main_loop  (in heartbeat_benchmarks_bin) + 240  [0x10028313c]  lib.rs:289
+        13       _RNvNtNtCsblkilOWXfC6_3std6thread9functions4park  (in heartbeat_benchmarks_bin) + 96  [0x1006c1a30]  functions.rs:533
+        13       _RNvNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin8std_park4park  (in heartbeat_benchmarks_bin) + 236  [0x10026f180]  binary_tree.rs:106
+        13       _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNCNCNvCs2VdSuciCVdQ_24heartbeat_benchmarks_bin11bench_harts000uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2i_  (in heartbeat_benchmarks_bin) + 44  [0x100270548]  unwind_safe.rs:275
+        13       __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1002605fc]
+        13       _dispatch_sema4_wait  (in libdispatch.dylib) + 28  [0x189b64490]
+        13       _dispatch_semaphore_wait_slow  (in libdispatch.dylib) + 132  [0x189b64b20]
+        13       semaphore_wait_trap  (in libsystem_kernel.dylib) + 0  [0x189cd9ba8]
+        11       _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep13no_work_foundNCNvMs8_NtB5_8registryNtB19_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 288  [0x1004f3708]  mod.rs:106
+        11       _RINvMNtCsfxUfxqSFJoR_10rayon_core5sleepNtB3_5Sleep5sleepNCNvMs8_NtB5_8registryNtB10_12WorkerThread15wait_until_cold0EB5_  (in heartbeat_benchmarks_bin) + 984  [0x1004f3be0]  mod.rs:187
+        11       _RINvMNtNtNtCsblkilOWXfC6_3std4sync6poison7condvarNtB3_7Condvar4waitbECsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 48  [0x1004eea14]  condvar.rs:128
+        11       _RINvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB6_12WorkerThread10wait_untilNtNtB8_5latch9OnceLatchEB8_  (in heartbeat_benchmarks_bin) + 76  [0x1004e0e80]  registry.rs:775
+        11       _RINvNtNtCsblkilOWXfC6_3std3sys9backtrace28___rust_begin_short_backtraceNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1f_12DefaultSpawnNtB1f_11ThreadSpawn5spawn0uEB1h_  (in heartbeat_benchmarks_bin) + 16  [0x1004e3544]  backtrace.rs:166
+        11       _RINvNvNtCsblkilOWXfC6_3std9panicking12catch_unwind7do_callINtNtNtCs4Bl0CKBHNnK_4core5panic11unwind_safe16AssertUnwindSafeNCNCINvNtNtB6_6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2P_12DefaultSpawnNtB2P_11ThreadSpawn5spawn0uEs_00EuEB2R_  (in heartbeat_benchmarks_bin) + 48  [0x1004ef7b0]  panicking.rs:575
+        11       _RNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB16_12DefaultSpawnNtB16_11ThreadSpawn5spawn0uEs_0B18_  (in heartbeat_benchmarks_bin) + 208  [0x1004effb8]  lifecycle.rs:68
+        11       _RNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB18_12DefaultSpawnNtB18_11ThreadSpawn5spawn0uEs_00B1a_  (in heartbeat_benchmarks_bin) + 120  [0x1004f026c]  lifecycle.rs:70
+        11       _RNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB7_12DefaultSpawnNtB7_11ThreadSpawn5spawn0B9_  (in heartbeat_benchmarks_bin) + 44  [0x1004e3e14]  registry.rs:95
+        11       _RNSNvYNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB1b_12DefaultSpawnNtB1b_11ThreadSpawn5spawn0uEs_0INtNtNtCs4Bl0CKBHNnK_4core3ops8function6FnOnceuE9call_once6vtableB1d_  (in heartbeat_benchmarks_bin) + 24  [0x1004e3eec]  function.rs:250
+        11       _RNvMNtCsfxUfxqSFJoR_10rayon_core8registryNtB2_13ThreadBuilder3run  (in heartbeat_benchmarks_bin) + 44  [0x1004e3f6c]  registry.rs:50
+        11       _RNvMNtNtNtNtCsblkilOWXfC6_3std3sys4sync7condvar7pthreadNtB2_7Condvar4waitCsfxUfxqSFJoR_10rayon_core  (in heartbeat_benchmarks_bin) + 116  [0x1004f0ed0]  pthread.rs:64
+        11       _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread15wait_until_cold  (in heartbeat_benchmarks_bin) + 488  [0x1004e53a8]  registry.rs:806
+        11       _RNvMs8_NtCsfxUfxqSFJoR_10rayon_core8registryNtB5_12WorkerThread22wait_until_out_of_work  (in heartbeat_benchmarks_bin) + 184  [0x1004e5528]  registry.rs:824
+        11       _RNvNtCsfxUfxqSFJoR_10rayon_core8registry9main_loop  (in heartbeat_benchmarks_bin) + 260  [0x1004e7664]  registry.rs:929
+        11       _RNvXsn_NtNtCs4Bl0CKBHNnK_4core5panic11unwind_safeINtB5_16AssertUnwindSafeNCNCINvNtNtCsblkilOWXfC6_3std6thread9lifecycle15spawn_uncheckedNCNvXs0_NtCsfxUfxqSFJoR_10rayon_core8registryNtB2i_12DefaultSpawnNtB2i_11ThreadSpawn5spawn0uEs_00EINtNtNtB9_3ops8function6FnOnceuE9call_onceB2k_  (in heartbeat_benchmarks_bin) + 44  [0x1004f3224]  unwind_safe.rs:275
+        11       __psynch_cvwait  (in libsystem_kernel.dylib) + 0  [0x189cdd504]
+        11       __rust_try  (in heartbeat_benchmarks_bin) + 32  [0x1004f35ac]
+        11       _pthread_cond_wait  (in libsystem_pthread.dylib) + 980  [0x189d1e128]
+
+Sort by top of stack, same collapsed (when >= 5):
+        semaphore_wait_trap  (in libsystem_kernel.dylib)        98813
+        __psynch_cvwait  (in libsystem_kernel.dylib)        83611
+        __ulock_wait  (in libsystem_kernel.dylib)        7601
+
+Binary Images:
+       0x100254000 -        0x100900e07 +heartbeat_benchmarks_bin (???) <4C4C44CE-5555-3144-A1FB-BF8B4DA98A74> /Users/*/Documents/*/heartbeat_benchmarks_bin
+       0x1011bc000 -        0x1011c7ff3 +libiconv.2.dylib (0) <978331C5-45FC-3D49-A708-2BCA556EDF0E> /Volumes/*/libiconv.2.dylib
+       0x1011d4000 -        0x1011d7fff +libcharset.1.dylib (0) <99D418F1-2314-3B75-8173-4A78A200C963> /Volumes/*/libcharset.1.dylib
+       0x1898b8000 -        0x18990ab4b  libobjc.A.dylib (951.7) <FF1D8AE4-ABEF-35F1-A30A-1183B9CB414F> /usr/lib/libobjc.A.dylib
+       0x18990b000 -        0x18993fd07  libdyld.dylib (1378) <B147D877-D0C2-388F-B38D-D3132E39905F> /usr/lib/system/libdyld.dylib
+       0x189940000 -        0x1899e6217  dyld (1.0.0 - 1378) <A237EF81-B68B-37BA-A165-92C965529534> /usr/lib/dyld
+       0x1899e7000 -        0x1899ea228  libsystem_blocks.dylib (96) <CC947089-488D-316B-A9C7-46DEC0F73145> /usr/lib/system/libsystem_blocks.dylib
+       0x1899eb000 -        0x189a3f55f  libxpc.dylib (3102.120.13) <C40FCAE8-7A17-3D82-87CB-3DA4802ADEF1> /usr/lib/system/libxpc.dylib
+       0x189a40000 -        0x189a609ff  libsystem_trace.dylib (1861.120.4) <D0FABAB3-5AE7-3F10-8C62-60CBF5D70850> /usr/lib/system/libsystem_trace.dylib
+       0x189a61000 -        0x189b0f5f7  libcorecrypto.dylib (1922.121.1) <A01A158D-6FE7-3B1C-A2C4-6BCB90D7314A> /usr/lib/system/libcorecrypto.dylib
+       0x189b10000 -        0x189b601d7  libsystem_malloc.dylib (812.100.31) <5FAE4807-4D2B-3A95-A63A-DD96D3DA11B4> /usr/lib/system/libsystem_malloc.dylib
+       0x189b61000 -        0x189ba823f  libdispatch.dylib (1542.100.32) <F071EFE4-299F-3089-ACC4-0025B8FFB52A> /usr/lib/system/libdispatch.dylib
+       0x189ba9000 -        0x189babffb  libsystem_featureflags.dylib (103) <71FCFFBD-85F8-3365-AFE0-BECEA4369122> /usr/lib/system/libsystem_featureflags.dylib
+       0x189bac000 -        0x189c2cd9f  libsystem_c.dylib (1752.120.2) <694B7881-1BF3-3D0F-8F19-B50AE4E8EF8A> /usr/lib/system/libsystem_c.dylib
+       0x189c2d000 -        0x189cbdae7  libc++.1.dylib (2100.43) <5013C0F8-84A9-3B56-9FEB-C353816A750F> /usr/lib/libc++.1.dylib
+       0x189cbe000 -        0x189cd875f  libc++abi.dylib (2100.43) <E482D257-E5A0-3816-BD97-7B39342958DA> /usr/lib/libc++abi.dylib
+       0x189cd9000 -        0x189d162af  libsystem_kernel.dylib (12377.121.6) <CC1CF985-BC65-3725-809F-4C1E36B8F4BA> /usr/lib/system/libsystem_kernel.dylib
+       0x189d17000 -        0x189d23b3b  libsystem_pthread.dylib (539.100.4) <4F33683C-18C8-39A1-800B-2E3BD43BCC13> /usr/lib/system/libsystem_pthread.dylib
+       0x189d24000 -        0x189d2c963  libsystem_platform.dylib (375.120.2) <160FD864-8D15-36FC-9E97-9725388CFAFE> /usr/lib/system/libsystem_platform.dylib
+       0x189d2d000 -        0x189d5c6eb  libsystem_info.dylib (600) <3D62F2D9-F516-31BF-83C7-E203D872300B> /usr/lib/system/libsystem_info.dylib
+       0x18dcf4000 -        0x18dcfde5f  libsystem_darwin.dylib (1752.120.2) <8858F025-745A-388E-9544-080781CC9A69> /usr/lib/system/libsystem_darwin.dylib
+       0x18e15f000 -        0x18e1711b6  libsystem_notify.dylib (348.120.4) <64D76451-1E0C-369B-A631-54DA3140E083> /usr/lib/system/libsystem_notify.dylib
+       0x19042c000 -        0x190446f7b  libsystem_networkextension.dylib (2226.121.1) <0331EE20-A1FB-3C0D-990A-F65939CFF505> /usr/lib/system/libsystem_networkextension.dylib
+       0x1904c9000 -        0x1904e0fdf  libsystem_asl.dylib (406) <F40838DF-2F15-3F62-970F-DEE25706BF1B> /usr/lib/system/libsystem_asl.dylib
+       0x192087000 -        0x19208f387  libsystem_symptoms.dylib (2169.120.7) <F5029F5C-1BF3-31C7-892E-BC8606AC829E> /usr/lib/system/libsystem_symptoms.dylib
+       0x19632b000 -        0x196363257  libsystem_containermanager.dylib (725.120.2) <518BE44D-AA31-31E6-B44B-A37AD5E47040> /usr/lib/system/libsystem_containermanager.dylib
+       0x19773c000 -        0x1977405d7  libsystem_configuration.dylib (1405.120.5) <0F7BBC1C-3D50-3E59-A31F-E4672A80BCEB> /usr/lib/system/libsystem_configuration.dylib
+       0x197741000 -        0x1977478cf  libsystem_sandbox.dylib (2680.120.12) <EC3A75EA-44C0-3A0B-9BF7-71C117B0A9C6> /usr/lib/system/libsystem_sandbox.dylib
+       0x198d9b000 -        0x198d9e1fb  libquarantine.dylib (196.120.2) <5849009B-ACA3-3796-94C4-BBDF8D300EBA> /usr/lib/system/libquarantine.dylib
+       0x19953a000 -        0x199540d03  libsystem_coreservices.dylib (191.4.5) <9576143B-C303-35A3-BA63-1FD06EDA2BB1> /usr/lib/system/libsystem_coreservices.dylib
+       0x199ac5000 -        0x199b02a77  libsystem_m.dylib (3312.100.1) <A7E0863C-101A-31A0-922B-ED9B02626151> /usr/lib/system/libsystem_m.dylib
+       0x199b04000 -        0x199b07527  libmacho.dylib (1378) <755441B4-C034-3E3A-8E3C-F424FBB28261> /usr/lib/system/libmacho.dylib
+       0x199b21000 -        0x199b2e3a7  libcommonCrypto.dylib (600035) <CE357BB1-2D49-37CC-9FFE-D093936B1475> /usr/lib/system/libcommonCrypto.dylib
+       0x199b2f000 -        0x199b38ca3  libunwind.dylib (2100.2) <FC8F0C4E-6FB0-3E27-ABEF-B0FA720CD5E4> /usr/lib/system/libunwind.dylib
+       0x199b41000 -        0x199b4b7ff  libcopyfile.dylib (240) <8ACFAC7A-88E9-3EF4-853F-A9140FF110E5> /usr/lib/system/libcopyfile.dylib
+       0x199b4c000 -        0x199b4f987  libcompiler_rt.dylib (103.3) <AA79151F-C19D-3C7C-92F8-B10F04D82C1C> /usr/lib/system/libcompiler_rt.dylib
+       0x199b50000 -        0x199b5478b  libsystem_collections.dylib (1752.120.2) <72DB5BE7-EF78-37D0-8AAD-53E37CFE4287> /usr/lib/system/libsystem_collections.dylib
+       0x199b55000 -        0x199b584cf  libsystem_secinit.dylib (168.100.7) <E525C566-CDA4-3D99-B12B-1615FD54A1F3> /usr/lib/system/libsystem_secinit.dylib
+       0x199b59000 -        0x199b5bbf7  libremovefile.dylib (85.100.6) <635E661D-80A7-340D-A165-3F7D318FDFC9> /usr/lib/system/libremovefile.dylib
+       0x199b5c000 -        0x199b5cf27  libkeymgr.dylib (31) <8C08891A-DF1C-3DCC-AB64-4742FD6BE9BA> /usr/lib/system/libkeymgr.dylib
+       0x199b5d000 -        0x199b65e37  libsystem_dnssd.dylib (2881.120.11) <6F45DF3F-233B-3BC3-BA8C-B43E7DA884BF> /usr/lib/system/libsystem_dnssd.dylib
+       0x199b66000 -        0x199b6b09b  libcache.dylib (95) <189B576E-6176-3F82-8FA4-5914B0BEAEE7> /usr/lib/system/libcache.dylib
+       0x199b6c000 -        0x199b6dce3  libSystem.B.dylib (1356) <D65E4112-C151-3FF8-BEB7-4841436012D6> /usr/lib/libSystem.B.dylib
+       0x28cda3000 -        0x28cdaa349  libRosetta.dylib (367.9) <8651ED4F-6506-3788-B56B-32EE414A85CA> /usr/lib/libRosetta.dylib
+       0x28e9c0000 -        0x28e9c3a4b  libsystem_darwindirectory.dylib (122) <CF277A2C-C818-3F16-8B3F-3C7B39FCD164> /usr/lib/system/libsystem_darwindirectory.dylib
+       0x28e9c4000 -        0x28e9cd5d3  libsystem_eligibility.dylib (319.121.1) <DDAC0531-0262-3DDC-8EC8-80EB9438847A> /usr/lib/system/libsystem_eligibility.dylib
+       0x28e9ce000 -        0x28e9d588b  libsystem_sanitizers.dylib (26.1) <44C4234F-8B2D-38D3-A774-B4B3C75AF3A7> /usr/lib/system/libsystem_sanitizers.dylib
+       0x28e9d6000 -        0x28e9d6bb7  libsystem_trial.dylib (474.2.18.2) <68C583BA-AFF5-3916-86AE-6E38BFEF98D6> /usr/lib/system/libsystem_trial.dylib

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -3288,6 +3288,12 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "pin-project-lite",
+    actual = ":pin-project-lite-0.2",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "pin-project-lite-0.2.17.crate",
     sha256 = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd",

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -861,6 +861,7 @@ dependencies = [
  "object",
  "parking_lot",
  "pin-project",
+ "pin-project-lite",
  "proc-macro2",
  "proptest",
  "proptest-derive",

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -30,6 +30,7 @@ static_assertions = "1.1.0"
 futures = { version = "0.3.31", default-features = false, features = ["alloc"] }
 critical-section = { version = "1.2.0", default-features = false, features = ["restore-state-bool"] }
 uefi = { version = "0.37", features = [ "alloc", "global_allocator" ] }
+pin-project-lite = "0.2.17"
 
 # wast dependencies
 unicode-width = { version = "0.2.0" }


### PR DESCRIPTION
This PR adds a "heartbeat scheduler" implementation design for extremely low-overhead data parallelism workloads (it's about 20% faster than rayon). Heartbeat scheduling itself is just a low-overhead scheduling technique that performs better for many workloads than work stealing.

I'm not quite sure how we'll integrate this into the kernel, but its a promising start!