### PR TITLE
feat: add lock-free, bounded MPMC/SPSC queue

### DIFF
--- a/.github/workflows/_changed-targets.yml
+++ b/.github/workflows/_changed-targets.yml
@@ -28,7 +28,7 @@ jobs:
   changed-targets:
     name: Determine changed targets
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     outputs:
       targets: ${{ steps.compute.outputs.targets }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
   cargo-deny:
     name: Cargo deny
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - uses: DeterminateSystems/determinate-nix-action@61cbfe2efc2d4e7a8a6d56967c3c1058e846c858 # v3

--- a/build/bench.bzl
+++ b/build/bench.bzl
@@ -52,5 +52,6 @@ def rust_benchmark(name, modifiers = [], visibility = None, **kwargs):
         name = name,
         binary = ":" + bin_name,
         target_compatible_with = [host_configuration.os, host_configuration.cpu],
+        modifiers = _DEFAULT_MODIFIERS + modifiers,
         visibility = visibility,
     )

--- a/build/bench.bzl
+++ b/build/bench.bzl
@@ -45,5 +45,6 @@ def rust_benchmark(name, visibility = None, **kwargs):
         name = name,
         binary = ":" + bin_name,
         target_compatible_with = [host_configuration.os, host_configuration.cpu],
+        modifiers = _DEFAULT_MODIFIERS + modifiers,
         visibility = visibility,
     )

--- a/build/constraints/BUCK
+++ b/build/constraints/BUCK
@@ -9,6 +9,16 @@ constraint(
 )
 
 constraint(
+    name = "loom",
+    values = [
+        "enabled",
+        "disabled",
+    ],
+    default = "disabled",
+    visibility = ["PUBLIC"],
+)
+
+constraint(
     name = "opt-level",
     values = [
         "0",

--- a/build/loom.bzl
+++ b/build/loom.bzl
@@ -1,9 +1,5 @@
 load("@prelude//platforms:defs.bzl", "host_configuration")
 
-_DEFAULT_MODIFIERS = [
-    "constraints//:opt-level[3]",
-]
-
 _DEFAULT_ENV = {
     "LOOM_LOG": "debug",
     "LOOM_MAX_PREEMPTIONS": "2",
@@ -16,8 +12,6 @@ def rust_loom_test(
         crate,
         deps = [],
         env = {},
-        rustc_flags = [],
-        modifiers = [],
         labels = [],
         visibility = None,
         **kwargs):
@@ -29,10 +23,16 @@ def rust_loom_test(
         name = name,
         srcs = srcs,
         crate = crate,
-        deps = deps,
-        rustc_flags = ["--cfg=loom"] + rustc_flags,
-        target_compatible_with = [host_configuration.os, host_configuration.cpu],
-        modifiers = _DEFAULT_MODIFIERS + modifiers,
+        deps = deps + select({
+            "constraints//:loom[enabled]": ["//third-party:loom"],
+            "constraints//:loom[disabled]": [],
+        }),
+        incoming_transition = "root//build:loom",
+        target_compatible_with = [
+            host_configuration.os,
+            host_configuration.cpu,
+            "constraints//:loom[enabled]",
+        ],
         labels = ["loom"] + labels,
         env = merged_env,
         visibility = visibility,

--- a/build/toolchains/BUCK
+++ b/build/toolchains/BUCK
@@ -217,6 +217,9 @@ rust_toolchain(
         "constraints//:lto[off]": [],
         "constraints//:lto[thin]": ["-Clto=thin"],
     }) + select({
+        "constraints//:loom[enabled]": ["--cfg=loom"],
+        "constraints//:loom[disabled]": [],
+    }) + select({
         "constraints//:sanitizer[address]": [
             "-Zsanitizer=address",
             "-Cpasses=sancov-module",

--- a/flake.nix
+++ b/flake.nix
@@ -164,13 +164,27 @@
               '';
             };
 
-          # Upstream reindeer's rlimit test fails on Darwin sandboxes
-          # where the soft RLIMIT_NOFILE starts above the hard limit.
-          reindeer = pkgs.reindeer.overrideAttrs (old: {
-            checkFlags = (old.checkFlags or [ ]) ++ [
-              "--skip=rlimit::tests::raise_does_not_lower_limit"
-            ];
-          });
+          reindeer =
+            let
+              src = pkgs.fetchFromGitHub {
+                owner = "JonasKruckenberg";
+                repo = "reindeer";
+                rev = "86a2896136faf1582b9acf45c0b0be38b74a3ca8";
+                hash = "sha256-lbS5OPZZLP7eP8IuwVFUQtJ5wkF3UeZYR15vXy/hxTU=";
+              };
+            in
+            pkgs.reindeer.overrideAttrs (old: {
+              inherit src;
+
+              cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+                inherit src;
+                hash = "sha256-MB/TQnOB96x86uAQJNt6IiTUmy74Dom4xtqWGga6GkA=";
+              };
+
+              checkFlags = (old.checkFlags or [ ]) ++ [
+                "--skip=rlimit::tests::raise_does_not_lower_limit"
+              ];
+            });
 
           # Tools every current CI job needs. Anything outside this list
           # is interactive-only; keeping it small shrinks the closure that

--- a/lib/async-mpsc/BUCK
+++ b/lib/async-mpsc/BUCK
@@ -1,0 +1,48 @@
+load("@prelude//platforms:defs.bzl", "host_configuration")
+load("//build:bench.bzl", "rust_benchmark")
+load("//build:loom.bzl", "rust_loom_test")
+
+_DEPS = [
+    "//lib/util:util",
+
+    "//third-party:cordyceps",
+    "//third-party:maitake-sync",
+    "//third-party:cfg-if",
+]
+
+rust_library(
+    name = "async-mpsc",
+    srcs = glob(["src/**/*.rs"]),
+    crate = "async-mpsc",
+    deps = _DEPS,
+    visibility = ["PUBLIC"],
+    tests = [":async-mpsc_unittests", ":async-mpsc_loom_tests"],
+)
+
+rust_test(
+    name = "async-mpsc_unittests",
+    srcs = glob(["src/**/*.rs"]),
+    crate = "async-mpsc",
+    deps = _DEPS,
+    target_compatible_with = [host_configuration.os, host_configuration.cpu],
+    visibility = ["PUBLIC"],
+)
+
+rust_loom_test(
+    name = "async-mpsc_loom_tests",
+    srcs = glob(["src/**/*.rs"]),
+    crate = "async-mpsc",
+    deps = _DEPS + ["//third-party:loom"],
+)
+
+rust_benchmark(
+    name = "async-mpsc_benchmarks",
+    srcs = ["benches/channel.rs"],
+    crate_root = "benches/channel.rs",
+    deps = [
+        ":async-mpsc",
+        "//third-party:cordyceps",
+        "//third-party:criterion",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/lib/async-mpsc/benches/channel.rs
+++ b/lib/async-mpsc/benches/channel.rs
@@ -1,0 +1,321 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! FIFO against unordered, over the same message counts.
+//!
+//! Messages come from a pool leaked once per benchmark, so no allocator traffic lands inside a
+//! timed region: what is measured is the queue and its wakeups, nothing else. Every message is
+//! drained before an iteration ends, so the pool can be re-sent.
+
+use std::hint::black_box;
+use std::ptr::NonNull;
+use std::sync::Barrier;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use async_mpsc::{fifo, unordered};
+use cordyceps::{mpsc_queue, stack, Linked};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
+
+/// Messages per throughput iteration.
+const MSGS: usize = 100_000;
+
+/// Messages per drain iteration.
+const DRAIN: usize = 10_000;
+
+/// Thread counts sampled, capped at the machine's parallelism.
+const THREAD_COUNTS: [usize; 4] = [1, 2, 4, 8];
+
+macro_rules! message {
+    ($name:ident, $links:path) => {
+        struct $name {
+            links: $links,
+            value: u32,
+        }
+
+        // Safety: handles are `&'static` references to leaked messages, which are never freed and
+        // never moved, and `links` is a live field of every one of them.
+        unsafe impl Linked<$links> for $name {
+            type Handle = &'static Self;
+
+            fn into_ptr(handle: Self::Handle) -> NonNull<Self> {
+                NonNull::from(handle)
+            }
+
+            unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+                // Safety: every pointer in a queue came from `into_ptr`, so it points at a leaked
+                // message that outlives the channel.
+                unsafe { &*ptr.as_ptr() }
+            }
+
+            unsafe fn links(target: NonNull<Self>) -> NonNull<$links> {
+                // Safety: `target` points at a live message, so the projection is in bounds.
+                unsafe { NonNull::new_unchecked(&raw mut (*target.as_ptr()).links) }
+            }
+        }
+
+        /// Leaks `count` messages, so sending one never touches the allocator.
+        fn $name(count: usize) -> Vec<&'static $name> {
+            (0..count)
+                .map(|i| {
+                    &*Box::leak(Box::new($name {
+                        links: <$links>::new(),
+                        value: u32::try_from(i).expect("pool fits in u32"),
+                    }))
+                })
+                .collect()
+        }
+    };
+}
+
+message!(FifoMsg, mpsc_queue::Links<FifoMsg>);
+message!(StackMsg, stack::Links<StackMsg>);
+
+static FIFO_STUB: FifoMsg = FifoMsg {
+    links: mpsc_queue::Links::new_stub(),
+    value: 0,
+};
+
+fn fifo_channel() -> fifo::Channel<FifoMsg> {
+    // Safety: the stub is used by one channel at a time — benchmarks run one after another — is
+    // never sent, and is `'static`.
+    unsafe { fifo::Channel::new_with_static_stub(&FIFO_STUB) }
+}
+
+// -- throughput -----------------------------------------------------------------------------------
+
+fn fifo_throughput(producers: usize, pool: &[Vec<&'static FifoMsg>]) -> Duration {
+    let channel = fifo_channel();
+    let mut rx = channel.receiver().expect("first receiver");
+    let barrier = Barrier::new(producers + 2);
+    let (channel, barrier) = (&channel, &barrier);
+
+    thread::scope(|scope| {
+        for msgs in pool.iter().take(producers) {
+            scope.spawn(move || {
+                barrier.wait();
+                for msg in msgs {
+                    channel.send(msg);
+                }
+            });
+        }
+
+        let total = pool.iter().take(producers).map(Vec::len).sum::<usize>();
+        scope.spawn(move || {
+            barrier.wait();
+            let mut count = 0;
+            while count < total {
+                if let Ok(msg) = rx.try_recv() {
+                    black_box(msg.value);
+                    count += 1;
+                }
+            }
+        });
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn unordered_throughput(producers: usize, pool: &[Vec<&'static StackMsg>]) -> Duration {
+    let channel = unordered::Channel::<StackMsg>::new();
+    let mut rx = channel.receiver().expect("first receiver");
+    let barrier = Barrier::new(producers + 2);
+    let (channel, barrier) = (&channel, &barrier);
+
+    thread::scope(|scope| {
+        for msgs in pool.iter().take(producers) {
+            scope.spawn(move || {
+                let tx = channel.sender();
+                barrier.wait();
+                for msg in msgs {
+                    tx.send(msg);
+                }
+            });
+        }
+
+        let total = pool.iter().take(producers).map(Vec::len).sum::<usize>();
+        scope.spawn(move || {
+            barrier.wait();
+            let mut count = 0;
+            while count < total {
+                if let Ok(msg) = rx.try_recv() {
+                    black_box(msg.value);
+                    count += 1;
+                }
+            }
+        });
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn bench_throughput(c: &mut Criterion) {
+    let mut g = c.benchmark_group("throughput");
+    g.throughput(Throughput::Elements(MSGS as u64));
+
+    // Producers and the consumer should land on distinct cores, so cap at half the parallelism.
+    let max = thread::available_parallelism()
+        .map_or(2, std::num::NonZeroUsize::get)
+        .div_ceil(2)
+        .max(1);
+
+    for n in THREAD_COUNTS {
+        if n > max {
+            break;
+        }
+
+        let fifo_pool: Vec<_> = (0..n).map(|_| FifoMsg(MSGS / n)).collect();
+        let stack_pool: Vec<_> = (0..n).map(|_| StackMsg(MSGS / n)).collect();
+
+        g.bench_function(format!("fifo/{n}p1c"), |b| {
+            b.iter_custom(|iters| (0..iters).map(|_| fifo_throughput(n, &fifo_pool)).sum());
+        });
+        g.bench_function(format!("unordered/{n}p1c"), |b| {
+            b.iter_custom(|iters| {
+                (0..iters)
+                    .map(|_| unordered_throughput(n, &stack_pool))
+                    .sum()
+            });
+        });
+    }
+
+    g.finish();
+}
+
+// -- uncontended send -----------------------------------------------------------------------------
+//
+// One thread, no receiver draining: isolates the send path, including the wake that `fifo` pays on
+// every message and `unordered` pays only when the channel was empty.
+
+fn bench_send(c: &mut Criterion) {
+    let mut g = c.benchmark_group("send");
+    g.throughput(Throughput::Elements(DRAIN as u64));
+
+    let fifo_pool = FifoMsg(DRAIN);
+    g.bench_function("fifo", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    let channel = fifo_channel();
+                    let mut rx = channel.receiver().expect("first receiver");
+                    let start = Instant::now();
+                    for msg in &fifo_pool {
+                        channel.send(msg);
+                    }
+                    let elapsed = start.elapsed();
+                    while rx.try_recv().is_ok() {}
+                    elapsed
+                })
+                .sum()
+        });
+    });
+
+    let stack_pool = StackMsg(DRAIN);
+    g.bench_function("unordered", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    let channel = unordered::Channel::<StackMsg>::new();
+                    let mut rx = channel.receiver().expect("first receiver");
+                    let tx = channel.sender();
+                    let start = Instant::now();
+                    for msg in &stack_pool {
+                        tx.send(msg);
+                    }
+                    let elapsed = start.elapsed();
+                    while rx.try_recv().is_ok() {}
+                    elapsed
+                })
+                .sum()
+        });
+    });
+
+    g.finish();
+}
+
+// -- drain ----------------------------------------------------------------------------------------
+//
+// Everything queued up front, then drained by one thread: isolates the receive path, where
+// `unordered` takes the whole queue in one swap and `fifo` walks it a node at a time.
+
+fn bench_drain(c: &mut Criterion) {
+    let mut g = c.benchmark_group("drain");
+    g.throughput(Throughput::Elements(DRAIN as u64));
+
+    let fifo_pool = FifoMsg(DRAIN);
+    g.bench_function("fifo", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    let channel = fifo_channel();
+                    let mut rx = channel.receiver().expect("first receiver");
+                    for msg in &fifo_pool {
+                        channel.send(msg);
+                    }
+
+                    let start = Instant::now();
+                    while let Ok(msg) = rx.try_recv() {
+                        black_box(msg.value);
+                    }
+                    start.elapsed()
+                })
+                .sum()
+        });
+    });
+
+    let stack_pool = StackMsg(DRAIN);
+    g.bench_function("unordered", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    let channel = unordered::Channel::<StackMsg>::new();
+                    let mut rx = channel.receiver().expect("first receiver");
+                    let tx = channel.sender();
+                    for msg in &stack_pool {
+                        tx.send(msg);
+                    }
+
+                    let start = Instant::now();
+                    while let Ok(msg) = rx.try_recv() {
+                        black_box(msg.value);
+                    }
+                    start.elapsed()
+                })
+                .sum()
+        });
+    });
+
+    g.bench_function("unordered/batch", |b| {
+        b.iter_custom(|iters| {
+            (0..iters)
+                .map(|_| {
+                    let channel = unordered::Channel::<StackMsg>::new();
+                    let mut rx = channel.receiver().expect("first receiver");
+                    let tx = channel.sender();
+                    for msg in &stack_pool {
+                        tx.send(msg);
+                    }
+
+                    let start = Instant::now();
+                    for msg in rx.try_recv_all() {
+                        black_box(msg.value);
+                    }
+                    start.elapsed()
+                })
+                .sum()
+        });
+    });
+
+    g.finish();
+}
+
+criterion_group!(benches, bench_throughput, bench_send, bench_drain);
+criterion_main!(benches);

--- a/lib/async-mpsc/src/fifo.rs
+++ b/lib/async-mpsc/src/fifo.rs
@@ -1,0 +1,143 @@
+use cordyceps::{Linked, MpscQueue, mpsc_queue};
+use maitake_sync::WaitCell;
+
+use crate::loom::sync::atomic::AtomicBool;
+
+pub enum TryDequeueError {
+    Empty,
+    Inconsistent,
+}
+
+pub struct Channel<T: Linked<mpsc_queue::Links<T>>> {
+    queue: MpscQueue<T>,
+    has_consumer: AtomicBool,
+    rx_notify: WaitCell,
+}
+
+impl<T: Linked<mpsc_queue::Links<T>>> Channel<T> {
+    pub fn new_with_stub(stub: T::Handle) -> Self {
+        Self {
+            queue: MpscQueue::new_with_stub(stub),
+            has_consumer: AtomicBool::new(false),
+            rx_notify: WaitCell::new(),
+        }
+    }
+
+    #[cfg(not(loom))]
+    pub const unsafe fn new_with_static_stub(stub: &'static T) -> Self {
+        Self {
+            // Safety: the caller promises `stub` is exclusive to this channel and immortal.
+            queue: unsafe { MpscQueue::new_with_static_stub(stub) },
+            has_consumer: AtomicBool::new(false),
+            rx_notify: WaitCell::new(),
+        }
+    }
+
+    pub fn send(&self, element: T::Handle) {
+        self.queue.enqueue(element);
+
+        self.rx_notify.wake();
+    }
+
+    pub fn receiver(&self) -> Receiver<'_, T> {
+        self.try_receiver().expect("receiver already exists")
+    }
+
+    pub fn try_receiver(&self) -> Option<Receiver<'_, T>> {
+        self.queue.try_consume().map(|inner| Receiver {
+            inner,
+            rx_notify: &self.rx_notify,
+        })
+    }
+}
+
+pub struct Receiver<'q, T: Linked<mpsc_queue::Links<T>>> {
+    inner: mpsc_queue::Consumer<'q, T>,
+    rx_notify: &'q WaitCell,
+}
+
+impl<T: Linked<mpsc_queue::Links<T>> + Send> Receiver<'_, T> {
+    pub async fn recv(&mut self) -> T::Handle {
+        self.rx_notify
+            .wait_for_value(|| self.try_recv().ok())
+            .await
+            .unwrap()
+    }
+
+    pub fn try_recv(&mut self) -> Result<T::Handle, TryDequeueError> {
+        self.inner.try_dequeue().map_err(|err| match err {
+            mpsc_queue::TryDequeueError::Inconsistent => TryDequeueError::Inconsistent,
+            mpsc_queue::TryDequeueError::Empty => TryDequeueError::Empty,
+            mpsc_queue::TryDequeueError::Busy => unreachable!(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ptr::NonNull;
+
+    use super::*;
+
+    struct Msg {
+        links: mpsc_queue::Links<Self>,
+        value: u32,
+    }
+
+    impl Msg {
+        fn new(value: u32) -> Box<Self> {
+            Box::new(Self {
+                links: mpsc_queue::Links::new(),
+                value,
+            })
+        }
+    }
+
+    // Safety: `links` is a live field of every message, handles own their message through a
+    // `Box`, and nothing hands out a reference to a queued message.
+    unsafe impl Linked<mpsc_queue::Links<Self>> for Msg {
+        type Handle = Box<Self>;
+
+        fn into_ptr(handle: Self::Handle) -> NonNull<Self> {
+            NonNull::new(Box::into_raw(handle)).unwrap()
+        }
+
+        unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+            // Safety: every pointer in a queue came from `into_ptr` above.
+            unsafe { Box::from_raw(ptr.as_ptr()) }
+        }
+
+        unsafe fn links(target: NonNull<Self>) -> NonNull<mpsc_queue::Links<Self>> {
+            // Safety: `target` points at a live message, so the projection is in bounds.
+            unsafe { NonNull::new_unchecked(&raw mut (*target.as_ptr()).links) }
+        }
+    }
+
+    #[test]
+    #[cfg(loom)]
+    fn two_senders() {
+        use crate::loom;
+
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref CHANNEL: Channel<Msg> = Channel::new_with_stub(Msg::new(0));
+            }
+
+            let mut receiver = CHANNEL.receiver();
+
+            let sender = loom::thread::spawn(move || CHANNEL.send(Msg::new(2)));
+            CHANNEL.send(Msg::new(1));
+
+            // Both sends must arrive, and the wake elision in `send` must not lose one.
+            let mut sum = 0;
+            loom::future::block_on(async {
+                for _ in 0..2 {
+                    sum += receiver.recv().await.value;
+                }
+            });
+            assert_eq!(sum, 3);
+
+            sender.join().unwrap();
+        });
+    }
+}

--- a/lib/async-mpsc/src/lib.rs
+++ b/lib/async-mpsc/src/lib.rs
@@ -1,0 +1,5 @@
+#![cfg_attr(not(test), no_std)]
+
+pub mod fifo;
+mod loom;
+pub mod unordered;

--- a/lib/async-mpsc/src/loom.rs
+++ b/lib/async-mpsc/src/loom.rs
@@ -1,0 +1,34 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Shim routing the atomics to `loom` under `--cfg=loom`, to `std` under `cfg(test)`, and to
+//! `core` otherwise. Lets one test body compile under all three configs.
+//!
+//! The loom models need loom ≥ the fix for [tokio-rs/loom#416]: `block_on` built its waker vtable
+//! from a promoted temporary, which optimized builds duplicate per codegen unit, so a cloned waker
+//! failed [`core::task::Waker::will_wake`] against the waker it came from. Every primitive that
+//! caches a waker — `WaitCell`, `WaitQueue` — then replaced *and woke* its stored waker on each
+//! poll, so a model self-woke forever and died with "exceeded maximum number of branches".
+//!
+//! [tokio-rs/loom#416]: https://github.com/tokio-rs/loom/issues/416
+
+cfg_if::cfg_if! {
+    if #[cfg(loom)] {
+        pub(crate) use loom::sync;
+        #[cfg(test)]
+        pub(crate) use loom::{future, model, thread};
+        #[cfg(test)]
+        pub(crate) use loom::lazy_static;
+    } else {
+        #[cfg(not(test))]
+        pub(crate) use core::sync;
+        #[cfg(test)]
+        pub(crate) use std::sync;
+        #[cfg(test)]
+        pub(crate) use std::thread;
+    }
+}

--- a/lib/async-mpsc/src/unordered.rs
+++ b/lib/async-mpsc/src/unordered.rs
@@ -1,0 +1,144 @@
+use cordyceps::{Linked, Stack, TransferStack, stack};
+use maitake_sync::WaitCell;
+use util::loom_const_fn;
+
+use crate::loom::sync::atomic::{AtomicBool, Ordering};
+
+pub struct Channel<T: Linked<stack::Links<T>>> {
+    stack: TransferStack<T>,
+    has_consumer: AtomicBool,
+    rx_notify: WaitCell,
+}
+
+impl<T: Linked<stack::Links<T>>> Channel<T> {
+    loom_const_fn! {
+        pub const fn new() -> Self {
+            Self {
+                stack: TransferStack::new(),
+                has_consumer: AtomicBool::new(false),
+                rx_notify: WaitCell::new(),
+            }
+        }
+    }
+
+    /// Enqueue a new element at the end of the queue.
+    pub fn send(&self, element: T::Handle) {
+        if self.stack.push_was_empty(element) {
+            self.rx_notify.wake();
+        }
+    }
+
+    pub fn receiver(&self) -> Receiver<'_, T> {
+        self.try_receiver().expect("receiver already exists")
+    }
+
+    pub fn try_receiver(&self) -> Option<Receiver<'_, T>> {
+        if self
+            .has_consumer
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return None;
+        }
+
+        let stack = self.stack.take_all();
+
+        Some(Receiver {
+            channel: self,
+            stack,
+        })
+    }
+}
+
+pub struct Receiver<'q, T: Linked<stack::Links<T>>> {
+    channel: &'q Channel<T>,
+    stack: Stack<T>,
+}
+
+impl<T: Linked<stack::Links<T>>> Receiver<'_, T> {
+    pub async fn recv(&mut self) -> T::Handle {
+        self.channel
+            .rx_notify
+            .wait_for_value(|| self.try_recv())
+            .await
+            .unwrap()
+    }
+
+    pub fn try_recv(&mut self) -> Option<T::Handle> {
+        if let Some(el) = self.stack.pop() {
+            Some(el)
+        } else {
+            self.stack = self.channel.stack.take_all();
+            self.stack.pop()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::ptr::NonNull;
+
+    use super::*;
+
+    struct Msg {
+        links: stack::Links<Self>,
+        value: u32,
+    }
+
+    impl Msg {
+        fn new(value: u32) -> Box<Self> {
+            Box::new(Self {
+                links: stack::Links::new(),
+                value,
+            })
+        }
+    }
+
+    // Safety: `links` is a live field of every message, handles own their message through a
+    // `Box`, and nothing hands out a reference to a queued message.
+    unsafe impl Linked<stack::Links<Self>> for Msg {
+        type Handle = Box<Self>;
+
+        fn into_ptr(handle: Self::Handle) -> NonNull<Self> {
+            NonNull::new(Box::into_raw(handle)).unwrap()
+        }
+
+        unsafe fn from_ptr(ptr: NonNull<Self>) -> Self::Handle {
+            // Safety: every pointer in a queue came from `into_ptr` above.
+            unsafe { Box::from_raw(ptr.as_ptr()) }
+        }
+
+        unsafe fn links(target: NonNull<Self>) -> NonNull<stack::Links<Self>> {
+            // Safety: `target` points at a live message, so the projection is in bounds.
+            unsafe { NonNull::new_unchecked(&raw mut (*target.as_ptr()).links) }
+        }
+    }
+
+    #[test]
+    #[cfg(loom)]
+    fn two_senders() {
+        use crate::loom;
+
+        loom::model(|| {
+            loom::lazy_static! {
+                static ref CHANNEL: Channel<Msg> = Channel::new();
+            }
+
+            let mut receiver = CHANNEL.receiver();
+
+            let sender = loom::thread::spawn(move || CHANNEL.send(Msg::new(2)));
+            CHANNEL.send(Msg::new(1));
+
+            // Both sends must arrive, and the wake elision in `send` must not lose one.
+            let mut sum = 0;
+            loom::future::block_on(async {
+                for _ in 0..2 {
+                    sum += receiver.recv().await.value;
+                }
+            });
+            assert_eq!(sum, 3);
+
+            sender.join().unwrap();
+        });
+    }
+}

--- a/lib/cpu-local/BUCK
+++ b/lib/cpu-local/BUCK
@@ -1,11 +1,17 @@
 load("@prelude//platforms:defs.bzl", "host_configuration")
 
+_DEPS = [
+    "//lib/util:util",
+    "//third-party:cfg-if"
+] + select({
+    "constraints//:loom[enabled]": ["//third-party:loom"],
+    "constraints//:loom[disabled]": [],
+})
+
 rust_library(
     name = "cpu-local",
     srcs = glob(["src/**/*.rs"]),
-    deps = [
-        "//lib/util:util",
-    ],
+    deps = _DEPS,
     visibility = ["PUBLIC"],
     tests = [":cpu-local_unittests"],
 )
@@ -13,9 +19,7 @@ rust_library(
 rust_test(
     name = "cpu-local_unittests",
     srcs = glob(["src/**/*.rs"]),
-    deps = [
-        "//lib/util:util",
-    ],
+    deps = _DEPS,
     target_compatible_with = [host_configuration.os, host_configuration.cpu],
     visibility = ["PUBLIC"],
 )

--- a/lib/cpu-local/src/collection.rs
+++ b/lib/cpu-local/src/collection.rs
@@ -6,15 +6,15 @@
 // copied, modified, or distributed except according to those terms.
 
 use alloc::boxed::Box;
-use core::cell::UnsafeCell;
 use core::iter::FusedIterator;
 use core::panic::UnwindSafe;
-use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
-use core::{fmt, mem, ptr};
+use core::{array, fmt, mem, ptr};
 
-use util::CheckedMaybeUninit;
+use cfg_if::cfg_if;
+use util::{CheckedMaybeUninit, loom_const_fn};
 
-use crate::cpu_local;
+use crate::loom::cell::UnsafeCell;
+use crate::loom::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
 
 /// The total number of buckets stored in each cpu-local storage.
 /// All buckets combined can hold up to `usize::MAX - 1` entries.
@@ -38,11 +38,10 @@ struct Entry<T> {
 
 impl<T> Drop for Entry<T> {
     fn drop(&mut self) {
-        // Safety: the API ensures we cannot access the TLS value after drop
-        unsafe {
-            if *self.present.get_mut() {
-                ptr::drop_in_place((*self.value.get()).as_mut_ptr());
-            }
+        if self.present.load(Ordering::Relaxed) {
+            // Safety: the API ensures we cannot access the TLS value after drop
+            self.value
+                .with_mut(|ptr| unsafe { (*ptr).assume_init_drop() });
         }
     }
 }
@@ -60,7 +59,7 @@ impl<T: Send> Drop for CpuLocal<T> {
     fn drop(&mut self) {
         // Free each non-null bucket
         for (i, bucket) in self.buckets.iter_mut().enumerate() {
-            let bucket_ptr = *bucket.get_mut();
+            let bucket_ptr = bucket.load(Ordering::Relaxed);
 
             let this_bucket_size = 1 << i;
 
@@ -75,16 +74,16 @@ impl<T: Send> Drop for CpuLocal<T> {
 }
 
 impl<T: Send> CpuLocal<T> {
-    /// Creates a new empty `CpuLocal`.
-    pub const fn new() -> CpuLocal<T> {
-        let buckets = [ptr::null_mut::<Entry<T>>(); BUCKETS];
-        Self {
-            // Safety: AtomicPtr has the same representation as a pointer and arrays have the same
-            // representation as a sequence of their inner type.
-            buckets: unsafe {
-                mem::transmute::<[*mut Entry<T>; BUCKETS], [AtomicPtr<Entry<T>>; BUCKETS]>(buckets)
-            },
-            values: AtomicUsize::new(0),
+    loom_const_fn! {
+        /// Creates a new empty `CpuLocal`.
+        pub const fn new() -> Self {
+            Self {
+                #[cfg(not(loom))]
+                buckets: [const { AtomicPtr::new(ptr::null_mut()) }; BUCKETS],
+                #[cfg(loom)]
+                buckets: array::from_fn(|_| AtomicPtr::new(ptr::null_mut())),
+                values: AtomicUsize::new(0),
+            }
         }
     }
 
@@ -99,17 +98,14 @@ impl<T: Send> CpuLocal<T> {
         let allocated_buckets =
             usize::try_from(usize::BITS).unwrap() - (capacity.leading_zeros() as usize);
 
-        let mut buckets = [ptr::null_mut(); BUCKETS];
-        for (i, bucket) in buckets[..allocated_buckets].iter_mut().enumerate() {
-            *bucket = allocate_bucket::<T>(1 << i);
-        }
-
         Self {
-            // Safety: AtomicPtr has the same representation as a pointer and arrays have the same
-            // representation as a sequence of their inner type.
-            buckets: unsafe {
-                mem::transmute::<[*mut Entry<T>; BUCKETS], [AtomicPtr<Entry<T>>; BUCKETS]>(buckets)
-            },
+            buckets: array::from_fn(|i| {
+                AtomicPtr::new(if i < allocated_buckets {
+                    allocate_bucket::<T>(1 << i)
+                } else {
+                    ptr::null_mut()
+                })
+            }),
             values: AtomicUsize::new(0),
         }
     }
@@ -159,8 +155,8 @@ impl<T: Send> CpuLocal<T> {
         // Safety: bucket ptr is always valid
         unsafe {
             let entry = &*bucket_ptr.add(cpu.index);
-            if entry.present.load(Ordering::Relaxed) {
-                Some(&*(*entry.value.get()).as_ptr())
+            if entry.present.load(Ordering::Acquire) {
+                Some(entry.value.with(|ptr| (*ptr).assume_init_ref()))
             } else {
                 None
             }
@@ -170,14 +166,14 @@ impl<T: Send> CpuLocal<T> {
     #[cold]
     fn insert(&self, cpu: Cpu, data: T) -> &T {
         // Safety: `Cpu` constructors ensure correct bucket index
-        let bucket_atomic_ptr = unsafe { self.buckets.get_unchecked(cpu.bucket) };
-        let bucket_ptr: *const _ = bucket_atomic_ptr.load(Ordering::Acquire);
+        let bucket = unsafe { self.buckets.get_unchecked(cpu.bucket) };
 
         // If the bucket doesn't already exist, we need to allocate it
-        let bucket_ptr = if bucket_ptr.is_null() {
+        let mut bucket_ptr = bucket.load(Ordering::Acquire);
+        if bucket_ptr.is_null() {
             let new_bucket = allocate_bucket(cpu.bucket_size);
 
-            match bucket_atomic_ptr.compare_exchange(
+            bucket_ptr = match bucket.compare_exchange(
                 ptr::null_mut(),
                 new_bucket,
                 Ordering::AcqRel,
@@ -192,23 +188,23 @@ impl<T: Send> CpuLocal<T> {
                     unsafe { deallocate_bucket(new_bucket, cpu.bucket_size) }
                     bucket_ptr
                 }
-            }
-        } else {
-            bucket_ptr
-        };
+            };
+        }
 
         // Insert the new element into the bucket
         // Safety: `Cpu` constructors ensure correct index
         let entry = unsafe { &*bucket_ptr.add(cpu.index) };
-        let value_ptr = entry.value.get();
+
         // Safety: we just initialized the bucket
-        unsafe { value_ptr.write(CheckedMaybeUninit::new(data)) };
+        entry
+            .value
+            .with_mut(|ptr| unsafe { ptr.write(CheckedMaybeUninit::new(data)) });
         entry.present.store(true, Ordering::Release);
 
         self.values.fetch_add(1, Ordering::Release);
 
         // Safety: we just initialized the value
-        unsafe { &*(*value_ptr).as_ptr() }
+        entry.value.with(|ptr| unsafe { (*ptr).assume_init_ref() })
     }
 
     /// Returns an iterator over the local values of all cpus in unspecified
@@ -254,45 +250,7 @@ impl<T: Send> CpuLocal<T> {
     /// be done safely---the mutable borrow statically guarantees no other
     /// cpus are currently accessing their associated values.
     pub fn insert_for(&mut self, cpuid: usize, data: T) {
-        let cpu = Cpu::new(cpuid);
-
-        // Safety: `Cpu` constructors ensure correct bucket index
-        let bucket_atomic_ptr = unsafe { self.buckets.get_unchecked(cpu.bucket) };
-        let bucket_ptr: *const _ = bucket_atomic_ptr.load(Ordering::Acquire);
-
-        // If the bucket doesn't already exist, we need to allocate it
-        let bucket_ptr = if bucket_ptr.is_null() {
-            let new_bucket = allocate_bucket(cpu.bucket_size);
-
-            match bucket_atomic_ptr.compare_exchange(
-                ptr::null_mut(),
-                new_bucket,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => new_bucket,
-                // If the bucket value changed (from null), that means
-                // another cpu stored a new bucket before we could,
-                // and we can free our bucket and use that one instead
-                Err(bucket_ptr) => {
-                    // Safety: bucket will not be read from
-                    unsafe { deallocate_bucket(new_bucket, cpu.bucket_size) }
-                    bucket_ptr
-                }
-            }
-        } else {
-            bucket_ptr
-        };
-
-        // Insert the new element into the bucket
-        // Safety: `Cpu` constructors ensure correct index
-        let entry = unsafe { &*bucket_ptr.add(cpu.index) };
-        let value_ptr = entry.value.get();
-        // Safety: we just initialized the bucket
-        unsafe { value_ptr.write(CheckedMaybeUninit::new(data)) };
-        entry.present.store(true, Ordering::Release);
-
-        self.values.fetch_add(1, Ordering::Release);
+        self.insert(Cpu::new(cpuid), data);
     }
 
     pub fn len(&self) -> usize {
@@ -382,7 +340,7 @@ impl RawIter {
                     if entry.present.load(Ordering::Acquire) {
                         self.yielded += 1;
                         // Safety: we just ensured the value is valid
-                        return Some(unsafe { &*(*entry.value.get()).as_ptr() });
+                        return Some(entry.value.with(|ptr| unsafe { (*ptr).assume_init_ref() }));
                     }
                 }
             }
@@ -395,21 +353,21 @@ impl RawIter {
         &mut self,
         cpu_local: &'a mut CpuLocal<T>,
     ) -> Option<&'a mut Entry<T>> {
-        if *cpu_local.values.get_mut() == self.yielded {
+        if cpu_local.values.load(Ordering::Relaxed) == self.yielded {
             return None;
         }
 
         loop {
             // Safety: `Cpu` constructors ensure correct bucket index
             let bucket = unsafe { cpu_local.buckets.get_unchecked_mut(self.bucket) };
-            let bucket = *bucket.get_mut();
+            let bucket = bucket.load(Ordering::Relaxed);
 
             if !bucket.is_null() {
                 while self.index < self.bucket_size {
                     // Safety: `Cpu` constructors ensure correct index
                     let entry = unsafe { &mut *bucket.add(self.index) };
                     self.index += 1;
-                    if *entry.present.get_mut() {
+                    if entry.present.load(Ordering::Relaxed) {
                         self.yielded += 1;
                         return Some(entry);
                     }
@@ -432,8 +390,7 @@ impl RawIter {
         (total - self.yielded, None)
     }
     fn size_hint_frozen<T: Send>(&self, cpu_local: &CpuLocal<T>) -> (usize, Option<usize>) {
-        // Safety: used as a hint, so racily reading the value is fine
-        let total = unsafe { *ptr::from_ref::<AtomicUsize>(&cpu_local.values).cast::<usize>() };
+        let total = cpu_local.values.load(Ordering::Relaxed);
         let remaining = total - self.yielded;
         (remaining, Some(remaining))
     }
@@ -466,10 +423,12 @@ pub struct IterMut<'a, T: Send> {
 impl<'a, T: Send> Iterator for IterMut<'a, T> {
     type Item = &'a mut T;
     fn next(&mut self) -> Option<&'a mut T> {
-        self.raw
-            .next_mut(self.cpu_local)
-            // Safety: constructor ensures all ptrs are valid
-            .map(|entry| unsafe { &mut *(*entry.value.get()).as_mut_ptr() })
+        self.raw.next_mut(self.cpu_local).map(|entry| {
+            entry.value.with_mut(|ptr| {
+                // Safety: constructor ensures all ptrs are valid
+                unsafe { (*ptr).assume_init_mut() }
+            })
+        })
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.raw.size_hint_frozen(self.cpu_local)
@@ -499,11 +458,11 @@ impl<T: Send> Iterator for IntoIter<T> {
     type Item = T;
     fn next(&mut self) -> Option<T> {
         self.raw.next_mut(&mut self.cpu_local).map(|entry| {
-            *entry.present.get_mut() = false;
+            entry.present.store(false, Ordering::Relaxed);
             // Safety: constructor ensures all ptrs are valid
-            unsafe {
-                mem::replace(&mut *entry.value.get(), CheckedMaybeUninit::uninit()).assume_init()
-            }
+            entry.value.with_mut(|ptr| unsafe {
+                mem::replace(&mut *ptr, CheckedMaybeUninit::uninit()).assume_init()
+            })
         })
     }
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -559,14 +518,30 @@ unsafe fn deallocate_bucket<T>(bucket: *mut Entry<T>, size: usize) {
     let _ = unsafe { Box::from_raw(ptr::slice_from_raw_parts_mut(bucket, size)) };
 }
 
-static NEXT_CPUID: AtomicUsize = const { AtomicUsize::new(0) };
+cfg_if! {
+    if #[cfg(loom)] {
+        crate::loom::lazy_static! {
+            static ref NEXT_CPUID: AtomicUsize = AtomicUsize::new(0);
+        }
 
-cpu_local! {
-    static CPUID: usize = NEXT_CPUID.fetch_add(1, Ordering::SeqCst)
-}
+        crate::loom::thread_local! {
+            static CPUID: usize = NEXT_CPUID.fetch_add(1, Ordering::SeqCst)
+        }
 
-fn cpuid() -> usize {
-    *CPUID
+        fn cpuid() -> usize {
+            CPUID.with(|id| *id)
+        }
+    } else {
+        static NEXT_CPUID: AtomicUsize = const { AtomicUsize::new(0) };
+
+        crate::cpu_local! {
+            static CPUID: usize = NEXT_CPUID.fetch_add(1, Ordering::SeqCst)
+        }
+
+        fn cpuid() -> usize {
+            *CPUID
+        }
+    }
 }
 
 #[cfg(test)]

--- a/lib/cpu-local/src/lib.rs
+++ b/lib/cpu-local/src/lib.rs
@@ -90,12 +90,13 @@
 //! [`Cell`]: core::cell::Cell
 //! [`RefCell`]: core::cell::RefCell
 
-#![cfg_attr(not(test), no_std)]
-#![feature(thread_local)]
+#![cfg_attr(not(any(test, loom)), no_std)]
+#![cfg_attr(not(loom), feature(thread_local))]
 
 extern crate alloc;
 
 pub mod collection;
+mod loom;
 
 use core::ops::Deref;
 use core::ptr::NonNull;

--- a/lib/cpu-local/src/loom.rs
+++ b/lib/cpu-local/src/loom.rs
@@ -5,37 +5,14 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-use cfg_if::cfg_if;
-
-cfg_if! {
+cfg_if::cfg_if! {
     if #[cfg(loom)] {
-        pub(crate) use loom::{sync, cell, lazy_static, thread_local, hint};
-        #[cfg(test)]
-        pub(crate) use loom::{thread, model};
+        pub(crate) use loom::{cell, lazy_static, sync, thread_local};
     } else {
-        pub(crate) use core::hint;
-        #[cfg(any(test, feature = "__bench"))]
-        pub(crate) use std::thread;
-        #[cfg(any(test, feature = "__bench"))]
-        pub(crate) use std::thread_local;
-        #[cfg(test)]
-        pub(crate) use lazy_static::lazy_static;
-
-        #[cfg(test)]
-        #[inline(always)]
-        pub(crate) fn model<R>(f: impl FnOnce() -> R) -> R {
-            f()
-        }
-
-        pub(crate) mod sync {
-            pub use core::sync::*;
-            #[cfg(test)]
-            #[allow(unused_imports, reason = "they are actually used by tests")]
-            pub(crate) use std::sync::*;
-        }
+        pub(crate) use core::sync;
 
         pub(crate) mod cell {
-            #[derive(Debug)]
+            #[repr(transparent)]
             pub(crate) struct UnsafeCell<T>(core::cell::UnsafeCell<T>);
 
             impl<T> UnsafeCell<T> {

--- a/lib/qsbr/src/lib.rs
+++ b/lib/qsbr/src/lib.rs
@@ -71,7 +71,7 @@ use core::mem::MaybeUninit;
 use core::ptr::NonNull;
 
 use cordyceps::{Stack, TransferStack, stack};
-use util::CachePadded;
+use util::{CachePadded, loom_const_fn};
 
 pub use crate::atomic::{Atomic, Shared};
 use crate::loom::sync::atomic::{AtomicU64, AtomicUsize, Ordering, fence};
@@ -376,10 +376,12 @@ pub struct Links {
 
 impl Links {
     #[must_use]
-    pub const fn new() -> Self {
-        Self {
-            links: stack::Links::new(),
-            reclaim: MaybeUninit::uninit(),
+    loom_const_fn! {
+        pub const fn new() -> Self {
+            Self {
+                links: stack::Links::new(),
+                reclaim: MaybeUninit::uninit(),
+            }
         }
     }
 }

--- a/lib/ringbuf/BUCK
+++ b/lib/ringbuf/BUCK
@@ -1,0 +1,50 @@
+load("@prelude//platforms:defs.bzl", "host_configuration")
+load("//build:bench.bzl", "rust_benchmark")
+load("//build:loom.bzl", "rust_loom_test")
+
+_DEPS = [
+    "//lib/util:util",
+    "//third-party:cfg-if",
+]
+
+rust_library(
+    name = "ringbuf",
+    srcs = glob(["src/**/*.rs"]),
+    deps = _DEPS + select({
+        "constraints//:loom[enabled]": ["//third-party:loom"],
+        "constraints//:loom[disabled]": [],
+    }),
+    visibility = ["PUBLIC"],
+    tests = [":ringbuf_unittests", ":ringbuf_loom_tests"],
+)
+
+# Unit tests live inline under `#[cfg(test)]` so they can reach `remap` and `SHUFFLE_BITS`, which
+# are private. The crate becomes a std crate under `cfg(test)`, giving the concurrency tests
+# threads. Deps repeat the library's own, since this target recompiles `src/`.
+rust_test(
+    name = "ringbuf_unittests",
+    srcs = glob(["src/**/*.rs"]),
+    deps = _DEPS,
+    target_compatible_with = [host_configuration.os, host_configuration.cpu],
+    visibility = ["PUBLIC"],
+)
+
+# Same sources, built with `--cfg=loom`: `src/loom.rs` swaps `core`/`std` atomics for loom's and
+# the tests scale their thread and message counts down for the model checker.
+rust_loom_test(
+    name = "ringbuf_loom_tests",
+    srcs = glob(["src/**/*.rs"]),
+    crate = "ringbuf",
+    deps = _DEPS + ["//third-party:loom"],
+)
+
+rust_benchmark(
+    name = "ringbuf_benchmarks",
+    srcs = ["benches/queue.rs"],
+    crate_root = "benches/queue.rs",
+    deps = [
+        ":ringbuf",
+        "//third-party:criterion",
+    ],
+    visibility = ["PUBLIC"],
+)

--- a/lib/ringbuf/benches/queue.rs
+++ b/lib/ringbuf/benches/queue.rs
@@ -1,0 +1,292 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::hint::black_box;
+use std::sync::Barrier;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use ringbuf::RingBuf;
+
+/// Queue capacity.
+const CAP: usize = 1024;
+
+/// Messages per throughput iteration.
+const MSGS: u32 = 100_000;
+
+/// Thread counts sampled, capped at the machine's parallelism.
+const THREAD_COUNTS: [usize; 4] = [1, 2, 4, 8];
+
+/// Ping-pong capacity and round count.
+const PING_PONG_CAP: usize = 8;
+const PING_PONG_ROUNDS: u32 = 10_000;
+
+/// Thread and capacity counts are `usize` at the call sites but the message counters are `u32`.
+fn fits_u32(n: usize) -> u32 {
+    u32::try_from(n).expect("count fits in u32")
+}
+
+// -- throughput -----------------------------------------------------------------------------------
+
+fn mpmc_throughput(producers: usize, consumers: usize) -> Duration {
+    let q = RingBuf::<CAP, u32>::new();
+    let (np, nc) = (fits_u32(producers), fits_u32(consumers));
+    let per_producer = MSGS / np;
+    let per_consumer = per_producer * np / nc;
+    let barrier = Barrier::new(producers + consumers + 1);
+
+    thread::scope(|s| {
+        for _ in 0..producers {
+            let (q, b) = (&q, &barrier);
+            s.spawn(move || {
+                b.wait();
+                for i in 0..per_producer {
+                    q.push(i);
+                }
+            });
+        }
+        for _ in 0..consumers {
+            let (q, b) = (&q, &barrier);
+            s.spawn(move || {
+                b.wait();
+                let mut sum = 0u64;
+                for _ in 0..per_consumer {
+                    sum = sum.wrapping_add(u64::from(q.pop()));
+                }
+                black_box(sum);
+            });
+        }
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn mpsc_throughput(producers: usize) -> Duration {
+    // `split` takes `&'static self` and sets a one-shot flag, so each iteration leaks its own
+    // queue rather than re-splitting one. Allocation happens before the timer starts.
+    let q: &'static RingBuf<CAP, u32> = Box::leak(Box::new(RingBuf::new()));
+    let (tx, rx) = q.split();
+    let np = fits_u32(producers);
+    let per_producer = MSGS / np;
+    let total = per_producer * np;
+    let barrier = Barrier::new(producers + 2);
+
+    thread::scope(|s| {
+        for _ in 0..producers {
+            let (tx, b) = (tx.clone(), &barrier);
+            s.spawn(move || {
+                b.wait();
+                for i in 0..per_producer {
+                    tx.push(i);
+                }
+            });
+        }
+
+        let b = &barrier;
+        s.spawn(move || {
+            b.wait();
+            let mut sum = 0u64;
+            for _ in 0..total {
+                sum = sum.wrapping_add(u64::from(rx.pop()));
+            }
+            black_box(sum);
+        });
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn spsc_throughput() -> Duration {
+    // See `mpsc_throughput` for why the queue is leaked.
+    let q: &'static RingBuf<CAP, u32, true> = Box::leak(Box::new(RingBuf::new()));
+    let (tx, rx) = q.split();
+    let barrier = Barrier::new(3);
+
+    thread::scope(|s| {
+        let b = &barrier;
+        s.spawn(move || {
+            b.wait();
+            for i in 0..MSGS {
+                tx.push(i);
+            }
+        });
+
+        let b = &barrier;
+        s.spawn(move || {
+            b.wait();
+            let mut sum = 0u64;
+            for _ in 0..MSGS {
+                sum = sum.wrapping_add(u64::from(rx.pop()));
+            }
+            black_box(sum);
+        });
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn bench_throughput(c: &mut Criterion) {
+    let mut g = c.benchmark_group("throughput");
+    g.throughput(Throughput::Elements(u64::from(MSGS)));
+
+    // Producers and consumers should land on distinct cores, so cap at half the parallelism.
+    let max = thread::available_parallelism()
+        .map_or(2, std::num::NonZeroUsize::get)
+        .div_ceil(2)
+        .max(1);
+
+    g.bench_function("spsc/1p1c", |b| {
+        b.iter_custom(|iters| (0..iters).map(|_| spsc_throughput()).sum());
+    });
+
+    for n in THREAD_COUNTS {
+        if n > max {
+            break;
+        }
+
+        g.bench_function(format!("mpmc/{n}p{n}c"), |b| {
+            b.iter_custom(|iters| (0..iters).map(|_| mpmc_throughput(n, n)).sum());
+        });
+        g.bench_function(format!("mpsc/{n}p1c"), |b| {
+            b.iter_custom(|iters| (0..iters).map(|_| mpsc_throughput(n)).sum());
+        });
+        // `mpmc/1p1c` is already covered by the `NpNc` entry above.
+        if n > 1 {
+            g.bench_function(format!("mpmc/{n}p1c"), |b| {
+                b.iter_custom(|iters| (0..iters).map(|_| mpmc_throughput(n, 1)).sum());
+            });
+        }
+    }
+
+    g.finish();
+}
+
+// -- ping-pong latency ----------------------------------------------------------------------------
+
+fn mpmc_ping_pong() -> Duration {
+    let there = RingBuf::<PING_PONG_CAP, u32>::new();
+    let back = RingBuf::<PING_PONG_CAP, u32>::new();
+    let barrier = Barrier::new(3);
+    // Borrowed once here rather than per closure: re-binding inside the scope would shadow these
+    // with references that do not outlive the spawned threads.
+    let (there, back, barrier) = (&there, &back, &barrier);
+
+    thread::scope(|s| {
+        s.spawn(move || {
+            barrier.wait();
+            for _ in 0..PING_PONG_ROUNDS {
+                let n = there.pop();
+                back.push(n);
+            }
+        });
+
+        s.spawn(move || {
+            barrier.wait();
+            for i in 0..PING_PONG_ROUNDS {
+                there.push(i);
+                black_box(back.pop());
+            }
+        });
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn spsc_ping_pong() -> Duration {
+    // See `mpsc_throughput` for why the queues are leaked.
+    let there: &'static RingBuf<PING_PONG_CAP, u32, true> = Box::leak(Box::new(RingBuf::new()));
+    let back: &'static RingBuf<PING_PONG_CAP, u32, true> = Box::leak(Box::new(RingBuf::new()));
+    let (there_tx, there_rx) = there.split();
+    let (back_tx, back_rx) = back.split();
+    let barrier = Barrier::new(3);
+
+    thread::scope(|s| {
+        let b = &barrier;
+        s.spawn(move || {
+            b.wait();
+            for _ in 0..PING_PONG_ROUNDS {
+                let n = there_rx.pop();
+                back_tx.push(n);
+            }
+        });
+
+        let b = &barrier;
+        s.spawn(move || {
+            b.wait();
+            for i in 0..PING_PONG_ROUNDS {
+                there_tx.push(i);
+                black_box(back_rx.pop());
+            }
+        });
+
+        barrier.wait();
+        Instant::now()
+    })
+    .elapsed()
+}
+
+fn bench_ping_pong(c: &mut Criterion) {
+    let mut g = c.benchmark_group("ping_pong");
+    g.throughput(Throughput::Elements(u64::from(PING_PONG_ROUNDS)));
+
+    g.bench_function("spsc", |b| {
+        b.iter_custom(|iters| (0..iters).map(|_| spsc_ping_pong()).sum());
+    });
+    g.bench_function("mpmc", |b| {
+        b.iter_custom(|iters| (0..iters).map(|_| mpmc_ping_pong()).sum());
+    });
+
+    g.finish();
+}
+
+// -- uncontended baseline -------------------------------------------------------------------------
+
+fn bench_uncontended(c: &mut Criterion) {
+    let mut g = c.benchmark_group("uncontended");
+
+    g.throughput(Throughput::Elements(1));
+    g.bench_function("push_pop", |b| {
+        let q = RingBuf::<CAP, u32>::new();
+        b.iter(|| {
+            q.push(black_box(1));
+            black_box(q.pop());
+        });
+    });
+
+    // Fills and drains the whole queue, so consecutive slots are touched in sequence.
+    g.throughput(Throughput::Elements(CAP as u64));
+    g.bench_function("fill_drain", |b| {
+        let q = RingBuf::<CAP, u32>::new();
+        b.iter(|| {
+            for i in 0..fits_u32(CAP) {
+                q.push(black_box(i));
+            }
+            for _ in 0..CAP {
+                black_box(q.pop());
+            }
+        });
+    });
+
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_throughput,
+    bench_ping_pong,
+    bench_uncontended
+);
+criterion_main!(benches);

--- a/lib/ringbuf/src/lib.rs
+++ b/lib/ringbuf/src/lib.rs
@@ -1,0 +1,531 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! A bounded lock-free multi-producer multi-consumer queue.
+//!
+//! The design follows Maxim Egorushkin's [atomic_queue]: two free-running counters (`head`,
+//! `tail`) hand out slot tickets via atomic increment, and each slot carries a small state
+//! machine so producers and consumers never contend on a shared lock.
+//!
+//! # Modes
+//!
+//! Each side of the queue can drop an atomic read-modify-write when only one thread uses it:
+//!
+//! - **MPMC** (the default, [`RingBuf<N, T>`]) — any number of producers and consumers, all
+//!   operations available through `&self`.
+//! - **MPSC** — [`RingBuf::split`] on a default queue yields a cloneable [`Producer`] and a unique
+//!   [`Consumer`], making single-consumer use checkable by the compiler. It uses the same code as
+//!   MPMC: see [`Consumer::pop`] for why the relaxation is *not* applied here.
+//! - **SPSC** — `RingBuf<N, T, true>` additionally makes the producer unique, relaxing the push
+//!   path too. Only reachable through [`RingBuf::split`], because a shared-reference API would let
+//!   two threads push and race.
+//!
+//! [atomic_queue]: https://github.com/max0x7ba/atomic_queue
+
+#![cfg_attr(not(test), no_std)]
+
+mod loom;
+#[cfg(test)]
+mod tests;
+
+use core::marker::PhantomData;
+use core::mem::MaybeUninit;
+use core::sync::atomic::AtomicBool;
+
+use util::{CACHE_LINE_SIZE, CachePadded};
+
+use crate::loom::cell::UnsafeCell;
+use crate::loom::sync::atomic::{AtomicU8, AtomicU32, Ordering};
+
+/// Slot holds no value; a producer may claim it.
+const EMPTY: u8 = 0;
+/// Slot holds a value; a consumer may claim it.
+const STORED: u8 = 1;
+/// A producer has claimed the slot and is writing into it.
+const STORING: u8 = 2;
+/// A consumer has claimed the slot and is reading out of it.
+const LOADING: u8 = 4;
+
+struct Slot<T> {
+    /// The message.
+    value: UnsafeCell<MaybeUninit<T>>,
+    /// The state of the slot.
+    state: AtomicU8,
+}
+
+/// A bounded lock-free queue of `N` elements.
+///
+/// `N` must be a power of two — [`Self::remap`] masks indices with `N - 1`, and the free-running
+/// `u32` counters must wrap at a multiple of `N` for the index-to-slot mapping to stay consistent
+/// across a counter wrap. A non-power-of-two `N` fails to compile.
+///
+/// `SPSC` promises the queue has exactly one producer *and* one consumer, letting both sides skip
+/// their atomic read-modify-writes. The promise is not taken on trust: an `SPSC` queue exposes no
+/// shared-reference push or pop, so the only way to use one is [`Self::split`], whose handles are
+/// unique by construction. See the [module docs](self#modes).
+pub struct RingBuf<const N: usize, T, const SPSC: bool = false> {
+    head: CachePadded<AtomicU32>,
+    tail: CachePadded<AtomicU32>,
+    slots: [Slot<T>; N],
+    is_split: AtomicBool,
+}
+
+// Safety: the queue transfers ownership of `T` between threads, so `T: Send` is required and
+// sufficient. Access to each slot's `UnsafeCell` is serialized by its `state` atomic: a producer
+// writes only after winning `EMPTY -> STORING`, a consumer reads only after winning
+// `STORED -> LOADING`, and the release/acquire pairs on `state` order the payload accesses.
+unsafe impl<const N: usize, T: Send, const SPSC: bool> Send for RingBuf<N, T, SPSC> {}
+// Safety: see above. Shared access hands out `T` by value from `pop`/`try_pop`, never a
+// reference into a slot, so `T: Sync` is not required.
+unsafe impl<const N: usize, T: Send, const SPSC: bool> Sync for RingBuf<N, T, SPSC> {}
+
+#[inline(always)]
+#[expect(clippy::cast_possible_wrap, reason = "the wrap is the point")]
+const fn distance(a: u32, b: u32) -> i32 {
+    a.wrapping_sub(b) as i32
+}
+
+const fn get_shuffle_bits(array_size: usize, elements_per_cache_line: usize) -> usize {
+    let bits = match elements_per_cache_line {
+        256 => 8,
+        128 => 7,
+        64 => 6,
+        32 => 5,
+        16 => 4,
+        8 => 3,
+        4 => 2,
+        2 => 1,
+        _ => unreachable!(),
+    };
+    let min_size = 1 << (bits * 2);
+    if array_size < min_size { 0 } else { bits }
+}
+
+impl<const N: usize, T, const SPSC: bool> RingBuf<N, T, SPSC> {
+    const ASSERT_POWER_OF_TWO: () = assert!(
+        N.is_power_of_two(),
+        "RingBuf capacity N must be a power of two"
+    );
+
+    /// The signed-distance comparisons below only hold while the number of outstanding tickets
+    /// stays inside `i32`, so the capacity must too.
+    const ASSERT_FITS_SIGNED: () = assert!(
+        N <= i32::MAX as usize,
+        "RingBuf capacity N must fit in an i32"
+    );
+
+    /// `N` as a signed count, for comparison against [`distance`].
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_possible_wrap,
+        reason = "ASSERT_FITS_SIGNED, evaluated in `new`, rules out both"
+    )]
+    const CAPACITY: i32 = N as i32;
+
+    const SHUFFLE_BITS: usize = { get_shuffle_bits(N, CACHE_LINE_SIZE / size_of::<AtomicU8>()) };
+
+    const MASK_ELEM_IDX: usize = !(!0 << Self::SHUFFLE_BITS);
+    const MASK_HI: usize = !0 << (2 * Self::SHUFFLE_BITS);
+
+    /// Maps a free-running counter value onto a slot index, swapping the low `SHUFFLE_BITS` with
+    /// the next `SHUFFLE_BITS` so that consecutively-issued tickets land on different cache lines.
+    #[inline(always)]
+    const fn remap(index: u32) -> usize {
+        ((index as usize >> Self::SHUFFLE_BITS) & Self::MASK_ELEM_IDX)
+            | ((index as usize & Self::MASK_ELEM_IDX) << Self::SHUFFLE_BITS)
+            | (index as usize & (Self::MASK_HI & (N - 1)))
+    }
+
+    /// Creates a new empty queue.
+    #[must_use]
+    #[cfg(not(loom))]
+    pub const fn new() -> Self {
+        let () = Self::ASSERT_POWER_OF_TWO;
+        let () = Self::ASSERT_FITS_SIGNED;
+
+        Self {
+            head: CachePadded(AtomicU32::new(0)),
+            tail: CachePadded(AtomicU32::new(0)),
+            slots: [const {
+                Slot {
+                    value: UnsafeCell::new(MaybeUninit::uninit()),
+                    state: AtomicU8::new(EMPTY),
+                }
+            }; N],
+            is_split: AtomicBool::new(false),
+        }
+    }
+
+    /// Creates a new empty queue.
+    #[must_use]
+    #[cfg(loom)]
+    pub fn new() -> Self {
+        let () = Self::ASSERT_POWER_OF_TWO;
+        let () = Self::ASSERT_FITS_SIGNED;
+
+        Self {
+            head: CachePadded(AtomicU32::new(0)),
+            tail: CachePadded(AtomicU32::new(0)),
+            slots: core::array::from_fn(|_| Slot {
+                value: UnsafeCell::new(MaybeUninit::uninit()),
+                state: AtomicU8::new(EMPTY),
+            }),
+            is_split: AtomicBool::new(false),
+        }
+    }
+
+    /// The maximum number of elements the queue can hold.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        N
+    }
+
+    /// The number of elements in the queue at some point during the call.
+    #[must_use]
+    pub(crate) fn len(&self) -> usize {
+        let head = self.head.0.load(Ordering::Relaxed);
+        let tail = self.tail.0.load(Ordering::Relaxed);
+        usize::try_from(distance(head, tail).max(0)).unwrap_or(0)
+    }
+
+    /// Whether the queue held no elements at some point during the call. See [`Self::len`].
+    #[must_use]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Whether the queue was at capacity at some point during the call. See [`Self::len`].
+    #[must_use]
+    pub(crate) fn is_full(&self) -> bool {
+        self.len() >= N
+    }
+
+    /// Splits the queue into a producer and a consumer handle.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the queue was already split.
+    #[must_use]
+    pub fn split(&'static self) -> (Producer<'_, N, T, SPSC>, Consumer<'_, N, T, SPSC>) {
+        self.try_split().expect("queue already split")
+    }
+
+    /// Attempts to split the queue into a producer and a consumer handle.
+    /// Returns `None` if the queue was already split.
+    #[must_use]
+    pub fn try_split(
+        &'static self,
+    ) -> Option<(Producer<'_, N, T, SPSC>, Consumer<'_, N, T, SPSC>)> {
+        if self
+            .is_split
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            Some((
+                Producer {
+                    queue: self,
+                    _not_sync: PhantomData,
+                },
+                Consumer {
+                    queue: self,
+                    _not_sync: PhantomData,
+                },
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Pushes an element, returning it back as `Some` if the queue was full.
+    #[inline]
+    fn do_try_push(&self, element: T) -> Option<T> {
+        let mut head = self.head.0.load(Ordering::Relaxed);
+
+        loop {
+            if distance(head, self.tail.0.load(Ordering::Relaxed)) >= Self::CAPACITY {
+                return Some(element);
+            }
+            if SPSC {
+                self.head.0.store(head.wrapping_add(1), Ordering::Relaxed);
+                break;
+            }
+            match self.head.0.compare_exchange_weak(
+                head,
+                head.wrapping_add(1),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                // Another producer took this ticket; retry against the value it left behind.
+                Err(actual) => head = actual,
+            }
+        }
+
+        self.push_internal(element, head);
+        None
+    }
+
+    /// Pushes an element, spinning until a slot frees up if the queue is full.
+    #[inline]
+    fn do_push(&self, element: T) {
+        let head = if SPSC {
+            // Sole producer, so the counter has a single writer and needs no read-modify-write.
+            let head = self.head.0.load(Ordering::Relaxed);
+            self.head.0.store(head.wrapping_add(1), Ordering::Relaxed);
+            head
+        } else {
+            self.head.0.fetch_add(1, Ordering::Relaxed)
+        };
+        self.push_internal(element, head);
+    }
+
+    /// Writes `element` into the slot for `head`, spinning until the slot to become free.
+    #[inline(always)]
+    fn push_internal(&self, element: T, head: u32) {
+        let slot = &self.slots[Self::remap(head)];
+
+        if SPSC {
+            while slot.state.load(Ordering::Acquire) != EMPTY {
+                crate::loom::spin_hint();
+            }
+        } else {
+            while slot
+                .state
+                .compare_exchange_weak(EMPTY, STORING, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+            {
+                // Spin on a plain load rather than hammering the cache line with failed CAS traffic.
+                while slot.state.load(Ordering::Relaxed) != EMPTY {
+                    crate::loom::spin_hint();
+                }
+            }
+        }
+
+        slot.value.with_mut(|value| {
+            // Safety: the slot was observed `EMPTY` — and with multiple producers claimed via CAS —
+            // so this thread has exclusive access. No consumer can claim it until the `STORED`
+            // release store below.
+            unsafe { (*value).write(element) };
+        });
+        slot.state.store(STORED, Ordering::Release);
+    }
+
+    /// Pops an element, returning `None` if the queue was empty.
+    #[inline]
+    fn do_try_pop(&self) -> Option<T> {
+        let mut tail = self.tail.0.load(Ordering::Relaxed);
+
+        loop {
+            if distance(self.head.0.load(Ordering::Relaxed), tail) <= 0i32 {
+                return None;
+            }
+            if SPSC {
+                self.tail.0.store(tail.wrapping_add(1), Ordering::Relaxed);
+                break;
+            }
+            match self.tail.0.compare_exchange_weak(
+                tail,
+                tail.wrapping_add(1),
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => break,
+                // Another consumer took this ticket; retry against the value it left behind.
+                Err(actual) => tail = actual,
+            }
+        }
+
+        Some(self.pop_internal(tail))
+    }
+
+    /// Pops an element, spinning until one arrives if the queue is empty.
+    #[inline]
+    fn do_pop(&self) -> T {
+        let tail = if SPSC {
+            // Sole consumer, so the counter has a single writer.
+            let tail = self.tail.0.load(Ordering::Relaxed);
+            self.tail.0.store(tail.wrapping_add(1), Ordering::Relaxed);
+            tail
+        } else {
+            self.tail.0.fetch_add(1, Ordering::Relaxed)
+        };
+        self.pop_internal(tail)
+    }
+
+    /// Reads the element out of the slot for `tail`, waiting for one to arrive.
+    #[inline(always)]
+    fn pop_internal(&self, tail: u32) -> T {
+        let slot = &self.slots[Self::remap(tail)];
+
+        if SPSC {
+            while slot.state.load(Ordering::Acquire) != STORED {
+                crate::loom::spin_hint();
+            }
+        } else {
+            while slot
+                .state
+                .compare_exchange_weak(STORED, LOADING, Ordering::Acquire, Ordering::Relaxed)
+                .is_err()
+            {
+                while slot.state.load(Ordering::Relaxed) != STORED {
+                    crate::loom::spin_hint();
+                }
+            }
+        }
+
+        let element = slot.value.with(|value| {
+            // Safety: the slot was observed `STORED` — and with multiple consumers claimed via CAS
+            // — so this thread has exclusive access, and the acquire pairs with the producer's
+            // release store, making the payload write visible. `STORED` is only ever published
+            // after a completed write, so the value is initialized.
+            unsafe { (*value).assume_init_read() }
+        });
+        slot.state.store(EMPTY, Ordering::Release);
+
+        element
+    }
+}
+
+/// The shared-reference MPMC API, available only when `SPSC` is `false`.
+///
+/// An `SPSC` queue deliberately omits these: its relaxed push path is only sound with a single
+/// producer, which `&self` cannot guarantee. Use [`RingBuf::split`] instead.
+impl<const N: usize, T> RingBuf<N, T, false> {
+    /// Pushes an element, returning it back as `Some` if the queue was full.
+    #[inline]
+    pub fn try_push(&self, element: T) -> Option<T> {
+        self.do_try_push(element)
+    }
+
+    /// Pushes an element, spinning until a slot frees up if the queue is full.
+    #[inline]
+    pub fn push(&self, element: T) {
+        self.do_push(element);
+    }
+
+    /// Pops an element, returning `None` if the queue was empty.
+    #[inline]
+    pub fn try_pop(&self) -> Option<T> {
+        self.do_try_pop()
+    }
+
+    /// Pops an element, spinning until one arrives if the queue is empty.
+    #[inline]
+    pub fn pop(&self) -> T {
+        self.do_pop()
+    }
+}
+
+/// The producing half of a [split](RingBuf::split) queue.
+///
+/// `Clone` when the queue is not `SPSC`, giving any number of producers. On an `SPSC` queue it is
+/// deliberately not `Clone`, so a single producer is guaranteed and the push path can drop its
+/// read-modify-writes.
+pub struct Producer<'a, const N: usize, T, const SPSC: bool> {
+    queue: &'a RingBuf<N, T, SPSC>,
+    /// Keeps the handle from being *shared* between threads. Two threads pushing through one `&`
+    /// would defeat the single-producer guarantee just as two clones would.
+    _not_sync: PhantomData<*const ()>,
+}
+
+// Safety: the handle may be moved to another thread — that is how a producer is put to work — but
+// `_not_sync` keeps it from being shared, so `SPSC` mode still sees exactly one pusher.
+unsafe impl<const N: usize, T: Send, const SPSC: bool> Send for Producer<'_, N, T, SPSC> {}
+
+impl<const N: usize, T> Clone for Producer<'_, N, T, false> {
+    fn clone(&self) -> Self {
+        Self {
+            queue: self.queue,
+            _not_sync: PhantomData,
+        }
+    }
+}
+
+impl<const N: usize, T, const SPSC: bool> Producer<'_, N, T, SPSC> {
+    /// Pushes an element, returning it back as `Some` if the queue was full.
+    #[inline]
+    pub fn try_push(&self, element: T) -> Option<T> {
+        self.queue.do_try_push(element)
+    }
+
+    /// Pushes an element, spinning until a slot frees up if the queue is full.
+    #[inline]
+    pub fn push(&self, element: T) {
+        self.queue.do_push(element);
+    }
+
+    /// The maximum number of elements the queue can hold.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        N
+    }
+}
+
+/// The consuming half of a [split](RingBuf::split) queue.
+///
+/// Never `Clone`, in either mode, so there is provably one consumer.
+pub struct Consumer<'a, const N: usize, T, const SPSC: bool> {
+    queue: &'a RingBuf<N, T, SPSC>,
+    /// Keeps the handle from being shared between threads; see [`Producer`].
+    _not_sync: PhantomData<*const ()>,
+}
+
+// Safety: as for `Producer` — movable between threads, never shared, so there is exactly one
+// consumer however the handle travels.
+unsafe impl<const N: usize, T: Send, const SPSC: bool> Send for Consumer<'_, N, T, SPSC> {}
+
+impl<const N: usize, T, const SPSC: bool> Consumer<'_, N, T, SPSC> {
+    /// Pops an element, returning `None` if the queue was empty.
+    #[inline]
+    pub fn try_pop(&self) -> Option<T> {
+        self.queue.do_try_pop()
+    }
+
+    /// Pops an element, spinning until one arrives if the queue is empty.
+    ///
+    /// Uniqueness would make the relaxed pop path sound in MPSC mode too, but it is deliberately
+    /// only taken when `SPSC` — that is, when the producer is relaxed as well. Measured on
+    /// aarch64, relaxing *only* the consumer while producers still CAS is about 4.8x slower than
+    /// leaving both on the CAS path (60 vs 289 Melem/s at one producer). The likely cause is that
+    /// the relaxed consumer loads the slot state shared and then upgrades to store `EMPTY`, an
+    /// extra coherence transaction per element, where the CAS takes the line exclusive once. With
+    /// both sides relaxed the pattern is symmetric and the effect disappears.
+    ///
+    /// So MPSC buys a compiler-checked single-consumer API, not extra speed.
+    #[inline]
+    pub fn pop(&self) -> T {
+        self.queue.do_pop()
+    }
+
+    /// The maximum number of elements the queue can hold.
+    #[must_use]
+    pub const fn capacity(&self) -> usize {
+        N
+    }
+}
+
+impl<const N: usize, T, const SPSC: bool> Default for RingBuf<N, T, SPSC> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize, T, const SPSC: bool> Drop for RingBuf<N, T, SPSC> {
+    fn drop(&mut self) {
+        // NB: `&mut self` ensures exclusive ownership. Every slot is either `EMPTY` or `STORED`
+        // and we need no synchronization.
+        for slot in &self.slots {
+            if slot.state.load(Ordering::Relaxed) == STORED {
+                slot.value.with_mut(|value| {
+                    // Safety: `STORED` is only published after a completed write, so the value is
+                    // initialized, and exclusive access means nothing else can read it after.
+                    unsafe { (*value).assume_init_drop() };
+                });
+            }
+        }
+    }
+}

--- a/lib/ringbuf/src/loom.rs
+++ b/lib/ringbuf/src/loom.rs
@@ -1,0 +1,79 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Shim routing the concurrency primitives to `loom` under `--cfg=loom`, to `std` under
+//! `cfg(test)`, and to `core` otherwise. Lets one test body compile under all three configs.
+
+cfg_if::cfg_if! {
+    if #[cfg(loom)] {
+        pub(crate) use loom::cell;
+        pub(crate) use loom::model;
+        pub(crate) use loom::sync;
+        pub(crate) use loom::thread;
+
+        /// Yield to the model checker. A bare spin loop would let loom explore an
+        /// interleaving where the spinning thread never observes the other's store.
+        #[inline]
+        pub(crate) fn spin_hint() {
+            loom::thread::yield_now();
+        }
+    } else {
+        #[cfg(not(test))]
+        pub(crate) use core::sync;
+        #[cfg(test)]
+        pub(crate) use std::sync;
+        #[cfg(test)]
+        pub(crate) use std::thread;
+
+        #[inline(always)]
+        pub(crate) fn spin_hint() {
+            core::hint::spin_loop();
+        }
+
+        /// Runs the model once. Under `cfg(loom)` this is loom's exhaustive checker.
+        #[cfg(test)]
+        #[inline(always)]
+        pub(crate) fn model<F>(f: F)
+        where
+            F: Fn() + Sync + Send + 'static,
+        {
+            f();
+        }
+
+        pub(crate) mod cell {
+            /// Mirrors `loom::cell::UnsafeCell`'s `with`/`with_mut` API over the real one so
+            /// call sites are config-independent.
+            #[derive(Debug)]
+            #[repr(transparent)]
+            pub(crate) struct UnsafeCell<T: ?Sized>(core::cell::UnsafeCell<T>);
+
+            impl<T> UnsafeCell<T> {
+                pub(crate) const fn new(data: T) -> UnsafeCell<T> {
+                    UnsafeCell(core::cell::UnsafeCell::new(data))
+                }
+            }
+
+            impl<T: ?Sized> UnsafeCell<T> {
+                #[inline(always)]
+                pub(crate) fn with<F, R>(&self, f: F) -> R
+                where
+                    F: FnOnce(*const T) -> R,
+                {
+                    f(self.0.get())
+                }
+
+                #[inline(always)]
+                pub(crate) fn with_mut<F, R>(&self, f: F) -> R
+                where
+                    F: FnOnce(*mut T) -> R,
+                {
+                    f(self.0.get())
+                }
+            }
+        }
+    }
+}

--- a/lib/ringbuf/src/tests.rs
+++ b/lib/ringbuf/src/tests.rs
@@ -1,0 +1,798 @@
+// Copyright 2023-Present Jonas Kruckenberg
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+//! Tests ported from [atomic_queue's `tests.cc`][upstream], adapted to this implementation.
+//!
+//! The concurrency tests compile under three configurations: as plain threaded stress tests on
+//! the host, under miri, and under loom's model checker. Iteration counts and thread counts scale
+//! down accordingly — see [`CYCLES`] and [`STRESS_CAP`].
+//!
+//! [upstream]: https://github.com/max0x7ba/atomic_queue/blob/master/src/tests.cc
+
+use crate::RingBuf;
+use crate::loom::sync::Arc;
+use crate::loom::sync::atomic::{AtomicU64, Ordering};
+use crate::loom::{self, thread};
+
+/// Sentinel telling a consumer to stop. Upstream calls this `STOP_MSG`.
+const STOP_MSG: u32 = 0;
+
+/// Queue capacity for the stress test. Loom explores every interleaving, so the state space
+/// scales with capacity — a capacity of 2 is enough to exercise both the full and empty paths.
+#[cfg(loom)]
+const STRESS_CAP: usize = 2;
+#[cfg(not(loom))]
+const STRESS_CAP: usize = 4096;
+
+/// Messages each producer sends, counting down to 1. Upstream uses 1,000,000.
+const N_STRESS_MSG: u32 = if cfg!(loom) {
+    2
+} else if cfg!(miri) {
+    64
+} else {
+    1_000_000
+};
+
+/// Upstream stresses MPMC queues with 3 producers and 3 consumers. Loom caps concurrent threads
+/// and its state space grows exponentially with them, so it gets one of each.
+const PRODUCERS: usize = if cfg!(loom) { 1 } else { 3 };
+const CONSUMERS: usize = if cfg!(loom) { 1 } else { 3 };
+
+/// Repetitions for the non-model concurrency tests.
+const CYCLES: usize = if cfg!(loom) {
+    1
+} else if cfg!(miri) {
+    2
+} else {
+    50
+};
+
+// -- upstream `stress` ------------------------------------------------------------------------
+
+/// Every pushed element is popped exactly once, across all producers and consumers.
+///
+/// Producers count down from `N_STRESS_MSG` to 1; each consumer sums what it pops until it sees
+/// [`STOP_MSG`]. Checking the *sum* rather than the count catches duplication and loss that a
+/// bare count would miss.
+#[test]
+fn stress() {
+    loom::model(|| {
+        let q = Arc::new(RingBuf::<STRESS_CAP, u32>::new());
+        let sums: Arc<[AtomicU64; CONSUMERS]> =
+            Arc::new(core::array::from_fn(|_| AtomicU64::new(0)));
+
+        let producers: Vec<_> = (0..PRODUCERS)
+            .map(|_| {
+                let q = Arc::clone(&q);
+                thread::spawn(move || {
+                    for n in (1..=N_STRESS_MSG).rev() {
+                        q.push(n);
+                    }
+                })
+            })
+            .collect();
+
+        let consumers: Vec<_> = (0..CONSUMERS)
+            .map(|i| {
+                let q = Arc::clone(&q);
+                let sums = Arc::clone(&sums);
+                thread::spawn(move || {
+                    let mut sum = 0u64;
+                    loop {
+                        let n = q.pop();
+                        if n == STOP_MSG {
+                            break;
+                        }
+                        sum += u64::from(n);
+                    }
+                    sums[i].store(sum, Ordering::Relaxed);
+                })
+            })
+            .collect();
+
+        for p in producers {
+            p.join().unwrap();
+        }
+        // Only safe to send the sentinels once every producer is done, otherwise a consumer could
+        // stop while messages are still in flight.
+        for _ in 0..CONSUMERS {
+            q.push(STOP_MSG);
+        }
+        for c in consumers {
+            c.join().unwrap();
+        }
+
+        let n = u64::from(N_STRESS_MSG);
+        let expected = (n + 1) * n / 2 * PRODUCERS as u64;
+        let total: u64 = sums.iter().map(|s| s.load(Ordering::Relaxed)).sum();
+        assert_eq!(total, expected, "messages were lost or duplicated");
+
+        assert!(q.is_empty(), "queue should be drained");
+    });
+}
+
+/// No consumer is starved: each must receive at least 10% of its fair share.
+///
+/// Split from [`stress`] because it is a fairness property of the scheduler, not a correctness
+/// property of the queue — loom deliberately explores starving interleavings, and small message
+/// counts make the threshold meaningless.
+#[test]
+#[cfg_attr(loom, ignore = "loom explores starving interleavings by design")]
+#[cfg_attr(
+    miri,
+    ignore = "too few messages for the fairness threshold to be meaningful"
+)]
+fn stress_no_starvation() {
+    let q = Arc::new(RingBuf::<STRESS_CAP, u32>::new());
+    let sums: Arc<[AtomicU64; CONSUMERS]> = Arc::new(core::array::from_fn(|_| AtomicU64::new(0)));
+
+    let producers: Vec<_> = (0..PRODUCERS)
+        .map(|_| {
+            let q = Arc::clone(&q);
+            thread::spawn(move || {
+                for n in (1..=N_STRESS_MSG).rev() {
+                    q.push(n);
+                }
+            })
+        })
+        .collect();
+
+    let consumers: Vec<_> = (0..CONSUMERS)
+        .map(|i| {
+            let q = Arc::clone(&q);
+            let sums = Arc::clone(&sums);
+            thread::spawn(move || {
+                let mut sum = 0u64;
+                loop {
+                    let n = q.pop();
+                    if n == STOP_MSG {
+                        break;
+                    }
+                    sum += u64::from(n);
+                }
+                sums[i].store(sum, Ordering::Relaxed);
+            })
+        })
+        .collect();
+
+    for p in producers {
+        p.join().unwrap();
+    }
+    for _ in 0..CONSUMERS {
+        q.push(STOP_MSG);
+    }
+    for c in consumers {
+        c.join().unwrap();
+    }
+
+    let n = u64::from(N_STRESS_MSG);
+    let expected = (n + 1) * n / 2 * PRODUCERS as u64;
+    let min_share = expected / CONSUMERS as u64 / 10;
+    for (i, s) in sums.iter().enumerate() {
+        let got = s.load(Ordering::Relaxed);
+        assert!(
+            got >= min_share,
+            "consumer {i} starved: got {got}, expected at least {min_share}"
+        );
+    }
+}
+
+// -- upstream `move_only_element` -------------------------------------------------------------
+
+/// A move-only payload survives a round trip. Upstream uses `std::unique_ptr<int>`; `Box` is the
+/// Rust equivalent, and it also proves the queue never requires `T: Copy`.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn move_only_element() {
+    let q = RingBuf::<4096, Box<i32>>::new();
+    assert!(q.is_empty());
+    assert_eq!(q.len(), 0);
+
+    assert!(q.try_push(Box::new(1)).is_none());
+    q.push(Box::new(2));
+    assert!(!q.is_empty());
+    assert_eq!(q.len(), 2);
+
+    assert_eq!(*q.try_pop().unwrap(), 1);
+    assert_eq!(q.len(), 1);
+
+    assert_eq!(*q.pop(), 2);
+    assert!(q.is_empty());
+    assert_eq!(q.len(), 0);
+}
+
+// -- upstream `try_push_pop` ------------------------------------------------------------------
+
+/// Empty and full transitions, and FIFO ordering across a complete fill/drain cycle.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn try_push_pop() {
+    const CAP: usize = 64;
+    let q = RingBuf::<CAP, u32>::new();
+
+    assert!(q.try_pop().is_none(), "try_pop must fail on an empty queue");
+
+    for i in 1..=CAP as u32 {
+        assert!(q.try_push(i).is_none(), "push {i} within capacity");
+    }
+    assert!(q.is_full());
+    assert_eq!(q.len(), CAP);
+
+    assert_eq!(
+        q.try_push(999),
+        Some(999),
+        "try_push must hand the element back when full"
+    );
+
+    for i in 1..=CAP as u32 {
+        assert_eq!(q.try_pop(), Some(i), "FIFO order");
+    }
+    assert!(q.is_empty());
+    assert!(q.try_pop().is_none());
+}
+
+/// The queue keeps working after the indices wrap around the array many times.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn wraparound() {
+    const CAP: usize = 8;
+    let q = RingBuf::<CAP, u32>::new();
+
+    for round in 0..1000u32 {
+        for i in 0..CAP as u32 {
+            assert!(q.try_push(round * CAP as u32 + i).is_none());
+        }
+        assert!(q.is_full());
+        for i in 0..CAP as u32 {
+            assert_eq!(q.try_pop(), Some(round * CAP as u32 + i));
+        }
+        assert!(q.is_empty());
+    }
+}
+
+// -- upstream `size` --------------------------------------------------------------------------
+
+/// Capacity is exactly what was requested, and a fresh queue is empty and not full.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn size() {
+    let q = RingBuf::<1024, f32>::new();
+    assert_eq!(q.capacity(), 1024);
+    assert!(q.is_empty());
+    assert!(!q.is_full());
+    assert_eq!(q.len(), 0);
+}
+
+// -- Rust-specific: drop correctness ----------------------------------------------------------
+
+/// Elements still in the queue when it is dropped are dropped exactly once.
+///
+/// No upstream counterpart — C++ leans on `unique_ptr` for this. In Rust the queue holds
+/// `MaybeUninit` slots and must run the drop glue itself, so this is where a leak would show up.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn drops_remaining_elements() {
+    use std::sync::atomic::{AtomicUsize, Ordering as StdOrdering};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    struct CountsDrop;
+    impl Drop for CountsDrop {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, StdOrdering::Relaxed);
+        }
+    }
+
+    {
+        let q = RingBuf::<16, CountsDrop>::new();
+        for _ in 0..10 {
+            assert!(q.try_push(CountsDrop).is_none());
+        }
+        // Three leave through the front; the other seven must be cleaned up by `Drop`.
+        for _ in 0..3 {
+            drop(q.try_pop().unwrap());
+        }
+        assert_eq!(DROPS.load(StdOrdering::Relaxed), 3);
+    }
+
+    assert_eq!(
+        DROPS.load(StdOrdering::Relaxed),
+        10,
+        "every element must be dropped exactly once"
+    );
+}
+
+// -- upstream `remap_index` -------------------------------------------------------------------
+
+/// Exercises [`RingBuf::remap`] for a given capacity: it must stay in bounds, be a bijection over
+/// `0..N`, and be its own inverse.
+fn check_remap<const N: usize>() {
+    let mut seen = vec![false; N];
+
+    for i in 0..N as u32 {
+        let r = RingBuf::<N, u32>::remap(i);
+        assert!(r < N, "remap({i}) = {r} out of bounds for N = {N}");
+        assert!(
+            !seen[r],
+            "remap is not injective: {r} produced twice (N = {N})"
+        );
+        seen[r] = true;
+
+        let back = RingBuf::<N, u32>::remap(r as u32);
+        assert_eq!(
+            back, i as usize,
+            "remap is not self-inverse at {i} (N = {N})"
+        );
+    }
+
+    assert!(seen.into_iter().all(|s| s), "remap is not surjective");
+}
+
+/// Below the shuffle threshold `remap` is the identity; at and above it, it is a non-trivial but
+/// still bijective, self-inverse shuffle. Both must hold.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+#[cfg_attr(miri, ignore = "large capacities are slow under miri")]
+fn remap_is_a_self_inverse_bijection() {
+    check_remap::<2>();
+    check_remap::<8>();
+    check_remap::<64>();
+    check_remap::<256>();
+    check_remap::<4096>();
+    // Large enough that `get_shuffle_bits` returns non-zero on a 128-byte cache line, so this is
+    // the case that actually exercises the bit swapping.
+    check_remap::<16384>();
+}
+
+/// Consecutive indices must land far enough apart to fall on different cache lines — the entire
+/// point of the shuffle. Without it, adjacent tickets share a line and producers contend.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+#[cfg_attr(miri, ignore = "large capacity is slow under miri")]
+fn remap_spreads_adjacent_indices() {
+    const N: usize = 16384;
+    assert_ne!(
+        RingBuf::<N, u32>::SHUFFLE_BITS,
+        0,
+        "test capacity must be large enough to enable shuffling"
+    );
+
+    for i in 0..1024u32 {
+        let a = RingBuf::<N, u32>::remap(i);
+        let b = RingBuf::<N, u32>::remap(i + 1);
+        assert_ne!(a, b);
+        assert!(
+            a.abs_diff(b) > 1,
+            "remap({i}) = {a} and remap({}) = {b} are adjacent; shuffle did nothing",
+            i + 1
+        );
+    }
+}
+
+/// Indices beyond `N` wrap onto the same slots, so the mapping has period exactly `N`.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn remap_has_period_n() {
+    const N: usize = 4096;
+    for i in 0..2048u32 {
+        assert_eq!(
+            RingBuf::<N, u32>::remap(i),
+            RingBuf::<N, u32>::remap(i + N as u32)
+        );
+    }
+}
+
+/// The mapping must survive the `u32` counter wrapping to zero: index `u32::MAX` and index
+/// `u32::MAX + 1 == 0` have to remain distinct slots exactly `1` apart in ticket order.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn remap_survives_counter_wrap() {
+    const N: usize = 4096;
+    // `u32::MAX` is `N - 1` modulo `N` for power-of-two `N`, so the wrap is seamless: the slot
+    // after it is the one index 0 maps to.
+    assert_eq!(
+        RingBuf::<N, u32>::remap(u32::MAX),
+        RingBuf::<N, u32>::remap((N - 1) as u32)
+    );
+    assert_eq!(RingBuf::<N, u32>::remap(0), RingBuf::<N, u32>::remap(0));
+}
+
+// -- concurrency: SPSC ordering ---------------------------------------------------------------
+
+/// With a single producer and a single consumer the queue is strictly FIFO.
+#[test]
+fn spsc_preserves_order() {
+    const MSGS: u32 = if cfg!(loom) {
+        3
+    } else if cfg!(miri) {
+        32
+    } else {
+        10_000
+    };
+
+    loom::model(|| {
+        let q = Arc::new(RingBuf::<STRESS_CAP, u32>::new());
+
+        let producer = {
+            let q = Arc::clone(&q);
+            thread::spawn(move || {
+                for i in 0..MSGS {
+                    q.push(i);
+                }
+            })
+        };
+
+        let consumer = thread::spawn(move || {
+            for expected in 0..MSGS {
+                assert_eq!(q.pop(), expected, "SPSC must preserve order");
+            }
+        });
+
+        producer.join().unwrap();
+        consumer.join().unwrap();
+    });
+}
+
+/// `try_push` on a full queue and `try_pop` on an empty one must fail rather than block or
+/// corrupt state, even while another thread is actively draining and filling.
+#[test]
+#[cfg_attr(
+    loom,
+    ignore = "unbounded retry loop does not terminate under the model checker"
+)]
+fn try_ops_under_contention() {
+    for _ in 0..CYCLES {
+        let q = Arc::new(RingBuf::<4, u32>::new());
+        let total = Arc::new(AtomicU64::new(0));
+
+        let producer = {
+            let q = Arc::clone(&q);
+            thread::spawn(move || {
+                let mut sent = 0u32;
+                while sent < 1000 {
+                    if q.try_push(sent).is_none() {
+                        sent += 1;
+                    }
+                }
+            })
+        };
+
+        let consumer = {
+            let q = Arc::clone(&q);
+            let total = Arc::clone(&total);
+            thread::spawn(move || {
+                let mut got = 0u32;
+                let mut sum = 0u64;
+                while got < 1000 {
+                    if let Some(v) = q.try_pop() {
+                        sum += u64::from(v);
+                        got += 1;
+                    }
+                }
+                total.store(sum, Ordering::Relaxed);
+            })
+        };
+
+        producer.join().unwrap();
+        consumer.join().unwrap();
+
+        assert_eq!(total.load(Ordering::Relaxed), (0..1000u64).sum::<u64>());
+        assert!(q.is_empty());
+    }
+}
+
+/// Multiple producers and consumers on a capacity-limited queue: every element crosses exactly
+/// once. Small capacity forces the full/empty retry paths that [`stress`] mostly skips.
+#[test]
+#[cfg_attr(
+    loom,
+    ignore = "covered by `stress`; separate model would duplicate the state space"
+)]
+fn mpmc_conserves_elements() {
+    const MSGS: u32 = if cfg!(miri) { 32 } else { 5_000 };
+
+    for _ in 0..CYCLES {
+        let q = Arc::new(RingBuf::<4, u32>::new());
+        let received = Arc::new(AtomicU64::new(0));
+
+        let producers: Vec<_> = (0..PRODUCERS)
+            .map(|_| {
+                let q = Arc::clone(&q);
+                thread::spawn(move || {
+                    for i in 1..=MSGS {
+                        q.push(i);
+                    }
+                })
+            })
+            .collect();
+
+        let consumers: Vec<_> = (0..CONSUMERS)
+            .map(|_| {
+                let q = Arc::clone(&q);
+                let received = Arc::clone(&received);
+                thread::spawn(move || {
+                    loop {
+                        let v = q.pop();
+                        if v == STOP_MSG {
+                            break;
+                        }
+                        received.fetch_add(u64::from(v), Ordering::Relaxed);
+                    }
+                })
+            })
+            .collect();
+
+        for p in producers {
+            p.join().unwrap();
+        }
+        for _ in 0..CONSUMERS {
+            q.push(STOP_MSG);
+        }
+        for c in consumers {
+            c.join().unwrap();
+        }
+
+        let n = u64::from(MSGS);
+        assert_eq!(
+            received.load(Ordering::Relaxed),
+            (n + 1) * n / 2 * PRODUCERS as u64
+        );
+    }
+}
+
+// -- split handles: MPSC and SPSC ---------------------------------------------------------------
+
+/// Single-threaded exercise of the handle API: FIFO order, and the full/empty edges.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn split_round_trip() {
+    const CAP: usize = 8;
+    // `split` takes `&'static self`, but a `static` item cannot serve: `RingBuf::new` is not
+    // `const` under loom, where this file still has to compile. Hand the borrow out by raw pointer
+    // instead and take ownership back at the end, so miri sees no leak.
+    let q = Box::into_raw(Box::new(RingBuf::<CAP, u32>::new()));
+    // Safety: the box is reclaimed below, after the handles are gone, and nothing else aliases it.
+    let (tx, rx) = unsafe { &*q }.split();
+
+    assert!(rx.try_pop().is_none(), "empty queue");
+
+    for i in 1..=CAP as u32 {
+        assert!(tx.try_push(i).is_none());
+    }
+    assert_eq!(
+        tx.try_push(999),
+        Some(999),
+        "full queue hands the element back"
+    );
+
+    for i in 1..=CAP as u32 {
+        assert_eq!(rx.try_pop(), Some(i), "FIFO order");
+    }
+    assert!(rx.try_pop().is_none());
+
+    drop((tx, rx));
+    // Safety: the handles are gone, so nothing borrows the queue any more.
+    drop(unsafe { Box::from_raw(q) });
+}
+
+/// Elements left in a split queue are still dropped exactly once. The consumer's relaxed path
+/// leaves slots `EMPTY` without ever going through `LOADING`, so `Drop` must not depend on it.
+#[test]
+#[cfg_attr(loom, ignore = "not concurrency-relevant")]
+fn split_drops_remaining_elements() {
+    use std::sync::atomic::{AtomicUsize, Ordering as StdOrdering};
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+
+    struct CountsDrop;
+    impl Drop for CountsDrop {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, StdOrdering::Relaxed);
+        }
+    }
+
+    {
+        // The queue must still be dropped at the end of this scope — that is what the test is
+        // about — but `split` wants `&'static self`, so hand out the borrow by raw pointer and
+        // take ownership back once the handles are gone.
+        let q = Box::into_raw(Box::new(RingBuf::<16, CountsDrop>::new()));
+        {
+            // Safety: the box below is not reclaimed until this scope has ended, and nothing else
+            // aliases it.
+            let (tx, rx) = unsafe { &*q }.split();
+            for _ in 0..10 {
+                assert!(tx.try_push(CountsDrop).is_none());
+            }
+            for _ in 0..3 {
+                drop(rx.try_pop().unwrap());
+            }
+        }
+        assert_eq!(DROPS.load(StdOrdering::Relaxed), 3);
+
+        // Safety: the handles are gone, so nothing borrows the queue any more.
+        drop(unsafe { Box::from_raw(q) });
+    }
+
+    assert_eq!(DROPS.load(StdOrdering::Relaxed), 10);
+}
+
+/// MPSC: many cloned producers, one consumer. Every element crosses exactly once.
+///
+/// This is the path where the consumer drops both of its read-modify-writes while producers keep
+/// theirs, so it is the one that would break if the two relaxations were conflated.
+#[test]
+#[cfg_attr(loom, ignore = "scoped threads are unavailable under loom")]
+fn mpsc_split_conserves_elements() {
+    const MSGS: u32 = if cfg!(miri) { 32 } else { 5_000 };
+
+    // See `split_round_trip` for why the queue is handed out by raw pointer.
+    let q = Box::into_raw(Box::new(RingBuf::<4, u32>::new()));
+    // Safety: the box is reclaimed below, after the threads that hold the handles have joined.
+    let (tx, rx) = unsafe { &*q }.split();
+
+    std::thread::scope(|s| {
+        for _ in 0..PRODUCERS {
+            let tx = tx.clone();
+            s.spawn(move || {
+                for i in 1..=MSGS {
+                    tx.push(i);
+                }
+            });
+        }
+
+        s.spawn(move || {
+            let mut sum = 0u64;
+            for _ in 0..MSGS as usize * PRODUCERS {
+                sum += u64::from(rx.pop());
+            }
+            let n = u64::from(MSGS);
+            assert_eq!(sum, (n + 1) * n / 2 * PRODUCERS as u64);
+        });
+    });
+
+    // Safety: the threads have joined, so nothing borrows the queue any more.
+    drop(unsafe { Box::from_raw(q) });
+}
+
+/// SPSC: one producer, one consumer, both relaxed. Strict FIFO must survive.
+#[test]
+#[cfg_attr(loom, ignore = "scoped threads are unavailable under loom")]
+fn spsc_split_preserves_order() {
+    const MSGS: u32 = if cfg!(miri) { 32 } else { 10_000 };
+
+    // See `split_round_trip` for why the queue is handed out by raw pointer.
+    let q = Box::into_raw(Box::new(RingBuf::<4, u32, true>::new()));
+    // Safety: the box is reclaimed below, after the threads that hold the handles have joined.
+    let (tx, rx) = unsafe { &*q }.split();
+
+    std::thread::scope(|s| {
+        s.spawn(move || {
+            for i in 0..MSGS {
+                tx.push(i);
+            }
+        });
+        s.spawn(move || {
+            for expected in 0..MSGS {
+                assert_eq!(rx.pop(), expected, "SPSC must preserve order");
+            }
+        });
+    });
+
+    // Safety: the threads have joined, so nothing borrows the queue any more.
+    drop(unsafe { Box::from_raw(q) });
+}
+
+// -- loom coverage for the relaxed split paths --------------------------------------------------
+//
+// These are the paths the model checker most needs to see: the consumer (and, in SPSC, the
+// producer) skip their read-modify-writes, so correctness rests entirely on the release/acquire
+// pair on the slot's `state`. A missing edge there would be invisible to the threaded tests on
+// x86-ish hardware but caught here.
+//
+// The queue is leaked to obtain `'static` handles — `split` borrows, and loom has no scoped
+// threads. Capacity 2 keeps the state space small while still exercising both the full and the
+// empty path, and the consumer runs on the main thread to stay under loom's thread budget.
+
+/// MPSC: two producers contend for tickets while a lone consumer uses the relaxed pop path.
+///
+/// This is the combination that would break if the single-producer and single-consumer
+/// relaxations were conflated — producers must keep their CAS, the consumer must not.
+#[test]
+fn mpsc_split_model() {
+    loom::model(|| {
+        // See `split_round_trip` for why the queue is handed out by raw pointer.
+        let q = Box::into_raw(Box::new(RingBuf::<2, u32>::new()));
+        // Safety: the box is reclaimed below, after the threads holding handles have joined.
+        let (tx, rx) = unsafe { &*q }.split();
+        let tx2 = tx.clone();
+
+        let p1 = thread::spawn(move || tx.push(1));
+        let p2 = thread::spawn(move || tx2.push(2));
+
+        let a = rx.pop();
+        let b = rx.pop();
+
+        p1.join().unwrap();
+        p2.join().unwrap();
+
+        // Producers race, so either order is legal — but both values must arrive, exactly once.
+        assert!(
+            (a == 1 && b == 2) || (a == 2 && b == 1),
+            "expected {{1, 2}} in some order, got {{{a}, {b}}}"
+        );
+
+        drop(rx);
+        // Safety: the handles are gone, so nothing borrows the queue any more.
+        drop(unsafe { Box::from_raw(q) });
+    });
+}
+
+/// SPSC: both sides relaxed. Order must still be strict FIFO.
+#[test]
+fn spsc_split_model() {
+    loom::model(|| {
+        // See `split_round_trip` for why the queue is handed out by raw pointer.
+        let q = Box::into_raw(Box::new(RingBuf::<2, u32, true>::new()));
+        // Safety: the box is reclaimed below, after the thread holding a handle has joined.
+        let (tx, rx) = unsafe { &*q }.split();
+
+        // Three messages through a capacity-2 queue forces the producer to wait on the consumer.
+        let p = thread::spawn(move || {
+            for i in 1..=3 {
+                tx.push(i);
+            }
+        });
+
+        for expected in 1..=3 {
+            assert_eq!(rx.pop(), expected, "SPSC must preserve order");
+        }
+
+        p.join().unwrap();
+
+        drop(rx);
+        // Safety: the handles are gone, so nothing borrows the queue any more.
+        drop(unsafe { Box::from_raw(q) });
+    });
+}
+
+/// MPSC `try_` paths: the consumer's relaxed `try_pop` must never invent or duplicate an element.
+#[test]
+fn mpsc_split_try_model() {
+    loom::model(|| {
+        // See `split_round_trip` for why the queue is handed out by raw pointer.
+        let q = Box::into_raw(Box::new(RingBuf::<2, u32>::new()));
+        // Safety: the box is reclaimed below, after the thread holding a handle has joined.
+        let (tx, rx) = unsafe { &*q }.split();
+
+        // The queue starts empty with room for two, so this push cannot fail — no retry loop,
+        // which loom would treat as an algorithm requiring the processor to make progress.
+        let p = thread::spawn(move || {
+            assert!(tx.try_push(7).is_none(), "push into an empty queue");
+        });
+
+        // Bounded retries: an unbounded spin would blow loom's branch limit, but a fixed count
+        // still lets it explore the interleavings where the pop runs before, during and after the
+        // push. Whatever it finds, the element must be there once the producer has joined.
+        let mut got = None;
+        for _ in 0..2 {
+            got = rx.try_pop();
+            if got.is_some() {
+                break;
+            }
+        }
+
+        p.join().unwrap();
+
+        let got = got.or_else(|| rx.try_pop());
+        assert_eq!(got, Some(7), "the pushed element must arrive exactly once");
+        assert!(rx.try_pop().is_none(), "only one element was ever pushed");
+
+        drop(rx);
+        // Safety: the handles are gone, so nothing borrows the queue any more.
+        drop(unsafe { Box::from_raw(q) });
+    });
+}

--- a/lib/spin/BUCK
+++ b/lib/spin/BUCK
@@ -9,7 +9,10 @@ rust_library(
         "//third-party:cfg-if",
         "//third-party:lock_api",
         "//third-party:critical-section"
-    ],
+    ] + select({
+        "constraints//:loom[enabled]": ["//third-party:loom"],
+        "constraints//:loom[disabled]": [],
+    }),
     visibility = ["PUBLIC"],
     tests = [":spin_unittests", ":spin_loom_tests"]
 )

--- a/manual/src/building/buck2.md
+++ b/manual/src/building/buck2.md
@@ -88,7 +88,7 @@ build/
 | `--target=…` | constraints (`prelude//cpu:riscv64`, …) bundled into a *platform* under `platforms/` |
 | `RUSTFLAGS=-Cfoo` | `rustc_flags = ["-Cfoo"]` attribute of a `rust_library`/`rust_binary` rule |
 | `cfg(test)` | a dedicated `rust_test` target; can carry its own deps |
-| `cfg(loom)` | `rust_test` with `rustc_flags = ["--cfg=loom"]` and `labels = ["loom"]` |
+| `cfg(loom)` | `rust_loom_test`, which transitions the whole graph into `constraints//:loom[enabled]` passing `--cfg=loom` to all crates |
 
 [buck2]: https://buck2.build/
 [Cargo]: https://doc.rust-lang.org/cargo/

--- a/sys/async/src/executor.rs
+++ b/sys/async/src/executor.rs
@@ -429,7 +429,7 @@ impl Scheduler {
                 // If inconsistent, just try again.
                 Err(TryDequeueError::Inconsistent) => {
                     tracing::trace!("scheduler queue {:?} inconsistent", self.run_queue);
-                    core::hint::spin_loop();
+                    crate::loom::hint::spin_loop();
                     continue;
                 }
                 // Queue is empty or busy (in use by something else), bail out.
@@ -564,6 +564,7 @@ mod tests {
         })
     }
 
+    #[cfg(not(loom))]
     #[test]
     fn multi_threaded() {
         let _trace = tracing_subscriber::fmt()

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -789,6 +789,13 @@ cargo.rust_library(
         "default",
     ],
     visibility = [],
+    deps = select({
+        "DEFAULT": [],
+        "constraints//:loom[enabled]": [
+            "//third-party:loom",
+            "//third-party:tracing",
+        ],
+    }),
 )
 
 http_archive(
@@ -2800,7 +2807,13 @@ cargo.rust_library(
         ":mycelium-bitfield-0.1",
         ":pin-project-1",
         ":portable-atomic-1",
-    ],
+    ] + select({
+        "DEFAULT": [],
+        "constraints//:loom[enabled]": [
+            "//third-party:loom",
+            "//third-party:tracing",
+        ],
+    }),
 )
 
 http_archive(

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -8,6 +8,13 @@
 load("@prelude//rust:cargo_buildscript.bzl", "buildscript_run")
 load("@prelude//rust:cargo_package.bzl", "cargo")
 
+git_fetch(
+    name = "loom-26e51a59155a0738.git",
+    repo = "https://github.com/JonasKruckenberg/loom",
+    rev = "86a34aa91c547314145d7b566185337fb4dd15cb",
+    visibility = [],
+)
+
 http_archive(
     name = "adler2-2.0.1.crate",
     sha256 = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa",
@@ -2731,24 +2738,17 @@ cargo.rust_library(
 
 alias(
     name = "loom",
-    actual = ":loom-0.7",
+    actual = ":loom-0.7-86a34aa9",
     visibility = ["PUBLIC"],
 )
 
-http_archive(
-    name = "loom-0.7.2.crate",
-    sha256 = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca",
-    strip_prefix = "loom-0.7.2",
-    urls = ["https://static.crates.io/crates/loom/0.7.2/download"],
-    visibility = [],
-)
-
 cargo.rust_library(
-    name = "loom-0.7",
-    srcs = [":loom-0.7.2.crate"],
+    name = "loom-0.7-86a34aa9",
+    srcs = [":loom-26e51a59155a0738.git"],
     crate = "loom",
-    crate_root = "loom-0.7.2.crate/src/lib.rs",
-    edition = "2018",
+    crate_root = "loom-26e51a59155a0738/src/lib.rs",
+    edition = "2021",
+    features = ["futures"],
     visibility = [],
     deps = [
         ":cfg-if-1",

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -294,7 +294,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "688d7fbb8092b8de775ef2536f36c8c31f2bc4006ece2e8d8ad2d17d00ce0a2a"
 dependencies = [
- "loom",
+ "loom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -853,7 +853,7 @@ dependencies = [
  "libtest-mimic",
  "lock_api",
  "log",
- "loom",
+ "loom 0.7.2 (git+https://github.com/JonasKruckenberg/loom?rev=86a34aa91c547314145d7b566185337fb4dd15cb)",
  "maitake-sync",
  "memchr",
  "memmap2",
@@ -969,13 +969,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "git+https://github.com/JonasKruckenberg/loom?rev=86a34aa91c547314145d7b566185337fb4dd15cb#86a34aa91c547314145d7b566185337fb4dd15cb"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "maitake-sync"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d77c365d697828821727b9bc09e6bc3c518b8c63804e79e1be5a5ae091a7c5f"
 dependencies = [
  "cordyceps",
- "loom",
+ "loom 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mutex-traits",
  "mycelium-bitfield",
  "pin-project",

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -71,7 +71,7 @@ tracing-subscriber = { version = "0.3", optional = true }
 parking_lot = { version = "0.12.5",  optional = true }
 criterion = { version = "0.8.0", optional = true }
 libc = { version = "0.2.182", optional = true }
-loom = { version = "0.7",  default-features = false, optional = true }
+loom = { git = "https://github.com/JonasKruckenberg/loom", rev = "86a34aa91c547314145d7b566185337fb4dd15cb",  default-features = false, features = ["futures"], optional = true }
 test-log = { version = "0.2", optional = true }
 wat = { version = "1.219.1", optional = true }
 brie-tree = { version = "0.1.2", optional = true }

--- a/third-party/fixups/cordyceps/fixups.toml
+++ b/third-party/fixups/cordyceps/fixups.toml
@@ -1,5 +1,3 @@
-cargo_env = true
-
 # `[target.'cfg(loom)'.dependencies]` upstream. Reindeer resolves cfgs while
 # generating, so the dependency rides the loom constraint instead.
 [[extra_deps_select]]


### PR DESCRIPTION
This PR adds the `ringbuf` crate (k23-internal, don't confuse with crates.io `ringbuf`) that implements an array-based (therefore bounded), lock-free, MPMC & SPSC queue. While we don't use this yet its a great foundational building block for future subsystems.