### PR TITLE
fix: actually optimized benchmark builds

### DIFF
--- a/build/BUCK
+++ b/build/BUCK
@@ -51,10 +51,26 @@ configuration_transition(
     visibility = ["PUBLIC"],
 )
 
-# Sanitizer / opt / debuginfo overlay for fuzz binaries. Applied via
-# incoming_transition (not the rule's `modifiers` attr) so the toolchain's
-# `select(constraints//:sanitizer[address])` actually picks up the link flag
-# that pulls libstdc++/libc++ in on Linux.
+configuration_transition(
+    name = "loom",
+    constraint_values = [
+        "constraints//:loom[enabled]",
+        "constraints//:opt-level[3]", # loom is really slow unoptimized
+    ],
+    visibility = ["PUBLIC"],
+)
+
+configuration_transition(
+    name = "bench",
+    constraint_values = [
+        "constraints//:opt-level[3]",
+        "constraints//:debuginfo[line-tables-only]",
+        "constraints//:strip[debuginfo]",
+        "constraints//:lto[thin]",
+    ],
+    visibility = ["PUBLIC"],
+)
+
 configuration_transition(
     name = "fuzz",
     constraint_values = [

--- a/build/bench.bzl
+++ b/build/bench.bzl
@@ -1,12 +1,5 @@
 load("@prelude//platforms:defs.bzl", "host_configuration")
 
-_DEFAULT_MODIFIERS = [
-    "constraints//:opt-level[3]",
-    "constraints//:debuginfo[line-tables-only]",
-    "constraints//:strip[debuginfo]",
-    "constraints//:lto[thin]"
-]
-
 def _rust_benchmark_runner_impl(ctx: AnalysisContext) -> list[Provider]:
     bin_run = ctx.attrs.binary[RunInfo]
 
@@ -39,12 +32,12 @@ _rust_benchmark_runner = rule(
     },
 )
 
-def rust_benchmark(name, modifiers = [], visibility = None, **kwargs):
+def rust_benchmark(name, visibility = None, **kwargs):
     bin_name = name + "_bin"
     native.rust_binary(
         name = bin_name,
         target_compatible_with = [host_configuration.os, host_configuration.cpu],
-        modifiers = _DEFAULT_MODIFIERS + modifiers,
+        incoming_transition = "root//build:bench",
         visibility = visibility,
         **kwargs
     )


### PR DESCRIPTION
Applies the same `incoming_transition` treatment that loom and fuzzer builds use to ensure that actually all crates used in benchmarks are built optimized!